### PR TITLE
chore(git): clean up .gitignore and remove generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
+.dart_tool/
+.idea/
+.vscode/
+.DS_Store
+/pubspec.lock
 /test/testing_utils/otelcol
-/.dart_tool/pub/bin/test/test.dart-3.7.0.snapshot
-/.dart_tool/test/incremental_kernel.Ly9AZGFydD0zLjA=
 /coverage/
-/.dart_tool/pub/bin/coverage/format_coverage.dart-3.7.0.snapshot
 /test.txt
-/.dart_tool/pub/bin/coverage/collect_coverage.dart-3.7.0.snapshot


### PR DESCRIPTION
Supersedes #7 from @yuzurihaaa.

This commit: Removes tracked .dart_tool/.idea artifacts, ensures /pubspec.lock is ignored, and simplifies .gitignore.