### PR TITLE
fix: dependency issues caused by an outdated grpc version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   dartastic_opentelemetry_api: ^0.8.3
   fixnum: ^1.1.1
-  grpc: ^3.2.4
+  grpc: ^4.1.0
   http: ^1.3.0
   meta: ^1.16.0
   protobuf: ^3.1.0


### PR DESCRIPTION
### Bump grpc dependency to the latest version

Hey thanks for setting this repository up, as an [opentelemetry](https://pub.dev/packages/opentelemetry) user I am more than excited to try out this project. When running within our app I encountered the following issue:

```
Because foo depends on pointycastle ^4.0.0 and basic_utils >=5.6.1 <5.8.0 depends on pointycastle ^3.7.3, basic_utils >=5.6.1 <5.8.0 is forbidden.
And because bar depends on basic_utils ^5.7.0 and basic_utils >=5.8.0 depends on archive ^4.0.2, archive ^4.0.2 is required.
And because every version of dartastic_opentelemetry depends on grpc ^3.2.4 which depends on archive ^3.0.0, dartastic_opentelemetry is forbidden.
```

**Fix**

Bumping up [grpc](https://pub.dev/packages/grpc/changelog) to `4.0.1` as it removes the dependency on `package:archive` in `4.0.0`.

It would be awesome if we could also propagate this change into the flutter package.

`Validated changes`

- [x] Run dart analyze
- [x] Run dart test

There are 4 failing tests but they do not seem to be related to this change.


