### PR TITLE
feat: Implement OpenTelemetry Log Signal SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test.txt
 /.run/
 /dartastic_opentelemetry.iml
+/.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [^1.0.0-alpha] - 2025-12-22
+## [^1.0.0-alpha] - 2026-04-02
 ### Added
 - Log Signal SDK implementation
 - Upgraded to dartastic_opentelemetry_api: ^1.0.0-alpha with Log Signal API

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenTelemetry Specification](https://img.shields.io/badge/OpenTelemetry-Specification-blueviolet)](https://opentelemetry.io/docs/specs/otel/)
-[![Coverage Report](https://img.shields.io/badge/coverage-report-brightgreen.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)
+[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)
 
 Dartastic is an [OpenTelemetry](https://opentelemetry.io/) SDK to add standard observability to Dart applications.
 Dartastic can be used with any OTel backend since it's standards-compliant.
 
 Flutter developers should use the [Flutterific OpenTelemetry SDK](https://pub.dev/packages/flutterrific_opentelemetry/) which builds on top of Dartastic OTel.
 
-The Dartastic OTel SDK has been proposed for [Donation to the CNCF](https://github.com/open-telemetry/community/issues/2718).
+The Dartastic OTel SDK is in the process of being [Donation to the CNCF](https://github.com/open-telemetry/community/issues/2718) 
+to become the offical standard for Dart and Flutter OpenTelemetry.
 
 [Dartastic.io](https://dartastic.io) provides an OpenTelemetry support, training, consulting
 and an Observability backend customized for Flutter apps, Dart backends, and any other service or process that produces
@@ -69,7 +70,7 @@ Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Mindful 
 
 Michael is eternally grateful for the individual developers and small companies for their contributions. 
 
-Michael explicitly expresses his disthanks for the massive commercial companies in telcom, healthcare, Point of Sale, and more 
+Michael explicitly expresses his disthanks for the massive commercial companies in telcom, healthcare, point of sale, and more 
 who took time and provided nothing but requests for free software to support their 
 billions of customers.  Don't forget:
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@
 [![Coverage Report](https://img.shields.io/badge/coverage-report-brightgreen.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)
 
 Dartastic is an [OpenTelemetry](https://opentelemetry.io/) SDK to add standard observability to Dart applications.
-Dartastic can be used with any OTel backend since it's standards-compliant.
+Dartastic can be used with any OTel backend, it's standards-compliant.
 
 Flutter developers should use the [Flutterific OpenTelemetry SDK](https://pub.dev/packages/flutterrific_opentelemetry/) which builds on top of Dartastic OTel.
 
-The Dartastic OTel SDK has been proposed for [Donation to the CNCF](https://github.com/open-telemetry/community/issues/2718).
+The Dartastic and Flutterrific OTel SDK has been proposed for [Donation to the CNCF](https://github.com/open-telemetry/community/issues/2718).
+We need YOU to grow the Dartastic community and make this SDK the standard for Flutter and Dart OTel.
+Please use it, submit issues, support us with stars and contribute PRs. We are looking for contributors and maintainers.
+Also, please support the development by subscribing at [Dartastic.io](https://dartastic.io) and gain early access to the
+Flutter SDK and the Wondrous Demo.
 
 [Dartastic.io](https://dartastic.io) provides an OpenTelemetry support, training, consulting
 and an Observability backend customized for Flutter apps, Dart backends, and any other service or process that produces
@@ -39,7 +43,7 @@ OpenTelemetry data.
     - Low overhead
     - Batch processing
     - Performance test suite for proven benchmarks
-- 🐞 **Well Tested**: Very good test coverage (>90%). 
+- 🐞 **Well Tested**: Good test coverage (>85%). 
 - 📃 **Quality Documentation**: If it's not clearly documented, it's a bug. Extensive examples and best practices are
   provided. See the examples directory. 
 - 🎬 **Demo** The [Wonderous OpenTelemetry Demo](https://github.com/MindfulSoftwareLLC/wondrous_opentelemetry) demonstrates  
@@ -47,7 +51,7 @@ OpenTelemetry data.
 - ✅ **Supported Telemetry Signals and Features**:
   - Tracing with span processors and samplers
   - Metrics collection and aggregation
-  - Logs
+  - Logs with log record processors and exporters
   - Context propagation
   - Baggage management
 
@@ -59,28 +63,20 @@ The `dartastic_opentelemetry_api` exists as a standalone library to strictly adh
 OpenTelemetry specification which separates API and the SDK.  All OpenTelemetry API classes on in
 `dartastic_opentelemetry_api`.
 
-[Flutterrific OTel](https://pub.dev/packages/flutterrific_opentelemetry) adds Dartastic OTel to Flutter apps with ease.
+[Flutterrific OTel](https://pub.dev/packages/flutterrific_opentelemetry) adds Dartastic OTel to Flutter apps with ease.  Sign Up at Dartastic.io for early access to this soon to be open source.
 
 [Dartastic.io](https://dartastic.io) is an OpenTelemetry backend based on Elastic with a generous free tier.
 
-Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Mindful Software](https://mindfulsoftware.com) with support from:
-* [SEMPlicity, Inc.](https://semplicityinc.com), the Elastic experts, who provided the initial funding.
-* [The Anspar Foundation](https://anspar.org) and [CureHHT](https://curehht.org) for support of Michael Bushe's OTel work and early adopter status in [software used in FDA clinical trials](https://github.com/Cure-HHT/).
+Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Mindful Software](https://mindfulsoftware.com).
 
-Michael is eternally grateful for the individual developers and small companies for their contributions. 
-
-Michael explicitly expresses his disthanks for the massive commercial companies in telcom, healthcare, Point of Sale, and more 
-who took time and provided nothing but requests for free software to support their 
-billions of customers.  Don't forget:
-
-[Mindful Software](https://mindfulsoftware.com) offers paid support, consulting and developing on Flutter, OpenTelemetry and AI-driven Product Development.
+Mindful Software offers paid support, consulting and developing on Flutter, OpenTelemetry and UI Architecture.
 
 ## Getting started
 
 Include this in your pubspec.yaml:
 ```
 dependencies:
-  dartastic_opentelemetry: ^1.0.0-alpha
+  dartastic_opentelemetry: ^0.9.3
 ```
 
 The entrypoint to the SDK is the `OTel` class.  `OTel` has static "factory" methods for all
@@ -88,14 +84,13 @@ OTel API and SDK objects.  `OTel` needs to be initialized first to point to an O
 backend.  Initialization does a lot of work under the hood including gathering a rich set of
 standard resources for any OS that Dart runs in.  It prepares for the creation of the global
 default `TracerProvider` with the serviceName and a default `Tracer`, both created on first use.
-
 All configuration, include Trace and Metric exporters, can be made in code via `OTel.initialize()`.  
 Codeless configuration can be done with standard OpenTelemetry environmental variables either 
 through POSIX variable or `-D` or `--define` for Dart or with `--dart-define` for Flutter apps.
 
 ## Environment Variables
 
-Dartastic OpenTelemetry supports for all standard OpenTelemetry environment variables as defined in the [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
+Dartastic OpenTelemetry ~~supports~~ is working on support for all standard OpenTelemetry environment variables as defined in the [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
 
 Environment variables provide a convenient way to configure OpenTelemetry without hardcoding values. 
 All environment variable names are available as strongly-typed constants in the SDK for compile-time 
@@ -193,7 +188,32 @@ Constants are defined for all 74 OpenTelemetry environment variables. See `lib/s
 | `otelExporterOtlpMetricsProtocol`     | `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`   | Metrics-specific protocol |
 | `otelExporterOtlpMetricsHeaders`      | `OTEL_EXPORTER_OTLP_METRICS_HEADERS`    | Metrics-specific headers  |
 
-For the complete list of all 74 supported environment variables with full documentation, see [`lib/src/environment/env_constants.dart`](lib/src/environment/env_constants.dart).
+##### Logs
+
+| Constant                              | Environment Variable                    | Description               |
+|---------------------------------------|-----------------------------------------|---------------------------|
+| `otelLogsExporter`                    | `OTEL_LOGS_EXPORTER`                    | Logs exporter type (`otlp`, `console`, `none`) |
+| `otelExporterOtlpLogsEndpoint`        | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`      | Logs-specific endpoint    |
+| `otelExporterOtlpLogsProtocol`        | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`      | Logs-specific protocol    |
+| `otelExporterOtlpLogsHeaders`         | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`       | Logs-specific headers     |
+
+##### Batch LogRecord Processor (BLRP)
+
+| Constant                         | Environment Variable              | Default  | Description                          |
+|----------------------------------|-----------------------------------|----------|--------------------------------------|
+| `otelBlrpScheduleDelay`          | `OTEL_BLRP_SCHEDULE_DELAY`        | `1000`   | Delay between exports (milliseconds) |
+| `otelBlrpExportTimeout`          | `OTEL_BLRP_EXPORT_TIMEOUT`        | `30000`  | Export timeout (milliseconds)        |
+| `otelBlrpMaxQueueSize`           | `OTEL_BLRP_MAX_QUEUE_SIZE`        | `2048`   | Maximum queue size                   |
+| `otelBlrpMaxExportBatchSize`     | `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` | `512`    | Maximum batch size per export        |
+
+##### LogRecord Limits
+
+| Constant                                  | Environment Variable                        | Default  | Description                        |
+|-------------------------------------------|---------------------------------------------|----------|------------------------------------|
+| `otelLogrecordAttributeValueLengthLimit`  | `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT` | No limit | Maximum length of attribute values |
+| `otelLogrecordAttributeCountLimit`        | `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT`       | `128`    | Maximum number of attributes       |
+
+For the complete list of all supported environment variables with full documentation, see [`lib/src/environment/env_constants.dart`](lib/src/environment/env_constants.dart).
 
 ### Usage Examples
 
@@ -323,309 +343,6 @@ Since dartastic_opentelemetry exports all the classes of `opentelemetry_api`, re
 
 See the `/example` folder for more examples.
 
-## OpenTelemetry Tracing API
-
-The Tracing API is the primary signal in OpenTelemetry. A **trace** represents the end-to-end journey of a request
-through your system.  Each trace is composed of **spans** — individual units of work with a name, timing,
-attributes, and parent-child relationships.
-
-### Concepts
-
-- **TracerProvider**: Entry point to the tracing API, responsible for creating Tracers and configuring the tracing pipeline
-- **Tracer**: Creates Spans for a particular instrumentation scope (library, package, or module)
-- **Span**: Represents a single operation — tracks its name, start/end time, attributes, events, links, and status
-- **SpanProcessor**: Handles span lifecycle events (start, end) and manages export
-- **SpanExporter**: Sends finished spans to a backend (OTLP, console, etc.)
-- **Sampler**: Decides which spans to record and export
-- **Context**: Carries the active span and baggage across async boundaries and service boundaries
-
-### Basic Tracing
-
-```dart
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
-
-Future<void> main() async {
-  await OTel.initialize(serviceName: 'my-service');
-
-  // Get the default tracer
-  final tracer = OTel.tracer();
-
-  // Create a span
-  final span = tracer.startSpan(
-    'main-operation',
-    kind: SpanKind.server,
-    attributes: OTel.attributesFromMap({
-      'user.id': 'user-123',
-      'request.type': 'example',
-    }),
-  );
-
-  try {
-    await doWork();
-    span.setStatus(SpanStatusCode.Ok);
-  } catch (e, stackTrace) {
-    span.recordException(e, stackTrace: stackTrace);
-    span.setStatus(SpanStatusCode.Error, e.toString());
-  } finally {
-    span.end();
-  }
-
-  await OTel.shutdown();
-}
-```
-
-### Parent-Child Spans
-
-Spans form a tree by linking child spans to parent spans via context:
-
-```dart
-final parentSpan = tracer.startSpan('parent-operation');
-
-// Create a child span linked to the parent
-final childSpan = tracer.startSpan(
-  'database.query',
-  kind: SpanKind.client,
-  context: OTel.context(spanContext: parentSpan.spanContext),
-  attributes: OTel.attributesFromMap({
-    'db.system': 'postgresql',
-    'db.operation': 'SELECT',
-  }),
-);
-
-try {
-  await queryDatabase();
-  childSpan.setStatus(SpanStatusCode.Ok);
-} finally {
-  childSpan.end();
-}
-parentSpan.end();
-```
-
-### Automatic Span Management
-
-The Tracer provides convenience methods that automatically end spans and capture exceptions:
-
-```dart
-// Synchronous — span is ended and exceptions recorded automatically
-final result = tracer.recordSpan(
-  name: 'compute-result',
-  fn: () => computeExpensiveValue(),
-);
-
-// Async version
-final data = await tracer.recordSpanAsync(
-  name: 'fetch-data',
-  kind: SpanKind.client,
-  fn: () => httpClient.get('/api/data'),
-);
-
-// Active span — sets the span in Context automatically
-tracer.startActiveSpan(
-  name: 'process-request',
-  fn: (span) {
-    // span is active in Context.current
-    span.setStringAttribute('request.id', 'abc-123');
-    return processRequest();
-  },
-);
-```
-
-### Span Attributes
-
-Attributes are typed key-value pairs on spans. OTel restricts values to `String`, `bool`, `int`, `double`,
-and `List`s of those types.
-
-```dart
-// Type-safe individual attributes
-final span = tracer.startSpan('operation', attributes: OTel.attributes([
-  OTel.attributeString('http.method', 'GET'),
-  OTel.attributeInt('http.status_code', 200),
-  OTel.attributeBool('http.is_error', false),
-  OTel.attributeDouble('http.duration_ms', 123.45),
-  OTel.attributeStringList('http.headers', ['Accept', 'Content-Type']),
-]));
-
-// Or from a map (types are inferred automatically)
-final span = tracer.startSpan('operation',
-  attributes: OTel.attributesFromMap({
-    'http.method': 'GET',
-    'http.status_code': 200,
-  }),
-);
-
-// Add attributes after creation
-span.setStringAttribute('http.url', 'https://api.example.com/data');
-span.setIntAttribute('http.response_content_length', 1024);
-span.addAttributes(OTel.attributesFromMap({'processing.stage': 'complete'}));
-```
-
-### Span Events
-
-Events are time-stamped annotations on a span:
-
-```dart
-span.addEvent(OTel.spanEventNow(
-  'cache.hit',
-  OTel.attributesFromMap({'cache.key': 'user:123'}),
-));
-
-span.addEventNow('validation.passed');
-```
-
-### Span Links
-
-Links connect spans across traces — useful for batch processing or fan-out patterns:
-
-```dart
-final link = OTel.spanLink(
-  otherSpan.spanContext,
-  attributes: OTel.attributesFromMap({'link.type': 'triggers'}),
-);
-
-final span = tracer.startSpan('batch-process', links: [link]);
-```
-
-### SpanKind
-
-Classifies the relationship between a span and its remote counterpart:
-
-| SpanKind   | Description                                    | Example                           |
-|------------|------------------------------------------------|-----------------------------------|
-| `internal` | Default; internal operation with no remote side | Business logic, local computation |
-| `server`   | Server handling an incoming request             | HTTP server endpoint              |
-| `client`   | Client making an outgoing request               | HTTP client call, DB query        |
-| `producer` | Producer enqueuing a message                    | Kafka producer, queue publisher   |
-| `consumer` | Consumer processing a message                   | Kafka consumer, queue subscriber  |
-
-### Samplers
-
-Samplers control which spans are recorded and exported. Configure via `OTel.initialize()` or per-`Tracer`.
-
-| Sampler                | Description                                      | Use Case                          |
-|------------------------|--------------------------------------------------|-----------------------------------|
-| `AlwaysOnSampler`      | Samples every span (default)                     | Development, debugging            |
-| `AlwaysOffSampler`     | Never samples                                    | Disable tracing without code changes |
-| `TraceIdRatioSampler`  | Samples by trace ID ratio (consistent per trace) | Production with consistent sampling |
-| `ProbabilitySampler`   | Samples by random probability                    | Testing, non-critical sampling    |
-| `ParentBasedSampler`   | Respects parent span's sampling decision         | Distributed tracing across services |
-| `RateLimitingSampler`  | Limits sampled traces per second (token bucket)  | Controlling overhead              |
-| `CountingSampler`      | Samples every Nth request                        | Periodic sampling                 |
-| `CompositeSampler`     | Combines samplers with AND/OR logic              | Complex sampling policies         |
-
-```dart
-// Sample 10% of traces consistently
-await OTel.initialize(
-  serviceName: 'my-service',
-  sampler: TraceIdRatioSampler(0.1),
-);
-
-// Respect parent decisions, sample 50% of new root traces
-await OTel.initialize(
-  serviceName: 'my-service',
-  sampler: ParentBasedSampler(TraceIdRatioSampler(0.5)),
-);
-
-// Rate-limit to 100 traces/second
-await OTel.initialize(
-  serviceName: 'my-service',
-  sampler: RateLimitingSampler(100),
-);
-```
-
-### Span Processors
-
-Processors handle span lifecycle and export:
-
-```dart
-// SimpleSpanProcessor — exports each span immediately (good for debugging)
-await OTel.initialize(
-  spanProcessor: SimpleSpanProcessor(ConsoleExporter()),
-);
-
-// BatchSpanProcessor — batches spans for efficient production export
-await OTel.initialize(
-  spanProcessor: BatchSpanProcessor(
-    OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(endpoint: 'localhost:4317')),
-    BatchSpanProcessorConfig(
-      maxQueueSize: 2048,
-      scheduleDelay: Duration(milliseconds: 5000),
-      maxExportBatchSize: 512,
-    ),
-  ),
-);
-```
-
-### Span Exporters
-
-| Exporter               | Protocol       | Description                              |
-|------------------------|----------------|------------------------------------------|
-| `ConsoleExporter`      | stdout         | Prints spans to console for debugging    |
-| `OtlpGrpcSpanExporter` | gRPC           | Exports via OTLP/gRPC (production)      |
-| `OtlpHttpSpanExporter` | HTTP/protobuf  | Exports via OTLP/HTTP (web-compatible)  |
-
-```dart
-// Console (development)
-final exporter = ConsoleExporter();
-
-// OTLP gRPC (production)
-final exporter = OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
-  endpoint: 'otel-collector:4317',
-  headers: {'api-key': 'your-key'},
-  compression: true,
-));
-
-// OTLP HTTP (web-compatible)
-final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-  endpoint: 'https://otel-collector:4318',
-  headers: {'api-key': 'your-key'},
-));
-```
-
-### Context Propagation
-
-Propagate trace context across service boundaries using W3C Trace Context and Baggage:
-
-```dart
-final propagator = CompositePropagator<Map<String, String>, String>([
-  W3CTraceContextPropagator(),
-  W3CBaggagePropagator(),
-]);
-
-// Inject into outgoing HTTP headers
-final headers = <String, String>{};
-propagator.inject(Context.current, headers, MapTextMapSetter(headers));
-// Send headers with your HTTP request...
-
-// Extract from incoming HTTP headers
-final extractedContext = propagator.extract(
-  OTel.context(),
-  incomingHeaders,
-  MapTextMapGetter(incomingHeaders),
-);
-
-// Create a child span in the extracted context
-await extractedContext.run(() async {
-  final span = tracer.startSpan('handle-request');
-  // This span is part of the same distributed trace
-  span.end();
-});
-```
-
-Context also propagates across Dart async gaps and Isolates:
-
-```dart
-// Across Isolates
-final result = await Context.current.runIsolate(() async {
-  // Context is automatically restored in the new Isolate
-  final span = tracer.startSpan('isolate-work');
-  try {
-    return await computeInIsolate();
-  } finally {
-    span.end();
-  }
-});
-```
-
 ## OpenTelemetry Metrics API
 
 The Metrics API in OpenTelemetry provides a way to record measurements about your application. These measurements can be exported later as metrics, allowing you to monitor and analyze the performance and behavior of your application.
@@ -693,142 +410,167 @@ final observableCounter = meter.createObservableCounter(
 
 ## OpenTelemetry Logs API
 
-The Logs API provides structured logging that integrates with traces and metrics.  Unlike traditional logging
-frameworks, OpenTelemetry logs are first-class telemetry signals that carry context, severity, attributes,
-and can be correlated with the span that was active when the log was emitted.
+The Logs API in OpenTelemetry provides a way to record log events from your application. These logs can be exported to an OpenTelemetry backend for analysis alongside traces and metrics.
 
 ### Concepts
 
 - **LoggerProvider**: Entry point to the logs API, responsible for creating Loggers
-- **Logger**: Emits LogRecords for a particular instrumentation scope
-- **LogRecord**: A single log entry with timestamp, severity, body, attributes, and trace context
-- **Severity**: A 24-level severity scale grouped into standard levels (TRACE, DEBUG, INFO, WARN, ERROR, FATAL)
+- **Logger**: Used to emit log records
+- **LogRecord**: Represents a single log event with body, severity, attributes, timestamps, and trace context
+- **LogRecordProcessor**: Processes log records before export
+- **LogRecordExporter**: Exports log records to backends
 
-### Basic Logging
-
-```dart
-// Get a logger from the default provider
-final logger = OTel.loggerProvider().getLogger('my-service');
-
-// Emit a simple log
-logger.emit(
-  severityNumber: Severity.INFO,
-  body: 'User successfully logged in.',
-  attributes: OTel.attributesFromMap({
-    'user.id': 'user-123',
-    'auth.method': 'oauth',
-  }),
-);
-
-// Warning log
-logger.emit(
-  severityNumber: Severity.WARN,
-  body: 'Cache miss for requested key.',
-  attributes: OTel.attributesFromMap({
-    'cache.key': 'profile_42',
-    'cache.region': 'us-east-1',
-  }),
-);
-
-// Error log
-logger.emit(
-  severityNumber: Severity.ERROR,
-  body: 'Failed to connect to database.',
-  attributes: OTel.attributesFromMap({
-    'db.system': 'postgresql',
-    'error.type': 'ConnectionTimeout',
-  }),
-);
-```
-
-### Log-to-Trace Correlation
-
-Logs can be linked to the active span through `Context`, enabling powerful correlation in your backend:
+### Quick Start
 
 ```dart
-final span = tracer.startSpan('process-order');
-try {
-  logger.emit(
-    severityNumber: Severity.INFO,
-    body: 'Processing order.',
-    context: Context.current, // Links this log to the active span
-    attributes: OTel.attributesFromMap({'order.id': 'order-789'}),
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() async {
+  // Initialize with logs enabled (default)
+  await OTel.initialize(
+    serviceName: 'my-service',
+    enableLogs: true,  // Default is true
   );
-  await processOrder();
-} finally {
-  span.end();
+
+  // Get a logger
+  final logger = OTel.logger('my-component');
+
+  // Emit log records
+  logger.emit(
+    body: 'Application started',
+    severityNumber: Severity.INFO,
+  );
+
+  // Log with attributes
+  logger.emit(
+    body: 'User logged in',
+    severityNumber: Severity.INFO,
+    attributes: OTel.attributesFromMap({
+      'user.id': 'user123',
+      'user.role': 'admin',
+    }),
+  );
+
+  // Log an error with exception
+  try {
+    throw Exception('Something went wrong');
+  } catch (e, stackTrace) {
+    logger.emit(
+      body: 'Operation failed: $e',
+      severityNumber: Severity.ERROR,
+      attributes: OTel.attributesFromMap({
+        'exception.type': e.runtimeType.toString(),
+        'exception.stacktrace': stackTrace.toString(),
+      }),
+    );
+  }
 }
 ```
 
-### Severity Levels
+### Intercepting print() Calls
 
-OpenTelemetry defines a fine-grained 24-level severity scale, grouped into standard levels:
-
-| Level   | Severities                      | Use Case                              |
-|---------|---------------------------------|---------------------------------------|
-| TRACE   | `TRACE`, `TRACE2-4`            | Finest-grained debugging information  |
-| DEBUG   | `DEBUG`, `DEBUG2-4`            | Debugging information                 |
-| INFO    | `INFO`, `INFO2-4`             | Normal operational messages           |
-| WARN    | `WARN`, `WARN2-4`             | Warning conditions                    |
-| ERROR   | `ERROR`, `ERROR2-4`           | Error conditions                      |
-| FATAL   | `FATAL`, `FATAL2-4`           | System is unusable                    |
-
-Severity levels support comparison operators for filtering:
+Dartastic OpenTelemetry can automatically capture `print()` calls and convert them to OpenTelemetry logs:
 
 ```dart
-if (severity >= Severity.WARN) {
-  // Handle warning or above
-}
-```
-
-### Flexible Log Bodies
-
-The `body` parameter accepts diverse types — not just strings:
-
-```dart
-// String body
-logger.emit(body: 'Simple message.');
-
-// Structured body (Map)
-logger.emit(body: {'event': 'batch_complete', 'items': 42});
-
-// List body
-logger.emit(body: [
-  {'job': 'resize_images', 'status': 'ok'},
-  {'job': 'generate_thumbnails', 'status': 'failed'},
-]);
-```
-
-### Named Events
-
-Use `eventName` to categorize logs as discrete events:
-
-```dart
-logger.emit(
-  eventName: 'user_signup',
-  severityNumber: Severity.INFO,
-  body: 'New user registered.',
-  attributes: OTel.attributesFromMap({
-    'user.email_domain': 'example.com',
-    'signup.source': 'organic',
-  }),
+await OTel.initialize(
+  serviceName: 'my-service',
+  logPrint: true,  // Enable print interception
+  logPrintLoggerName: 'dart.print',  // Optional custom logger name
 );
+
+// Use runWithPrintInterception to capture prints
+OTel.runWithPrintInterception(() {
+  print('This will be captured as an OTel log');
+  print('So will this');
+});
+
+// For async code
+await OTel.runWithPrintInterceptionAsync(() async {
+  print('Async print captured');
+  await someAsyncOperation();
+});
+```
+
+### Log Severity Levels
+
+| Severity | Use Case |
+|----------|----------|
+| `Severity.TRACE` / `Severity.TRACE2-4` | Fine-grained debugging |
+| `Severity.DEBUG` / `Severity.DEBUG2-4` | Debug information |
+| `Severity.INFO` / `Severity.INFO2-4` | General information |
+| `Severity.WARN` / `Severity.WARN2-4` | Warning conditions |
+| `Severity.ERROR` / `Severity.ERROR2-4` | Error conditions |
+| `Severity.FATAL` / `Severity.FATAL2-4` | Critical failures |
+
+### Custom Log Exporters
+
+```dart
+// Use a custom exporter
+final customExporter = OtlpHttpLogRecordExporter(
+  OtlpHttpLogRecordExporterConfig(
+    endpoint: 'https://my-collector:4318',
+    headers: {'Authorization': 'Bearer token'},
+  ),
+);
+
+await OTel.initialize(
+  serviceName: 'my-service',
+  logRecordExporter: customExporter,
+);
+```
+
+### Console Logging (Development)
+
+```dart
+// Use console exporter for development
+await OTel.initialize(
+  serviceName: 'my-service',
+  logRecordProcessor: SimpleLogRecordProcessor(ConsoleLogRecordExporter()),
+);
+```
+
+### Configuration via Environment Variables
+
+Logs can be configured via environment variables:
+
+```bash
+# Set logs exporter (otlp, console, or none)
+export OTEL_LOGS_EXPORTER=otlp
+
+# Set logs-specific endpoint
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs-collector:4318
+
+# Configure batch processor
+export OTEL_BLRP_SCHEDULE_DELAY=5000
+export OTEL_BLRP_MAX_QUEUE_SIZE=4096
+
+# Set log record limits
+export OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=128
 ```
 
 ## Integration with Dartastic/Flutterrific
 
-All three signal APIs (Traces, Metrics, Logs) follow the same multi-layered factory pattern:
+This API implementation follows the same pattern as the tracing API, where the creation of objects is managed through
+factory methods. This allows for a clear separation between API and SDK, and ensures that the metrics and logs functionality
+can be used in a no-op mode when the SDK is not initialized.
 
-1. **API Layer**: Defines interfaces and provides no-op implementations
-2. **SDK Layer**: Provides concrete implementations with export and processing
-3. **Flutter Layer**: Adds UI-specific functionality (route observation, app lifecycle, etc.)
+## Commercial Support
 
-The creation of objects is managed through factory methods on `OTel`, ensuring a clear separation between
-API and SDK.  Each signal can be used in no-op mode when the SDK is not initialized.
+[Dartastic.io](https://dartastic.io) provides an OpenTelemetry Observability backend specifically built for Dart and Flutter applications. Features include:
+
+- Enhanced tracing with source code integration
+- Real-time user monitoring for Flutter apps
+- Advanced dashboard and visualization
+- Integration with native platforms
+- Generous free tier and enterprise support options
 
 ## Roadmap
 
-- [ ] Support for Zipkin, Jaeger exporters
+- [ ] Enhanced metrics support
+- [ ] Support for Zipkin, Jaeger
+- [ ] Integration with common Dart libraries (Dio, etc.)
+- [ ] Context propagation through http, Android, iOS, WebViews
+
 
 ## CNCF Contribution and Alignment
 
@@ -861,7 +603,7 @@ Dartastic.io offers:
 
 ## AI Usage
 Practically all code in Dartastic was generated via Claude. EVERY character 
-is reviewed by a human.
+is reviewed by a human.  Tests may need improved quality.
 
 ## Additional information
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ billions of customers.  Don't forget:
 Include this in your pubspec.yaml:
 ```
 dependencies:
-  dartastic_opentelemetry: ^0.9.3
+  dartastic_opentelemetry: ^1.0.0-alpha
 ```
 
 The entrypoint to the SDK is the `OTel` class.  `OTel` has static "factory" methods for all
@@ -718,18 +718,13 @@ final observableCounter = meter.createObservableCounter(
 
 ## OpenTelemetry Logs API
 
-<<<<<<< HEAD
-The Logs API in OpenTelemetry provides a way to record log events from your application. These logs can be exported to an OpenTelemetry backend for analysis alongside traces and metrics.
-=======
 The Logs API provides structured logging that integrates with traces and metrics.  Unlike traditional logging
 frameworks, OpenTelemetry logs are first-class telemetry signals that carry context, severity, attributes,
 and can be correlated with the span that was active when the log was emitted.
->>>>>>> 4831683 (chore: Test coverage from 69% to 90%, bug fixes, version 1.0.0-alpha)
 
 ### Concepts
 
 - **LoggerProvider**: Entry point to the logs API, responsible for creating Loggers
-<<<<<<< HEAD
 - **Logger**: Used to emit log records
 - **LogRecord**: Represents a single log event with body, severity, attributes, timestamps, and trace context
 - **LogRecordProcessor**: Processes log records before export
@@ -817,62 +812,6 @@ await OTel.runWithPrintInterceptionAsync(() async {
 | `Severity.ERROR` / `Severity.ERROR2-4` | Error conditions |
 | `Severity.FATAL` / `Severity.FATAL2-4` | Critical failures |
 
-### Custom Log Exporters
-
-```dart
-// Use a custom exporter
-final customExporter = OtlpHttpLogRecordExporter(
-  OtlpHttpLogRecordExporterConfig(
-    endpoint: 'https://my-collector:4318',
-    headers: {'Authorization': 'Bearer token'},
-  ),
-);
-
-await OTel.initialize(
-  serviceName: 'my-service',
-  logRecordExporter: customExporter,
-);
-```
-
-### Console Logging (Development)
-
-```dart
-// Use console exporter for development
-await OTel.initialize(
-  serviceName: 'my-service',
-  logRecordProcessor: SimpleLogRecordProcessor(ConsoleLogRecordExporter()),
-);
-```
-
-### Configuration via Environment Variables
-
-Logs can be configured via environment variables:
-
-```bash
-# Set logs exporter (otlp, console, or none)
-export OTEL_LOGS_EXPORTER=otlp
-
-# Set logs-specific endpoint
-export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs-collector:4318
-
-# Configure batch processor
-export OTEL_BLRP_SCHEDULE_DELAY=5000
-export OTEL_BLRP_MAX_QUEUE_SIZE=4096
-
-# Set log record limits
-export OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=128
-```
-
-## Integration with Dartastic/Flutterrific
-
-This API implementation follows the same pattern as the tracing API, where the creation of objects is managed through
-factory methods. This allows for a clear separation between API and SDK, and ensures that the metrics and logs functionality
-can be used in a no-op mode when the SDK is not initialized.
-=======
-- **Logger**: Emits LogRecords for a particular instrumentation scope
-- **LogRecord**: A single log entry with timestamp, severity, body, attributes, and trace context
-- **Severity**: A 24-level severity scale grouped into standard levels (TRACE, DEBUG, INFO, WARN, ERROR, FATAL)
-
 ### Basic Logging
 
 ```dart
@@ -927,7 +866,54 @@ try {
 } finally {
   span.end();
 }
+
 ```
+### Custom Log Exporters
+
+```dart
+// Use a custom exporter
+final customExporter = OtlpHttpLogRecordExporter(
+  OtlpHttpLogRecordExporterConfig(
+    endpoint: 'https://my-collector:4318',
+    headers: {'Authorization': 'Bearer token'},
+  ),
+);
+
+await OTel.initialize(
+  serviceName: 'my-service',
+  logRecordExporter: customExporter,
+);
+```
+
+### Console Logging (Development)
+
+```dart
+// Use console exporter for development
+await OTel.initialize(
+  serviceName: 'my-service',
+  logRecordProcessor: SimpleLogRecordProcessor(ConsoleLogRecordExporter()),
+);
+```
+
+### Configuration via Environment Variables
+
+Logs can be configured via environment variables:
+
+```bash
+# Set logs exporter (otlp, console, or none)
+export OTEL_LOGS_EXPORTER=otlp
+
+# Set logs-specific endpoint
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs-collector:4318
+
+# Configure batch processor
+export OTEL_BLRP_SCHEDULE_DELAY=5000
+export OTEL_BLRP_MAX_QUEUE_SIZE=4096
+
+# Set log record limits
+export OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=128
+```
+
 
 ### Severity Levels
 
@@ -984,10 +970,10 @@ logger.emit(
 );
 ```
 
+
 ## Integration with Dartastic/Flutterrific
 
 All three signal APIs (Traces, Metrics, Logs) follow the same multi-layered factory pattern:
->>>>>>> 4831683 (chore: Test coverage from 69% to 90%, bug fixes, version 1.0.0-alpha)
 
 1. **API Layer**: Defines interfaces and provides no-op implementations
 2. **SDK Layer**: Provides concrete implementations with export and processing

--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@
 [![Coverage Report](https://img.shields.io/badge/coverage-report-brightgreen.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)
 
 Dartastic is an [OpenTelemetry](https://opentelemetry.io/) SDK to add standard observability to Dart applications.
-Dartastic can be used with any OTel backend, it's standards-compliant.
+Dartastic can be used with any OTel backend since it's standards-compliant.
 
 Flutter developers should use the [Flutterific OpenTelemetry SDK](https://pub.dev/packages/flutterrific_opentelemetry/) which builds on top of Dartastic OTel.
 
-The Dartastic and Flutterrific OTel SDK has been proposed for [Donation to the CNCF](https://github.com/open-telemetry/community/issues/2718).
-We need YOU to grow the Dartastic community and make this SDK the standard for Flutter and Dart OTel.
-Please use it, submit issues, support us with stars and contribute PRs. We are looking for contributors and maintainers.
-Also, please support the development by subscribing at [Dartastic.io](https://dartastic.io) and gain early access to the
-Flutter SDK and the Wondrous Demo.
+The Dartastic OTel SDK has been proposed for [Donation to the CNCF](https://github.com/open-telemetry/community/issues/2718).
 
 [Dartastic.io](https://dartastic.io) provides an OpenTelemetry support, training, consulting
 and an Observability backend customized for Flutter apps, Dart backends, and any other service or process that produces
@@ -43,7 +39,7 @@ OpenTelemetry data.
     - Low overhead
     - Batch processing
     - Performance test suite for proven benchmarks
-- 🐞 **Well Tested**: Good test coverage (>85%). 
+- 🐞 **Well Tested**: Very good test coverage (>90%). 
 - 📃 **Quality Documentation**: If it's not clearly documented, it's a bug. Extensive examples and best practices are
   provided. See the examples directory. 
 - 🎬 **Demo** The [Wonderous OpenTelemetry Demo](https://github.com/MindfulSoftwareLLC/wondrous_opentelemetry) demonstrates  
@@ -63,13 +59,21 @@ The `dartastic_opentelemetry_api` exists as a standalone library to strictly adh
 OpenTelemetry specification which separates API and the SDK.  All OpenTelemetry API classes on in
 `dartastic_opentelemetry_api`.
 
-[Flutterrific OTel](https://pub.dev/packages/flutterrific_opentelemetry) adds Dartastic OTel to Flutter apps with ease.  Sign Up at Dartastic.io for early access to this soon to be open source.
+[Flutterrific OTel](https://pub.dev/packages/flutterrific_opentelemetry) adds Dartastic OTel to Flutter apps with ease.
 
 [Dartastic.io](https://dartastic.io) is an OpenTelemetry backend based on Elastic with a generous free tier.
 
-Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Mindful Software](https://mindfulsoftware.com).
+Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Mindful Software](https://mindfulsoftware.com) with support from:
+* [SEMPlicity, Inc.](https://semplicityinc.com), the Elastic experts, who provided the initial funding.
+* [The Anspar Foundation](https://anspar.org) and [CureHHT](https://curehht.org) for support of Michael Bushe's OTel work and early adopter status in [software used in FDA clinical trials](https://github.com/Cure-HHT/).
 
-Mindful Software offers paid support, consulting and developing on Flutter, OpenTelemetry and UI Architecture.
+Michael is eternally grateful for the individual developers and small companies for their contributions. 
+
+Michael explicitly expresses his disthanks for the massive commercial companies in telcom, healthcare, Point of Sale, and more 
+who took time and provided nothing but requests for free software to support their 
+billions of customers.  Don't forget:
+
+[Mindful Software](https://mindfulsoftware.com) offers paid support, consulting and developing on Flutter, OpenTelemetry and AI-driven Product Development.
 
 ## Getting started
 
@@ -84,13 +88,14 @@ OTel API and SDK objects.  `OTel` needs to be initialized first to point to an O
 backend.  Initialization does a lot of work under the hood including gathering a rich set of
 standard resources for any OS that Dart runs in.  It prepares for the creation of the global
 default `TracerProvider` with the serviceName and a default `Tracer`, both created on first use.
+
 All configuration, include Trace and Metric exporters, can be made in code via `OTel.initialize()`.  
 Codeless configuration can be done with standard OpenTelemetry environmental variables either 
 through POSIX variable or `-D` or `--define` for Dart or with `--dart-define` for Flutter apps.
 
 ## Environment Variables
 
-Dartastic OpenTelemetry ~~supports~~ is working on support for all standard OpenTelemetry environment variables as defined in the [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
+Dartastic OpenTelemetry supports for all standard OpenTelemetry environment variables as defined in the [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
 
 Environment variables provide a convenient way to configure OpenTelemetry without hardcoding values. 
 All environment variable names are available as strongly-typed constants in the SDK for compile-time 
@@ -343,6 +348,309 @@ Since dartastic_opentelemetry exports all the classes of `opentelemetry_api`, re
 
 See the `/example` folder for more examples.
 
+## OpenTelemetry Tracing API
+
+The Tracing API is the primary signal in OpenTelemetry. A **trace** represents the end-to-end journey of a request
+through your system.  Each trace is composed of **spans** — individual units of work with a name, timing,
+attributes, and parent-child relationships.
+
+### Concepts
+
+- **TracerProvider**: Entry point to the tracing API, responsible for creating Tracers and configuring the tracing pipeline
+- **Tracer**: Creates Spans for a particular instrumentation scope (library, package, or module)
+- **Span**: Represents a single operation — tracks its name, start/end time, attributes, events, links, and status
+- **SpanProcessor**: Handles span lifecycle events (start, end) and manages export
+- **SpanExporter**: Sends finished spans to a backend (OTLP, console, etc.)
+- **Sampler**: Decides which spans to record and export
+- **Context**: Carries the active span and baggage across async boundaries and service boundaries
+
+### Basic Tracing
+
+```dart
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+Future<void> main() async {
+  await OTel.initialize(serviceName: 'my-service');
+
+  // Get the default tracer
+  final tracer = OTel.tracer();
+
+  // Create a span
+  final span = tracer.startSpan(
+    'main-operation',
+    kind: SpanKind.server,
+    attributes: OTel.attributesFromMap({
+      'user.id': 'user-123',
+      'request.type': 'example',
+    }),
+  );
+
+  try {
+    await doWork();
+    span.setStatus(SpanStatusCode.Ok);
+  } catch (e, stackTrace) {
+    span.recordException(e, stackTrace: stackTrace);
+    span.setStatus(SpanStatusCode.Error, e.toString());
+  } finally {
+    span.end();
+  }
+
+  await OTel.shutdown();
+}
+```
+
+### Parent-Child Spans
+
+Spans form a tree by linking child spans to parent spans via context:
+
+```dart
+final parentSpan = tracer.startSpan('parent-operation');
+
+// Create a child span linked to the parent
+final childSpan = tracer.startSpan(
+  'database.query',
+  kind: SpanKind.client,
+  context: OTel.context(spanContext: parentSpan.spanContext),
+  attributes: OTel.attributesFromMap({
+    'db.system': 'postgresql',
+    'db.operation': 'SELECT',
+  }),
+);
+
+try {
+  await queryDatabase();
+  childSpan.setStatus(SpanStatusCode.Ok);
+} finally {
+  childSpan.end();
+}
+parentSpan.end();
+```
+
+### Automatic Span Management
+
+The Tracer provides convenience methods that automatically end spans and capture exceptions:
+
+```dart
+// Synchronous — span is ended and exceptions recorded automatically
+final result = tracer.recordSpan(
+  name: 'compute-result',
+  fn: () => computeExpensiveValue(),
+);
+
+// Async version
+final data = await tracer.recordSpanAsync(
+  name: 'fetch-data',
+  kind: SpanKind.client,
+  fn: () => httpClient.get('/api/data'),
+);
+
+// Active span — sets the span in Context automatically
+tracer.startActiveSpan(
+  name: 'process-request',
+  fn: (span) {
+    // span is active in Context.current
+    span.setStringAttribute('request.id', 'abc-123');
+    return processRequest();
+  },
+);
+```
+
+### Span Attributes
+
+Attributes are typed key-value pairs on spans. OTel restricts values to `String`, `bool`, `int`, `double`,
+and `List`s of those types.
+
+```dart
+// Type-safe individual attributes
+final span = tracer.startSpan('operation', attributes: OTel.attributes([
+  OTel.attributeString('http.method', 'GET'),
+  OTel.attributeInt('http.status_code', 200),
+  OTel.attributeBool('http.is_error', false),
+  OTel.attributeDouble('http.duration_ms', 123.45),
+  OTel.attributeStringList('http.headers', ['Accept', 'Content-Type']),
+]));
+
+// Or from a map (types are inferred automatically)
+final span = tracer.startSpan('operation',
+  attributes: OTel.attributesFromMap({
+    'http.method': 'GET',
+    'http.status_code': 200,
+  }),
+);
+
+// Add attributes after creation
+span.setStringAttribute('http.url', 'https://api.example.com/data');
+span.setIntAttribute('http.response_content_length', 1024);
+span.addAttributes(OTel.attributesFromMap({'processing.stage': 'complete'}));
+```
+
+### Span Events
+
+Events are time-stamped annotations on a span:
+
+```dart
+span.addEvent(OTel.spanEventNow(
+  'cache.hit',
+  OTel.attributesFromMap({'cache.key': 'user:123'}),
+));
+
+span.addEventNow('validation.passed');
+```
+
+### Span Links
+
+Links connect spans across traces — useful for batch processing or fan-out patterns:
+
+```dart
+final link = OTel.spanLink(
+  otherSpan.spanContext,
+  attributes: OTel.attributesFromMap({'link.type': 'triggers'}),
+);
+
+final span = tracer.startSpan('batch-process', links: [link]);
+```
+
+### SpanKind
+
+Classifies the relationship between a span and its remote counterpart:
+
+| SpanKind   | Description                                    | Example                           |
+|------------|------------------------------------------------|-----------------------------------|
+| `internal` | Default; internal operation with no remote side | Business logic, local computation |
+| `server`   | Server handling an incoming request             | HTTP server endpoint              |
+| `client`   | Client making an outgoing request               | HTTP client call, DB query        |
+| `producer` | Producer enqueuing a message                    | Kafka producer, queue publisher   |
+| `consumer` | Consumer processing a message                   | Kafka consumer, queue subscriber  |
+
+### Samplers
+
+Samplers control which spans are recorded and exported. Configure via `OTel.initialize()` or per-`Tracer`.
+
+| Sampler                | Description                                      | Use Case                          |
+|------------------------|--------------------------------------------------|-----------------------------------|
+| `AlwaysOnSampler`      | Samples every span (default)                     | Development, debugging            |
+| `AlwaysOffSampler`     | Never samples                                    | Disable tracing without code changes |
+| `TraceIdRatioSampler`  | Samples by trace ID ratio (consistent per trace) | Production with consistent sampling |
+| `ProbabilitySampler`   | Samples by random probability                    | Testing, non-critical sampling    |
+| `ParentBasedSampler`   | Respects parent span's sampling decision         | Distributed tracing across services |
+| `RateLimitingSampler`  | Limits sampled traces per second (token bucket)  | Controlling overhead              |
+| `CountingSampler`      | Samples every Nth request                        | Periodic sampling                 |
+| `CompositeSampler`     | Combines samplers with AND/OR logic              | Complex sampling policies         |
+
+```dart
+// Sample 10% of traces consistently
+await OTel.initialize(
+  serviceName: 'my-service',
+  sampler: TraceIdRatioSampler(0.1),
+);
+
+// Respect parent decisions, sample 50% of new root traces
+await OTel.initialize(
+  serviceName: 'my-service',
+  sampler: ParentBasedSampler(TraceIdRatioSampler(0.5)),
+);
+
+// Rate-limit to 100 traces/second
+await OTel.initialize(
+  serviceName: 'my-service',
+  sampler: RateLimitingSampler(100),
+);
+```
+
+### Span Processors
+
+Processors handle span lifecycle and export:
+
+```dart
+// SimpleSpanProcessor — exports each span immediately (good for debugging)
+await OTel.initialize(
+  spanProcessor: SimpleSpanProcessor(ConsoleExporter()),
+);
+
+// BatchSpanProcessor — batches spans for efficient production export
+await OTel.initialize(
+  spanProcessor: BatchSpanProcessor(
+    OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(endpoint: 'localhost:4317')),
+    BatchSpanProcessorConfig(
+      maxQueueSize: 2048,
+      scheduleDelay: Duration(milliseconds: 5000),
+      maxExportBatchSize: 512,
+    ),
+  ),
+);
+```
+
+### Span Exporters
+
+| Exporter               | Protocol       | Description                              |
+|------------------------|----------------|------------------------------------------|
+| `ConsoleExporter`      | stdout         | Prints spans to console for debugging    |
+| `OtlpGrpcSpanExporter` | gRPC           | Exports via OTLP/gRPC (production)      |
+| `OtlpHttpSpanExporter` | HTTP/protobuf  | Exports via OTLP/HTTP (web-compatible)  |
+
+```dart
+// Console (development)
+final exporter = ConsoleExporter();
+
+// OTLP gRPC (production)
+final exporter = OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
+  endpoint: 'otel-collector:4317',
+  headers: {'api-key': 'your-key'},
+  compression: true,
+));
+
+// OTLP HTTP (web-compatible)
+final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
+  endpoint: 'https://otel-collector:4318',
+  headers: {'api-key': 'your-key'},
+));
+```
+
+### Context Propagation
+
+Propagate trace context across service boundaries using W3C Trace Context and Baggage:
+
+```dart
+final propagator = CompositePropagator<Map<String, String>, String>([
+  W3CTraceContextPropagator(),
+  W3CBaggagePropagator(),
+]);
+
+// Inject into outgoing HTTP headers
+final headers = <String, String>{};
+propagator.inject(Context.current, headers, MapTextMapSetter(headers));
+// Send headers with your HTTP request...
+
+// Extract from incoming HTTP headers
+final extractedContext = propagator.extract(
+  OTel.context(),
+  incomingHeaders,
+  MapTextMapGetter(incomingHeaders),
+);
+
+// Create a child span in the extracted context
+await extractedContext.run(() async {
+  final span = tracer.startSpan('handle-request');
+  // This span is part of the same distributed trace
+  span.end();
+});
+```
+
+Context also propagates across Dart async gaps and Isolates:
+
+```dart
+// Across Isolates
+final result = await Context.current.runIsolate(() async {
+  // Context is automatically restored in the new Isolate
+  final span = tracer.startSpan('isolate-work');
+  try {
+    return await computeInIsolate();
+  } finally {
+    span.end();
+  }
+});
+```
+
 ## OpenTelemetry Metrics API
 
 The Metrics API in OpenTelemetry provides a way to record measurements about your application. These measurements can be exported later as metrics, allowing you to monitor and analyze the performance and behavior of your application.
@@ -410,11 +718,18 @@ final observableCounter = meter.createObservableCounter(
 
 ## OpenTelemetry Logs API
 
+<<<<<<< HEAD
 The Logs API in OpenTelemetry provides a way to record log events from your application. These logs can be exported to an OpenTelemetry backend for analysis alongside traces and metrics.
+=======
+The Logs API provides structured logging that integrates with traces and metrics.  Unlike traditional logging
+frameworks, OpenTelemetry logs are first-class telemetry signals that carry context, severity, attributes,
+and can be correlated with the span that was active when the log was emitted.
+>>>>>>> 4831683 (chore: Test coverage from 69% to 90%, bug fixes, version 1.0.0-alpha)
 
 ### Concepts
 
 - **LoggerProvider**: Entry point to the logs API, responsible for creating Loggers
+<<<<<<< HEAD
 - **Logger**: Used to emit log records
 - **LogRecord**: Represents a single log event with body, severity, attributes, timestamps, and trace context
 - **LogRecordProcessor**: Processes log records before export
@@ -553,24 +868,137 @@ export OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=128
 This API implementation follows the same pattern as the tracing API, where the creation of objects is managed through
 factory methods. This allows for a clear separation between API and SDK, and ensures that the metrics and logs functionality
 can be used in a no-op mode when the SDK is not initialized.
+=======
+- **Logger**: Emits LogRecords for a particular instrumentation scope
+- **LogRecord**: A single log entry with timestamp, severity, body, attributes, and trace context
+- **Severity**: A 24-level severity scale grouped into standard levels (TRACE, DEBUG, INFO, WARN, ERROR, FATAL)
 
-## Commercial Support
+### Basic Logging
 
-[Dartastic.io](https://dartastic.io) provides an OpenTelemetry Observability backend specifically built for Dart and Flutter applications. Features include:
+```dart
+// Get a logger from the default provider
+final logger = OTel.loggerProvider().getLogger('my-service');
 
-- Enhanced tracing with source code integration
-- Real-time user monitoring for Flutter apps
-- Advanced dashboard and visualization
-- Integration with native platforms
-- Generous free tier and enterprise support options
+// Emit a simple log
+logger.emit(
+  severityNumber: Severity.INFO,
+  body: 'User successfully logged in.',
+  attributes: OTel.attributesFromMap({
+    'user.id': 'user-123',
+    'auth.method': 'oauth',
+  }),
+);
+
+// Warning log
+logger.emit(
+  severityNumber: Severity.WARN,
+  body: 'Cache miss for requested key.',
+  attributes: OTel.attributesFromMap({
+    'cache.key': 'profile_42',
+    'cache.region': 'us-east-1',
+  }),
+);
+
+// Error log
+logger.emit(
+  severityNumber: Severity.ERROR,
+  body: 'Failed to connect to database.',
+  attributes: OTel.attributesFromMap({
+    'db.system': 'postgresql',
+    'error.type': 'ConnectionTimeout',
+  }),
+);
+```
+
+### Log-to-Trace Correlation
+
+Logs can be linked to the active span through `Context`, enabling powerful correlation in your backend:
+
+```dart
+final span = tracer.startSpan('process-order');
+try {
+  logger.emit(
+    severityNumber: Severity.INFO,
+    body: 'Processing order.',
+    context: Context.current, // Links this log to the active span
+    attributes: OTel.attributesFromMap({'order.id': 'order-789'}),
+  );
+  await processOrder();
+} finally {
+  span.end();
+}
+```
+
+### Severity Levels
+
+OpenTelemetry defines a fine-grained 24-level severity scale, grouped into standard levels:
+
+| Level   | Severities                      | Use Case                              |
+|---------|---------------------------------|---------------------------------------|
+| TRACE   | `TRACE`, `TRACE2-4`            | Finest-grained debugging information  |
+| DEBUG   | `DEBUG`, `DEBUG2-4`            | Debugging information                 |
+| INFO    | `INFO`, `INFO2-4`             | Normal operational messages           |
+| WARN    | `WARN`, `WARN2-4`             | Warning conditions                    |
+| ERROR   | `ERROR`, `ERROR2-4`           | Error conditions                      |
+| FATAL   | `FATAL`, `FATAL2-4`           | System is unusable                    |
+
+Severity levels support comparison operators for filtering:
+
+```dart
+if (severity >= Severity.WARN) {
+  // Handle warning or above
+}
+```
+
+### Flexible Log Bodies
+
+The `body` parameter accepts diverse types — not just strings:
+
+```dart
+// String body
+logger.emit(body: 'Simple message.');
+
+// Structured body (Map)
+logger.emit(body: {'event': 'batch_complete', 'items': 42});
+
+// List body
+logger.emit(body: [
+  {'job': 'resize_images', 'status': 'ok'},
+  {'job': 'generate_thumbnails', 'status': 'failed'},
+]);
+```
+
+### Named Events
+
+Use `eventName` to categorize logs as discrete events:
+
+```dart
+logger.emit(
+  eventName: 'user_signup',
+  severityNumber: Severity.INFO,
+  body: 'New user registered.',
+  attributes: OTel.attributesFromMap({
+    'user.email_domain': 'example.com',
+    'signup.source': 'organic',
+  }),
+);
+```
+
+## Integration with Dartastic/Flutterrific
+
+All three signal APIs (Traces, Metrics, Logs) follow the same multi-layered factory pattern:
+>>>>>>> 4831683 (chore: Test coverage from 69% to 90%, bug fixes, version 1.0.0-alpha)
+
+1. **API Layer**: Defines interfaces and provides no-op implementations
+2. **SDK Layer**: Provides concrete implementations with export and processing
+3. **Flutter Layer**: Adds UI-specific functionality (route observation, app lifecycle, etc.)
+
+The creation of objects is managed through factory methods on `OTel`, ensuring a clear separation between
+API and SDK.  Each signal can be used in no-op mode when the SDK is not initialized.
 
 ## Roadmap
 
-- [ ] Enhanced metrics support
-- [ ] Support for Zipkin, Jaeger
-- [ ] Integration with common Dart libraries (Dio, etc.)
-- [ ] Context propagation through http, Android, iOS, WebViews
-
+- [ ] Support for Zipkin, Jaeger exporters
 
 ## CNCF Contribution and Alignment
 
@@ -603,7 +1031,7 @@ Dartastic.io offers:
 
 ## AI Usage
 Practically all code in Dartastic was generated via Claude. EVERY character 
-is reviewed by a human.  Tests may need improved quality.
+is reviewed by a human.
 
 ## Additional information
 

--- a/example/baggage_error_handling_example.dart
+++ b/example/baggage_error_handling_example.dart
@@ -50,10 +50,7 @@ class UserPreferenceService {
       print('Failed to get user preferences: $e');
 
       // Provide sensible defaults
-      return {
-        'language': 'en-US',
-        'theme': 'light',
-      };
+      return {'language': 'en-US', 'theme': 'light'};
     }
   }
 
@@ -94,10 +91,7 @@ class ConfigurationService {
       if (env != null && !_validEnvironments.contains(env)) {
         throw BaggageException(
           'Invalid environment value',
-          context: {
-            'value': env,
-            'validValues': _validEnvironments,
-          },
+          context: {'value': env, 'validValues': _validEnvironments},
         );
       }
 
@@ -106,10 +100,7 @@ class ConfigurationService {
       if (logLevel != null && !_validLogLevels.contains(logLevel)) {
         throw BaggageException(
           'Invalid log level',
-          context: {
-            'value': logLevel,
-            'validValues': _validLogLevels,
-          },
+          context: {'value': logLevel, 'validValues': _validLogLevels},
         );
       }
 
@@ -164,18 +155,12 @@ Baggage _safelyAddBaggageEntry(
 }) {
   // Validate key format
   if (!_isValidBaggageKey(key)) {
-    throw BaggageException(
-      'Invalid baggage key format',
-      context: {'key': key},
-    );
+    throw BaggageException('Invalid baggage key format', context: {'key': key});
   }
 
   // Validate value
   if (!validator(value)) {
-    throw BaggageException(
-      errorMessage,
-      context: {'key': key, 'value': value},
-    );
+    throw BaggageException(errorMessage, context: {'key': key, 'value': value});
   }
 
   // Add metadata about validation
@@ -195,10 +180,10 @@ bool _isValidBaggageKey(String key) {
 
 Future<void> main() async {
   // Example with missing required value
-  final invalidContext = OTel.context()
-      .withBaggage(OTel.baggage().copyWith('user.language', 'fr-FR')
-          // Note: missing required user.id
-          );
+  final invalidContext = OTel.context().withBaggage(
+    OTel.baggage().copyWith('user.language', 'fr-FR'),
+    // Note: missing required user.id
+  );
 
   await invalidContext.run(() async {
     final service = UserPreferenceService();
@@ -208,7 +193,8 @@ Future<void> main() async {
 
   // Example with invalid value
   final invalidValueContext = OTel.context().withBaggage(
-      OTel.baggage().copyWith('service.environment', 'invalid_env'));
+    OTel.baggage().copyWith('service.environment', 'invalid_env'),
+  );
 
   await invalidValueContext.run(() async {
     final service = ConfigurationService();

--- a/example/baggage_example.dart
+++ b/example/baggage_example.dart
@@ -14,7 +14,7 @@ Future<void> main() async {
   // Chain operations to build up the baggage you need
   // Best practice: Use dot notation for key namespacing to avoid conflicts
   final enrichedBaggage = baggage
-      .copyWith('deployment.environment', 'staging')
+      .copyWith(EnvironmentResource.deploymentEnvironment.key, 'staging')
       .copyWith('user.region', 'us-west', 'source=user profile');
 
   // Baggage is always associated with a Context
@@ -88,7 +88,7 @@ Future<void> distributedTracingExample() async {
     final serviceBaggage = Context.currentWithBaggage()
         .baggage!
         .copyWith('service.instance', 'backend-01')
-        .copyWith('service.version', '2.1.0');
+        .copyWith(ServiceResource.serviceVersion.key, '2.1.0');
 
     // Best practice: Update context when baggage changes
     // This ensures proper propagation
@@ -113,7 +113,7 @@ Future<void> monitoringExample() async {
   // Examples: service names, regions, environments
   final baseContext = OTel.context().withBaggage(
     OTel.baggage()
-        .copyWith('service.name', 'payment-processor')
+        .copyWith(ServiceResource.serviceName.key, 'payment-processor')
         .copyWith('deployment.region', 'us-west-2'),
   );
 

--- a/example/baggage_example.dart
+++ b/example/baggage_example.dart
@@ -6,8 +6,9 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
 Future<void> main() async {
   // Create a baggage with a single key-value pair
-  final baggage = OTel.baggage(
-      {'customer.id': OTel.baggageEntry('123', 'source=mobile app')});
+  final baggage = OTel.baggage({
+    'customer.id': OTel.baggageEntry('123', 'source=mobile app'),
+  });
 
   // Since baggage is immutable, each operation returns a new instance
   // Chain operations to build up the baggage you need
@@ -28,7 +29,8 @@ Future<void> main() async {
 
     // Baggage entries can be accessed individually
     print(
-        'Current customer ID: ${currentBaggage!.getEntry('customer.id')?.value}');
+      'Current customer ID: ${currentBaggage!.getEntry('customer.id')?.value}',
+    );
 
     // Or you can get all entries at once
     // Best practice: Check getAllEntries when debugging propagation issues
@@ -109,9 +111,11 @@ Future<void> monitoringExample() async {
   // Best practice: Start with low-cardinality data
   // These are values that have a small set of possible values
   // Examples: service names, regions, environments
-  final baseContext = OTel.context().withBaggage(OTel.baggage()
-      .copyWith('service.name', 'payment-processor')
-      .copyWith('deployment.region', 'us-west-2'));
+  final baseContext = OTel.context().withBaggage(
+    OTel.baggage()
+        .copyWith('service.name', 'payment-processor')
+        .copyWith('deployment.region', 'us-west-2'),
+  );
 
   await baseContext.run(() async {
     // High-cardinality data has many possible values
@@ -119,10 +123,14 @@ Future<void> monitoringExample() async {
     // Warning: Too much high-cardinality data can impact performance
     final processingBaggage = Context.currentWithBaggage()
         .baggage!
-        .copyWith('transaction.id',
-            'tx_789012') // High cardinality: Many possible values
-        .copyWith('user.tenant',
-            'tenant_456'); // High cardinality: Many possible values
+        .copyWith(
+          'transaction.id',
+          'tx_789012',
+        ) // High cardinality: Many possible values
+        .copyWith(
+          'user.tenant',
+          'tenant_456',
+        ); // High cardinality: Many possible values
 
     // Best practice: Scope high-cardinality baggage
     // Only use it where the detailed information is needed

--- a/example/console_exporter_sanity_check.dart
+++ b/example/console_exporter_sanity_check.dart
@@ -35,14 +35,16 @@ Future<void> main(List<String> arguments) async {
       // attributedFromMap can throw with bad types, OTel has typesafe attribute methods
       OTel.attributes([
         OTel.attributeString('event-foo', 'bar'),
-        OTel.attributeBool('event-baz', true)
+        OTel.attributeBool('event-baz', true),
       ]),
     );
   } catch (e, s) {
     print('\nHandling exception...');
     rootSpan.recordException(e, stackTrace: s);
     rootSpan.setStatus(
-        SpanStatusCode.Error, 'Error running importantFunction $e');
+      SpanStatusCode.Error,
+      'Error running importantFunction $e',
+    );
   } finally {
     print('\nEnding span (this should trigger ConsoleExporter export)...');
     // Ending a span sets the span status to SpanStatusCode.Ok, unless

--- a/example/example.dart
+++ b/example/example.dart
@@ -104,10 +104,12 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
     await Future<void>.delayed(const Duration(milliseconds: 100));
 
     // Add response attributes
-    span.addAttributes(OTel.attributesFromMap({
-      'http.status_code': 200,
-      'http.response_content_length': 1024,
-    }));
+    span.addAttributes(
+      OTel.attributesFromMap({
+        'http.status_code': 200,
+        'http.response_content_length': 1024,
+      }),
+    );
 
     span.setStatus(SpanStatusCode.Ok);
   } finally {

--- a/example/example.dart
+++ b/example/example.dart
@@ -71,9 +71,9 @@ Future<void> performDatabaseQuery(Tracer tracer, Span parentSpan) async {
     // Link to parent span via context
     context: OTel.context(spanContext: parentSpan.spanContext),
     attributes: OTel.attributesFromMap({
-      'db.system': 'postgresql',
-      'db.operation': 'SELECT',
-      'db.name': 'users',
+      DatabaseResource.dbSystem.key: 'postgresql',
+      DatabaseResource.dbOperation.key: 'SELECT',
+      DatabaseResource.dbName.key: 'users',
     }),
   );
 
@@ -93,9 +93,11 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
     kind: SpanKind.client,
     context: OTel.context(spanContext: parentSpan.spanContext),
     attributes: OTel.attributesFromMap({
-      'http.method': 'GET',
-      'http.url': 'https://api.example.com/data',
-      'http.target': '/data',
+      HttpResource.requestMethod.key: 'GET',
+      // TODO: Replace with UrlResource.urlFull.key once added to the API
+      // semantics (OTel renamed http.url → url.full).
+      'url.full': 'https://api.example.com/data',
+      'url.path': '/data',
     }),
   );
 
@@ -106,7 +108,7 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
     // Add response attributes
     span.addAttributes(
       OTel.attributesFromMap({
-        'http.status_code': 200,
+        HttpResource.responseStatusCode.key: 200,
         'http.response_content_length': 1024,
       }),
     );

--- a/example/grafana/grafana_cloud_env_example.dart
+++ b/example/grafana/grafana_cloud_env_example.dart
@@ -104,9 +104,11 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     'http.request',
     kind: SpanKind.client,
     attributes: OTel.attributesFromMap({
-      'http.method': 'GET',
-      'http.url': 'https://api.example.com/users/123',
-      'http.target': '/users/123',
+      HttpResource.requestMethod.key: 'GET',
+      // TODO: Replace with UrlResource.urlFull.key once added to the API
+      // semantics (OTel renamed http.url → url.full).
+      'url.full': 'https://api.example.com/users/123',
+      'url.path': '/users/123',
       'net.peer.name': 'api.example.com',
       'net.peer.port': 443,
     }),
@@ -119,14 +121,14 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     // Set response attributes
     span.addAttributes(
       OTel.attributesFromMap({
-        'http.status_code': 200,
+        HttpResource.responseStatusCode.key: 200,
         'http.response_content_length': 1234,
       }),
     );
 
     span.setStatus(SpanStatusCode.Ok);
   } catch (error) {
-    span.addAttributes(OTel.attributesFromMap({'http.status_code': 500}));
+    span.addAttributes(OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
     span.setStatus(SpanStatusCode.Error, 'HTTP request failed');
     span.recordException(error);
   } finally {
@@ -140,11 +142,11 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
     'db.query',
     kind: SpanKind.client,
     attributes: OTel.attributesFromMap({
-      'db.system': 'postgresql',
-      'db.name': 'users_db',
-      'db.operation': 'SELECT',
-      'db.statement': 'SELECT * FROM users WHERE active = true LIMIT 100',
-      'db.user': 'app_user',
+      DatabaseResource.dbSystem.key: 'postgresql',
+      DatabaseResource.dbName.key: 'users_db',
+      DatabaseResource.dbOperation.key: 'SELECT',
+      DatabaseResource.dbStatement.key: 'SELECT * FROM users WHERE active = true LIMIT 100',
+      DatabaseResource.dbUser.key: 'app_user',
       'net.peer.name': 'postgres.example.com',
       'net.peer.port': 5432,
     }),

--- a/example/grafana/grafana_cloud_env_example.dart
+++ b/example/grafana/grafana_cloud_env_example.dart
@@ -128,7 +128,8 @@ Future<void> traceHttpRequest(Tracer tracer) async {
 
     span.setStatus(SpanStatusCode.Ok);
   } catch (error) {
-    span.addAttributes(OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
+    span.addAttributes(
+        OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
     span.setStatus(SpanStatusCode.Error, 'HTTP request failed');
     span.recordException(error);
   } finally {
@@ -145,7 +146,8 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
       DatabaseResource.dbSystem.key: 'postgresql',
       DatabaseResource.dbName.key: 'users_db',
       DatabaseResource.dbOperation.key: 'SELECT',
-      DatabaseResource.dbStatement.key: 'SELECT * FROM users WHERE active = true LIMIT 100',
+      DatabaseResource.dbStatement.key:
+          'SELECT * FROM users WHERE active = true LIMIT 100',
       DatabaseResource.dbUser.key: 'app_user',
       'net.peer.name': 'postgres.example.com',
       'net.peer.port': 5432,

--- a/example/grafana/grafana_cloud_env_example.dart
+++ b/example/grafana/grafana_cloud_env_example.dart
@@ -38,7 +38,8 @@ Future<void> main() async {
 
   print('OpenTelemetry initialized with environment configuration');
   print(
-      'Service: ${OTel.defaultResource?.attributes.toList().firstWhere((a) => a.key == 'service.name').value}');
+    'Service: ${OTel.defaultResource?.attributes.toList().firstWhere((a) => a.key == 'service.name').value}',
+  );
 
   // Create a tracer
   final tracer = OTel.tracer();
@@ -76,13 +77,15 @@ Future<void> traceUserLogin(Tracer tracer, String userId) async {
     await Future<void>.delayed(const Duration(milliseconds: 100));
 
     // Add event for successful authentication
-    span.addEvent(OTel.spanEventNow(
-      'authentication.success',
-      OTel.attributesFromMap({
-        'session.id': 'sess_${DateTime.now().millisecondsSinceEpoch}',
-        'permissions': 'read,write',
-      }),
-    ));
+    span.addEvent(
+      OTel.spanEventNow(
+        'authentication.success',
+        OTel.attributesFromMap({
+          'session.id': 'sess_${DateTime.now().millisecondsSinceEpoch}',
+          'permissions': 'read,write',
+        }),
+      ),
+    );
 
     // Record success
     span.setStatus(SpanStatusCode.Ok);
@@ -114,16 +117,16 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     await Future<void>.delayed(const Duration(milliseconds: 200));
 
     // Set response attributes
-    span.addAttributes(OTel.attributesFromMap({
-      'http.status_code': 200,
-      'http.response_content_length': 1234,
-    }));
+    span.addAttributes(
+      OTel.attributesFromMap({
+        'http.status_code': 200,
+        'http.response_content_length': 1234,
+      }),
+    );
 
     span.setStatus(SpanStatusCode.Ok);
   } catch (error) {
-    span.addAttributes(OTel.attributesFromMap({
-      'http.status_code': 500,
-    }));
+    span.addAttributes(OTel.attributesFromMap({'http.status_code': 500}));
     span.setStatus(SpanStatusCode.Error, 'HTTP request failed');
     span.recordException(error);
   } finally {
@@ -182,9 +185,7 @@ Future<void> initializeWithCode() async {
       OtlpHttpSpanExporter(
         OtlpHttpExporterConfig(
           endpoint: 'https://otlp-gateway-prod-us-central-0.grafana.net/otlp',
-          headers: {
-            'authorization': 'Basic $base64Credentials',
-          },
+          headers: {'authorization': 'Basic $base64Credentials'},
           compression: true,
         ),
       ),

--- a/example/grafana/grafana_smoke_test.dart
+++ b/example/grafana/grafana_smoke_test.dart
@@ -10,15 +10,18 @@ Future<void> main() async {
   await OTel.initialize();
 
   // Emit a simple span
-  final tracer =
-      OTel.tracerProvider().getTracer('dartastic-smoketest', version: '1.0.0');
+  final tracer = OTel.tracerProvider().getTracer(
+    'dartastic-smoketest',
+    version: '1.0.0',
+  );
   await tracer.startActiveSpanAsync(
-      name: 'gc-smoke-span',
-      fn: (span) async {
-        span.addAttributes(Attributes.of({'smoke': true}));
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        span.end();
-      });
+    name: 'gc-smoke-span',
+    fn: (span) async {
+      span.addAttributes(Attributes.of({'smoke': true}));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      span.end();
+    },
+  );
 
   await OTel.shutdown();
   print('Sent smoke test span(s). Check Grafana Cloud Explore/Traces.');

--- a/example/grafana_cloud_env_example.dart
+++ b/example/grafana_cloud_env_example.dart
@@ -104,9 +104,11 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     'http.request',
     kind: SpanKind.client,
     attributes: OTel.attributesFromMap({
-      'http.method': 'GET',
-      'http.url': 'https://api.example.com/users/123',
-      'http.target': '/users/123',
+      HttpResource.requestMethod.key: 'GET',
+      // TODO: Replace with UrlResource.urlFull.key once added to the API
+      // semantics (OTel renamed http.url → url.full).
+      'url.full': 'https://api.example.com/users/123',
+      'url.path': '/users/123',
       'net.peer.name': 'api.example.com',
       'net.peer.port': 443,
     }),
@@ -119,14 +121,14 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     // Set response attributes
     span.addAttributes(
       OTel.attributesFromMap({
-        'http.status_code': 200,
+        HttpResource.responseStatusCode.key: 200,
         'http.response_content_length': 1234,
       }),
     );
 
     span.setStatus(SpanStatusCode.Ok);
   } catch (error) {
-    span.addAttributes(OTel.attributesFromMap({'http.status_code': 500}));
+    span.addAttributes(OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
     span.setStatus(SpanStatusCode.Error, 'HTTP request failed');
     span.recordException(error);
   } finally {
@@ -140,11 +142,11 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
     'db.query',
     kind: SpanKind.client,
     attributes: OTel.attributesFromMap({
-      'db.system': 'postgresql',
-      'db.name': 'users_db',
-      'db.operation': 'SELECT',
-      'db.statement': 'SELECT * FROM users WHERE active = true LIMIT 100',
-      'db.user': 'app_user',
+      DatabaseResource.dbSystem.key: 'postgresql',
+      DatabaseResource.dbName.key: 'users_db',
+      DatabaseResource.dbOperation.key: 'SELECT',
+      DatabaseResource.dbStatement.key: 'SELECT * FROM users WHERE active = true LIMIT 100',
+      DatabaseResource.dbUser.key: 'app_user',
       'net.peer.name': 'postgres.example.com',
       'net.peer.port': 5432,
     }),

--- a/example/grafana_cloud_env_example.dart
+++ b/example/grafana_cloud_env_example.dart
@@ -128,7 +128,8 @@ Future<void> traceHttpRequest(Tracer tracer) async {
 
     span.setStatus(SpanStatusCode.Ok);
   } catch (error) {
-    span.addAttributes(OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
+    span.addAttributes(
+        OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
     span.setStatus(SpanStatusCode.Error, 'HTTP request failed');
     span.recordException(error);
   } finally {
@@ -145,7 +146,8 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
       DatabaseResource.dbSystem.key: 'postgresql',
       DatabaseResource.dbName.key: 'users_db',
       DatabaseResource.dbOperation.key: 'SELECT',
-      DatabaseResource.dbStatement.key: 'SELECT * FROM users WHERE active = true LIMIT 100',
+      DatabaseResource.dbStatement.key:
+          'SELECT * FROM users WHERE active = true LIMIT 100',
       DatabaseResource.dbUser.key: 'app_user',
       'net.peer.name': 'postgres.example.com',
       'net.peer.port': 5432,

--- a/example/grafana_cloud_env_example.dart
+++ b/example/grafana_cloud_env_example.dart
@@ -38,7 +38,8 @@ Future<void> main() async {
 
   print('OpenTelemetry initialized with environment configuration');
   print(
-      'Service: ${OTel.defaultResource?.attributes.toList().firstWhere((a) => a.key == 'service.name').value}');
+    'Service: ${OTel.defaultResource?.attributes.toList().firstWhere((a) => a.key == 'service.name').value}',
+  );
 
   // Create a tracer
   final tracer = OTel.tracer();
@@ -76,13 +77,15 @@ Future<void> traceUserLogin(Tracer tracer, String userId) async {
     await Future<void>.delayed(const Duration(milliseconds: 100));
 
     // Add event for successful authentication
-    span.addEvent(OTel.spanEventNow(
-      'authentication.success',
-      OTel.attributesFromMap({
-        'session.id': 'sess_${DateTime.now().millisecondsSinceEpoch}',
-        'permissions': 'read,write',
-      }),
-    ));
+    span.addEvent(
+      OTel.spanEventNow(
+        'authentication.success',
+        OTel.attributesFromMap({
+          'session.id': 'sess_${DateTime.now().millisecondsSinceEpoch}',
+          'permissions': 'read,write',
+        }),
+      ),
+    );
 
     // Record success
     span.setStatus(SpanStatusCode.Ok);
@@ -114,16 +117,16 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     await Future<void>.delayed(const Duration(milliseconds: 200));
 
     // Set response attributes
-    span.addAttributes(OTel.attributesFromMap({
-      'http.status_code': 200,
-      'http.response_content_length': 1234,
-    }));
+    span.addAttributes(
+      OTel.attributesFromMap({
+        'http.status_code': 200,
+        'http.response_content_length': 1234,
+      }),
+    );
 
     span.setStatus(SpanStatusCode.Ok);
   } catch (error) {
-    span.addAttributes(OTel.attributesFromMap({
-      'http.status_code': 500,
-    }));
+    span.addAttributes(OTel.attributesFromMap({'http.status_code': 500}));
     span.setStatus(SpanStatusCode.Error, 'HTTP request failed');
     span.recordException(error);
   } finally {
@@ -182,9 +185,7 @@ Future<void> initializeWithCode() async {
       OtlpHttpSpanExporter(
         OtlpHttpExporterConfig(
           endpoint: 'https://otlp-gateway-prod-us-central-0.grafana.net/otlp',
-          headers: {
-            'authorization': 'Basic $base64Credentials',
-          },
+          headers: {'authorization': 'Basic $base64Credentials'},
           compression: true,
         ),
       ),

--- a/example/otlp_grpc_example.dart
+++ b/example/otlp_grpc_example.dart
@@ -10,19 +10,20 @@ void main() async {
   final endpoint = 'http://my-otel-collector:4317';
   final secure = false;
   await OTel.initialize(
-      secure: secure,
-      endpoint: endpoint,
-      serviceName: 'dartastic-examples',
-      tracerName: 'otlp_grpc_example',
-      tracerVersion: '1.0.0',
-      tenantId: 'my-valued-customer',
-      // Always consult the OTel Semantic Conventions to find an existing
-      // convention name for an attribute:
-      // https://opentelemetry.io/docs/specs/semconv/general/attributes/
-      resourceAttributes: {
-        DeploymentResource.deploymentEnvironmentName.key:
-            'dev', //https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
-      }.toAttributes());
+    secure: secure,
+    endpoint: endpoint,
+    serviceName: 'dartastic-examples',
+    tracerName: 'otlp_grpc_example',
+    tracerVersion: '1.0.0',
+    tenantId: 'my-valued-customer',
+    // Always consult the OTel Semantic Conventions to find an existing
+    // convention name for an attribute:
+    // https://opentelemetry.io/docs/specs/semconv/general/attributes/
+    resourceAttributes: {
+      DeploymentResource.deploymentEnvironmentName.key:
+          'dev', //https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+    }.toAttributes(),
+  );
 
   // Get the default tracer
   final tracer = OTel.tracer();
@@ -31,8 +32,9 @@ void main() async {
   // Always consult the OTel Semantic Conventions to find an existing
   // convention name for an attribute:
   // https://opentelemetry.io/docs/specs/semconv/general/attributes/
-  tracer.attributes =
-      OTel.attributesFromMap({SourceCodeResource.codeFunctionName.key: 'main'});
+  tracer.attributes = OTel.attributesFromMap({
+    SourceCodeResource.codeFunctionName.key: 'main',
+  });
 
   // Create a new root span
   final rootSpan = tracer.startSpan(

--- a/example/otlp_grpc_simple_sync_example.dart
+++ b/example/otlp_grpc_simple_sync_example.dart
@@ -35,9 +35,10 @@ void main() async {
   final tracer = tracerProvider.getTracer('example-sync-tracer');
 
   // Create and end a simple span
-  final span = tracer.startSpan('sync-operation',
-      attributes: OTel.attributesFromMap({'example.sync': true}))
-    ..end();
+  final span = tracer.startSpan(
+    'sync-operation',
+    attributes: OTel.attributesFromMap({'example.sync': true}),
+  )..end();
 
   try {
     // Add an event to match Python example

--- a/example/propagator_example.dart
+++ b/example/propagator_example.dart
@@ -56,11 +56,7 @@ void main() async {
   // === EXTRACT: Incoming Request ===
   print('3. Extracting trace context from HTTP headers (simulated)...');
   final getter = MapTextMapGetter(carrier);
-  final extractedContext = propagator.extract(
-    OTel.context(),
-    carrier,
-    getter,
-  );
+  final extractedContext = propagator.extract(OTel.context(), carrier, getter);
 
   final extractedSpanContext = extractedContext.spanContext;
   final extractedBaggage = extractedContext.baggage;
@@ -85,7 +81,8 @@ void main() async {
   print('   ✓ SpanId preserved: $sameSpanId');
   print('   ✓ Baggage preserved: $sameBaggage');
   print(
-      '   ✓ IsRemote set correctly: ${extractedSpanContext?.isRemote == true}\n');
+    '   ✓ IsRemote set correctly: ${extractedSpanContext?.isRemote == true}\n',
+  );
 
   // === Create Child Span in Extracted Context ===
   print('5. Creating child span in extracted context...');
@@ -96,9 +93,11 @@ void main() async {
     print('   Child TraceId: ${childContext.spanContext?.traceId.hexString}');
     print('   Child SpanId: ${childContext.spanContext?.spanId.hexString}');
     print(
-        '   Child Baggage: user.id=${childContext.baggage?.getValue('user.id')}');
+      '   Child Baggage: user.id=${childContext.baggage?.getValue('user.id')}',
+    );
     print(
-        '   → Same TraceId as parent: ${childContext.spanContext?.traceId.hexString == extractedSpanContext?.traceId.hexString}\n');
+      '   → Same TraceId as parent: ${childContext.spanContext?.traceId.hexString == extractedSpanContext?.traceId.hexString}\n',
+    );
 
     childSpan.end();
   });

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -38,6 +38,7 @@ export 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
         InteractionSemantics,
         KubernetesResource,
         LifecycleState,
+        LogRecord,
         Measurement,
         MessagingResource,
         NavigationSemantics,
@@ -53,6 +54,8 @@ export 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
         RPCResource,
         ServiceResource,
         SessionViewSemantics,
+        Severity,
+        SeverityLevel,
         SourceCodeResource,
         SpanContext,
         SpanEvent,
@@ -73,7 +76,22 @@ export 'src/context/propagation/w3c_baggage_propagator.dart';
 export 'src/environment/env_constants.dart';
 export 'src/environment/environment_service.dart';
 export 'src/environment/otel_env.dart';
+export 'src/export/export_result.dart';
 export 'src/factory/otel_sdk_factory.dart';
+export 'src/logs/bridge/dart_log_bridge.dart';
+export 'src/logs/export/batch_log_record_processor.dart';
+export 'src/logs/export/console_log_record_exporter.dart';
+export 'src/logs/export/log_record_exporter.dart';
+export 'src/logs/export/otlp/http/otlp_http_log_record_exporter.dart';
+export 'src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart';
+export 'src/logs/export/otlp/log_record_transformer.dart';
+export 'src/logs/export/otlp/otlp_grpc_log_record_exporter.dart';
+export 'src/logs/export/otlp/otlp_grpc_log_record_exporter_config.dart';
+export 'src/logs/export/simple_log_record_processor.dart';
+export 'src/logs/log_record_processor.dart';
+export 'src/logs/logger.dart';
+export 'src/logs/logger_provider.dart';
+export 'src/logs/readable_log_record.dart';
 export 'src/metrics/data/exemplar.dart';
 export 'src/metrics/data/metric.dart';
 export 'src/metrics/data/metric_data.dart';

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -82,6 +82,7 @@ export 'src/logs/bridge/dart_log_bridge.dart';
 export 'src/logs/export/batch_log_record_processor.dart';
 export 'src/logs/export/console_log_record_exporter.dart';
 export 'src/logs/export/log_record_exporter.dart';
+export 'src/logs/export/logs_config.dart';
 export 'src/logs/export/otlp/http/otlp_http_log_record_exporter.dart';
 export 'src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart';
 export 'src/logs/export/otlp/log_record_transformer.dart';

--- a/lib/src/context/propagation/w3c_baggage_propagator.dart
+++ b/lib/src/context/propagation/w3c_baggage_propagator.dart
@@ -28,8 +28,11 @@ class W3CBaggagePropagator
   /// @param getter The getter used to extract values from the carrier
   /// @return A new Context with the extracted baggage
   @override
-  Context extract(Context context, Map<String, String> carrier,
-      TextMapGetter<String> getter) {
+  Context extract(
+    Context context,
+    Map<String, String> carrier,
+    TextMapGetter<String> getter,
+  ) {
     final value = getter.get(_baggageHeader);
     OTelLog.debug('Extracting baggage: $value');
     if (value == null || value.isEmpty) {
@@ -72,8 +75,11 @@ class W3CBaggagePropagator
   /// @param carrier The carrier to inject the baggage header into
   /// @param setter The setter used to add values to the carrier
   @override
-  void inject(Context context, Map<String, String> carrier,
-      TextMapSetter<String> setter) {
+  void inject(
+    Context context,
+    Map<String, String> carrier,
+    TextMapSetter<String> setter,
+  ) {
     if (OTelLog.isDebug()) {
       OTelLog.debug('Injecting baggage. Context: $context');
     }
@@ -81,7 +87,8 @@ class W3CBaggagePropagator
     if (contextBaggage != null) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Context baggage: $contextBaggage (${contextBaggage.runtimeType})');
+          'Context baggage: $contextBaggage (${contextBaggage.runtimeType})',
+        );
       }
 
       final baggage = contextBaggage;
@@ -99,7 +106,8 @@ class W3CBaggagePropagator
         final metadata = entry.value.metadata;
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'Processing entry - Key: $key, Value: $value, Metadata: $metadata');
+            'Processing entry - Key: $key, Value: $value, Metadata: $metadata',
+          );
         }
         if (metadata != null && metadata.isNotEmpty) {
           return '$key=$value;$metadata';
@@ -127,9 +135,9 @@ class W3CBaggagePropagator
   /// @param value The value to encode
   /// @return The encoded value
   String _encodeComponent(String value) {
-    return Uri.encodeComponent(value)
-        .replaceAll('%20', '+')
-        .replaceAll('*', '%2A');
+    return Uri.encodeComponent(
+      value,
+    ).replaceAll('%20', '+').replaceAll('*', '%2A');
   }
 
   /// Decodes a component from the baggage header.

--- a/lib/src/environment/env_from_define.dart
+++ b/lib/src/environment/env_from_define.dart
@@ -79,7 +79,8 @@ String? getFromEnvironment(String key) {
       return const String.fromEnvironment(otelExporterOtlpTracesClientKey);
     case otelExporterOtlpTracesClientCertificate:
       return const String.fromEnvironment(
-          otelExporterOtlpTracesClientCertificate);
+        otelExporterOtlpTracesClientCertificate,
+      );
 
     // Metrics-specific Configuration
     case otelMetricsExporter:
@@ -102,7 +103,8 @@ String? getFromEnvironment(String key) {
       return const String.fromEnvironment(otelExporterOtlpMetricsClientKey);
     case otelExporterOtlpMetricsClientCertificate:
       return const String.fromEnvironment(
-          otelExporterOtlpMetricsClientCertificate);
+        otelExporterOtlpMetricsClientCertificate,
+      );
 
     // Logs-specific Configuration
     case otelLogsExporter:
@@ -125,7 +127,8 @@ String? getFromEnvironment(String key) {
       return const String.fromEnvironment(otelExporterOtlpLogsClientKey);
     case otelExporterOtlpLogsClientCertificate:
       return const String.fromEnvironment(
-          otelExporterOtlpLogsClientCertificate);
+        otelExporterOtlpLogsClientCertificate,
+      );
 
     // Batch Span Processor
     case otelBspScheduleDelay:
@@ -170,7 +173,8 @@ String? getFromEnvironment(String key) {
     // LogRecord Limits
     case otelLogrecordAttributeValueLengthLimit:
       return const String.fromEnvironment(
-          otelLogrecordAttributeValueLengthLimit);
+        otelLogrecordAttributeValueLengthLimit,
+      );
     case otelLogrecordAttributeCountLimit:
       return const String.fromEnvironment(otelLogrecordAttributeCountLimit);
 

--- a/lib/src/environment/environment_service_web.dart
+++ b/lib/src/environment/environment_service_web.dart
@@ -148,7 +148,8 @@ class EnvironmentService implements EnvironmentServiceInterface {
         return const String.fromEnvironment(otelExporterOtlpTracesClientKey);
       case otelExporterOtlpTracesClientCertificate:
         return const String.fromEnvironment(
-            otelExporterOtlpTracesClientCertificate);
+          otelExporterOtlpTracesClientCertificate,
+        );
 
       // Metrics-specific Configuration
       case otelMetricsExporter:
@@ -171,7 +172,8 @@ class EnvironmentService implements EnvironmentServiceInterface {
         return const String.fromEnvironment(otelExporterOtlpMetricsClientKey);
       case otelExporterOtlpMetricsClientCertificate:
         return const String.fromEnvironment(
-            otelExporterOtlpMetricsClientCertificate);
+          otelExporterOtlpMetricsClientCertificate,
+        );
 
       // Logs-specific Configuration
       case otelLogsExporter:
@@ -194,7 +196,8 @@ class EnvironmentService implements EnvironmentServiceInterface {
         return const String.fromEnvironment(otelExporterOtlpLogsClientKey);
       case otelExporterOtlpLogsClientCertificate:
         return const String.fromEnvironment(
-            otelExporterOtlpLogsClientCertificate);
+          otelExporterOtlpLogsClientCertificate,
+        );
 
       // Batch Span Processor
       case otelBspScheduleDelay:
@@ -239,7 +242,8 @@ class EnvironmentService implements EnvironmentServiceInterface {
       // LogRecord Limits
       case otelLogrecordAttributeValueLengthLimit:
         return const String.fromEnvironment(
-            otelLogrecordAttributeValueLengthLimit);
+          otelLogrecordAttributeValueLengthLimit,
+        );
       case otelLogrecordAttributeCountLimit:
         return const String.fromEnvironment(otelLogrecordAttributeCountLimit);
 

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -382,6 +382,86 @@ class OTelEnv {
     }
   }
 
+  /// Get Batch LogRecord Processor (BLRP) configuration from environment variables.
+  ///
+  /// Returns a map containing the BLRP configuration read from environment variables.
+  /// Keys returned:
+  /// - 'scheduleDelay': Duration for the schedule delay
+  /// - 'exportTimeout': Duration for the export timeout
+  /// - 'maxQueueSize': int for maximum queue size
+  /// - 'maxExportBatchSize': int for maximum export batch size
+  static Map<String, dynamic> getBlrpConfig() {
+    final config = <String, dynamic>{};
+
+    // Get schedule delay
+    final scheduleDelay = _getEnv(otelBlrpScheduleDelay);
+    if (scheduleDelay != null) {
+      final delayMs = int.tryParse(scheduleDelay);
+      if (delayMs != null) {
+        config['scheduleDelay'] = Duration(milliseconds: delayMs);
+      }
+    }
+
+    // Get export timeout
+    final exportTimeout = _getEnv(otelBlrpExportTimeout);
+    if (exportTimeout != null) {
+      final timeoutMs = int.tryParse(exportTimeout);
+      if (timeoutMs != null) {
+        config['exportTimeout'] = Duration(milliseconds: timeoutMs);
+      }
+    }
+
+    // Get max queue size
+    final maxQueueSize = _getEnv(otelBlrpMaxQueueSize);
+    if (maxQueueSize != null) {
+      final size = int.tryParse(maxQueueSize);
+      if (size != null) {
+        config['maxQueueSize'] = size;
+      }
+    }
+
+    // Get max export batch size
+    final maxExportBatchSize = _getEnv(otelBlrpMaxExportBatchSize);
+    if (maxExportBatchSize != null) {
+      final size = int.tryParse(maxExportBatchSize);
+      if (size != null) {
+        config['maxExportBatchSize'] = size;
+      }
+    }
+
+    return config;
+  }
+
+  /// Get LogRecord attribute limits from environment variables.
+  ///
+  /// Returns a map containing the log record attribute limits.
+  /// Keys returned:
+  /// - 'attributeValueLengthLimit': int for max attribute value length
+  /// - 'attributeCountLimit': int for max number of attributes
+  static Map<String, dynamic> getLogRecordLimits() {
+    final config = <String, dynamic>{};
+
+    // Get attribute value length limit
+    final valueLengthLimit = _getEnv(otelLogrecordAttributeValueLengthLimit);
+    if (valueLengthLimit != null) {
+      final limit = int.tryParse(valueLengthLimit);
+      if (limit != null) {
+        config['attributeValueLengthLimit'] = limit;
+      }
+    }
+
+    // Get attribute count limit
+    final countLimit = _getEnv(otelLogrecordAttributeCountLimit);
+    if (countLimit != null) {
+      final limit = int.tryParse(countLimit);
+      if (limit != null) {
+        config['attributeCountLimit'] = limit;
+      }
+    }
+
+    return config;
+  }
+
   /// Parse headers from the environment variable format.
   ///
   /// Headers are expected in the format: key1=value1,key2=value2

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -19,9 +19,9 @@ class OTelEnv {
   /// and configures the OTelLog accordingly.
   ///
   /// If a custom log function has already been set (e.g., by tests),
-  /// this method will preserve it and only update the log level.
-  /// This allows tests to capture logs while still respecting
-  /// environment variable configuration.
+  /// this method will preserve it along with the current log level.
+  /// This allows tests to fully control logging configuration without
+  /// environment variables overriding their settings.
   static void initializeLogging() {
     // Save the current log function to check if it's custom
     final existingLogFunction = OTelLog.logFunction;
@@ -30,9 +30,10 @@ class OTelEnv {
     final hasCustomLogFunction =
         existingLogFunction != null && existingLogFunction != print;
 
-    // Set log level based on environment variable
+    // Set log level and function based on environment variable,
+    // but only if no custom log function is already configured.
     final logLevel = _getEnv(otelLogLevel)?.toLowerCase();
-    if (logLevel != null) {
+    if (logLevel != null && !hasCustomLogFunction) {
       switch (logLevel) {
         case 'trace':
           OTelLog.enableTraceLogging();
@@ -57,10 +58,7 @@ class OTelEnv {
           break;
       }
 
-      // Only set to print if no custom function is already configured
-      if (!hasCustomLogFunction) {
-        OTelLog.logFunction = print;
-      }
+      OTelLog.logFunction = print;
     }
 
     // Enable metrics logging based on environment variable

--- a/lib/src/export/export_result.dart
+++ b/lib/src/export/export_result.dart
@@ -1,0 +1,14 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+/// Result of an export operation.
+///
+/// This enum is shared across all telemetry signals (traces, metrics, logs)
+/// to provide a consistent export result type.
+enum ExportResult {
+  /// The export was successful.
+  success,
+
+  /// The export failed. The batch may need to be retried or dropped.
+  failure,
+}

--- a/lib/src/factory/otel_sdk_factory.dart
+++ b/lib/src/factory/otel_sdk_factory.dart
@@ -2,8 +2,9 @@
 // Copyright 2025, Michael Bushe, All rights reserved.
 import 'package:dartastic_opentelemetry/src/trace/tracer_provider.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
-import '../metrics/meter_provider.dart';
 
+import '../logs/logger_provider.dart';
+import '../metrics/meter_provider.dart';
 import '../resource/resource.dart';
 
 /// Factory function that creates an OTelSDKFactory with the specified configuration.
@@ -116,6 +117,30 @@ class OTelSDKFactory extends OTelAPIFactory {
       Resource? resource}) {
     return SDKMeterProviderCreate.create(
         delegate: super.meterProvider(
+            endpoint: endpoint,
+            serviceVersion: serviceVersion,
+            serviceName: serviceName),
+        resource: resource);
+  }
+
+  /// Creates a LoggerProvider with the specified configuration.
+  ///
+  /// This implementation overrides the API's method to create an SDK LoggerProvider
+  /// that produces real logs instead of no-op logs.
+  ///
+  /// @param endpoint The endpoint URL for the OpenTelemetry collector
+  /// @param serviceName The name of the service being instrumented
+  /// @param serviceVersion The version of the service being instrumented
+  /// @param resource Optional resource describing the service
+  /// @return A configured LoggerProvider instance
+  @override
+  APILoggerProvider loggerProvider(
+      {required String endpoint,
+      String serviceName = "@dart/opentelemetry_api",
+      String? serviceVersion,
+      Resource? resource}) {
+    return SDKLoggerProviderCreate.create(
+        delegate: super.loggerProvider(
             endpoint: endpoint,
             serviceVersion: serviceVersion,
             serviceName: serviceName),

--- a/lib/src/factory/otel_sdk_factory.dart
+++ b/lib/src/factory/otel_sdk_factory.dart
@@ -46,11 +46,12 @@ class OTelSDKFactory extends OTelAPIFactory {
   /// @param apiServiceName The name of the service being instrumented
   /// @param apiServiceVersion The version of the service being instrumented
   /// @param factoryFactory Optional factory function for creating new instances
-  OTelSDKFactory(
-      {required super.apiEndpoint,
-      required super.apiServiceName,
-      required super.apiServiceVersion,
-      super.factoryFactory = otelSDKFactoryFactoryFunction});
+  OTelSDKFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+    super.factoryFactory = otelSDKFactoryFactoryFunction,
+  });
 
   /// Creates a new Resource with the specified attributes and schema URL.
   ///
@@ -85,18 +86,21 @@ class OTelSDKFactory extends OTelAPIFactory {
   /// @param resource Optional resource describing the service
   /// @return A configured TracerProvider instance
   @override
-  APITracerProvider tracerProvider(
-      {required String endpoint,
-      String serviceName =
-          "@dart/opentelemetry_api", //TODO - @dart/dartastic_opentelemetry
-      String? serviceVersion,
-      Resource? resource}) {
+  APITracerProvider tracerProvider({
+    required String endpoint,
+    String serviceName =
+        "@dart/opentelemetry_api", //TODO - @dart/dartastic_opentelemetry
+    String? serviceVersion,
+    Resource? resource,
+  }) {
     return SDKTracerProviderCreate.create(
-        delegate: super.tracerProvider(
-            endpoint: endpoint,
-            serviceVersion: serviceVersion,
-            serviceName: serviceName),
-        resource: resource);
+      delegate: super.tracerProvider(
+        endpoint: endpoint,
+        serviceVersion: serviceVersion,
+        serviceName: serviceName,
+      ),
+      resource: resource,
+    );
   }
 
   /// Creates a MeterProvider with the specified configuration.
@@ -110,17 +114,20 @@ class OTelSDKFactory extends OTelAPIFactory {
   /// @param resource Optional resource describing the service
   /// @return A configured MeterProvider instance
   @override
-  APIMeterProvider meterProvider(
-      {required String endpoint,
-      String serviceName = "@dart/opentelemetry_api",
-      String? serviceVersion,
-      Resource? resource}) {
+  APIMeterProvider meterProvider({
+    required String endpoint,
+    String serviceName = "@dart/opentelemetry_api",
+    String? serviceVersion,
+    Resource? resource,
+  }) {
     return SDKMeterProviderCreate.create(
-        delegate: super.meterProvider(
-            endpoint: endpoint,
-            serviceVersion: serviceVersion,
-            serviceName: serviceName),
-        resource: resource);
+      delegate: super.meterProvider(
+        endpoint: endpoint,
+        serviceVersion: serviceVersion,
+        serviceName: serviceName,
+      ),
+      resource: resource,
+    );
   }
 
   /// Creates a LoggerProvider with the specified configuration.

--- a/lib/src/logs/bridge/dart_log_bridge.dart
+++ b/lib/src/logs/bridge/dart_log_bridge.dart
@@ -1,0 +1,296 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:async';
+import 'dart:developer' as developer;
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+import '../logger.dart';
+import '../logger_provider.dart';
+
+/// A bridge that intercepts Dart's built-in logging and sends it to OpenTelemetry.
+///
+/// This bridge provides integration with Dart's `dart:developer` log function
+/// by allowing you to configure a callback that converts Dart log calls to
+/// OpenTelemetry log records.
+///
+/// Note: Dart's built-in `print` function cannot be intercepted directly.
+/// For `print` interception, you must replace `print` with a custom function
+/// in your zone or use a logging framework.
+///
+/// Example usage:
+/// ```dart
+/// // Initialize OTel and set up the bridge
+/// await OTel.initialize(...);
+/// final logger = OTel.logger('my-app');
+///
+/// // Install the bridge
+/// DartLogBridge.install(logger);
+///
+/// // Now developer.log calls will be captured
+/// developer.log('Hello from dart:developer', name: 'my-app');
+/// ```
+class DartLogBridge {
+  /// The logger provider to use for creating loggers.
+  final LoggerProvider _loggerProvider;
+
+  /// Default logger name for logs without a name.
+  final String _defaultLoggerName;
+
+  /// Minimum severity level to capture.
+  final Severity _minimumSeverity;
+
+  /// Whether the bridge is active.
+  bool _isActive = false;
+
+  /// Singleton instance for the installed bridge.
+  static DartLogBridge? _instance;
+
+  /// Creates a new DartLogBridge.
+  ///
+  /// @param loggerProvider The LoggerProvider to use for creating loggers
+  /// @param defaultLoggerName Default name for logs without a name
+  /// @param minimumSeverity Minimum severity level to capture
+  DartLogBridge({
+    required LoggerProvider loggerProvider,
+    String defaultLoggerName = 'dart.developer',
+    Severity minimumSeverity = Severity.DEBUG,
+  })  : _loggerProvider = loggerProvider,
+        _defaultLoggerName = defaultLoggerName,
+        _minimumSeverity = minimumSeverity;
+
+  /// Installs the bridge using a specific Logger.
+  ///
+  /// This is a convenience method for simple use cases where you want
+  /// all dart:developer logs to go to a single logger.
+  ///
+  /// @param logger The logger to send all logs to
+  /// @param minimumSeverity Minimum severity level to capture
+  /// @return The installed DartLogBridge instance
+  static DartLogBridge install(
+    Logger logger, {
+    Severity minimumSeverity = Severity.DEBUG,
+  }) {
+    _instance = DartLogBridge(
+      loggerProvider: logger.provider,
+      defaultLoggerName: logger.name,
+      minimumSeverity: minimumSeverity,
+    );
+    _instance!.activate();
+    return _instance!;
+  }
+
+  /// Installs the bridge using a LoggerProvider.
+  ///
+  /// This allows logs to be routed to different loggers based on the
+  /// log name in dart:developer.log().
+  ///
+  /// @param loggerProvider The LoggerProvider to use
+  /// @param defaultLoggerName Default name for logs without a name
+  /// @param minimumSeverity Minimum severity level to capture
+  /// @return The installed DartLogBridge instance
+  static DartLogBridge installWithProvider(
+    LoggerProvider loggerProvider, {
+    String defaultLoggerName = 'dart.developer',
+    Severity minimumSeverity = Severity.DEBUG,
+  }) {
+    _instance = DartLogBridge(
+      loggerProvider: loggerProvider,
+      defaultLoggerName: defaultLoggerName,
+      minimumSeverity: minimumSeverity,
+    );
+    _instance!.activate();
+    return _instance!;
+  }
+
+  /// Uninstalls the current bridge.
+  static void uninstall() {
+    _instance?.deactivate();
+    _instance = null;
+  }
+
+  /// Gets the currently installed bridge, if any.
+  static DartLogBridge? get current => _instance;
+
+  /// Activates the bridge to start capturing logs.
+  void activate() {
+    _isActive = true;
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('DartLogBridge: Activated');
+    }
+  }
+
+  /// Deactivates the bridge to stop capturing logs.
+  void deactivate() {
+    _isActive = false;
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('DartLogBridge: Deactivated');
+    }
+  }
+
+  /// Whether the bridge is currently active.
+  bool get isActive => _isActive;
+
+  /// Logs a message using the bridge.
+  ///
+  /// This method is called by the zone handler when dart:developer.log is used.
+  ///
+  /// @param message The log message
+  /// @param time The timestamp
+  /// @param sequenceNumber The sequence number
+  /// @param level The log level (0-2000)
+  /// @param name The log name (logger name)
+  /// @param zone The zone where the log was made
+  /// @param error The error object, if any
+  /// @param stackTrace The stack trace, if any
+  void log(
+    String message, {
+    DateTime? time,
+    int? sequenceNumber,
+    int level = 0,
+    String? name,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    if (!_isActive) return;
+
+    // Convert Dart log level to OTel Severity
+    // Dart levels: 0 = finest/trace, 500 = fine/debug, 800 = config/info,
+    // 900 = info, 1000 = warning, 2000 = severe
+    final severity = _levelToSeverity(level);
+
+    // Filter by minimum severity
+    if (severity.severityNumber < _minimumSeverity.severityNumber) {
+      return;
+    }
+
+    // Get the appropriate logger
+    final loggerName = name?.isNotEmpty == true ? name! : _defaultLoggerName;
+    final logger = _loggerProvider.getLogger(loggerName);
+
+    // Build attributes
+    final attributes = <Attribute>[];
+    if (sequenceNumber != null) {
+      attributes.add(OTelAPI.attributeInt('sequence_number', sequenceNumber));
+    }
+    if (error != null) {
+      attributes.add(OTelAPI.attributeString(
+          'exception.type', error.runtimeType.toString()));
+      attributes
+          .add(OTelAPI.attributeString('exception.message', error.toString()));
+    }
+    if (stackTrace != null) {
+      attributes.add(OTelAPI.attributeString(
+          'exception.stacktrace', stackTrace.toString()));
+    }
+
+    // Emit the log
+    logger.emit(
+      timeStamp: time,
+      severityNumber: severity,
+      severityText: severity.name,
+      body: message,
+      attributes:
+          attributes.isNotEmpty ? OTelAPI.attributesFromList(attributes) : null,
+    );
+  }
+
+  /// Converts a Dart log level to an OpenTelemetry Severity.
+  ///
+  /// Dart log levels (from logging package):
+  /// - 0: ALL/finest (trace)
+  /// - 300: FINEST
+  /// - 400: FINER
+  /// - 500: FINE (debug)
+  /// - 700: CONFIG
+  /// - 800: INFO
+  /// - 900: WARNING
+  /// - 1000: SEVERE (error)
+  /// - 1200: SHOUT
+  /// - 2000: OFF
+  Severity _levelToSeverity(int level) {
+    if (level < 300) {
+      return Severity.TRACE;
+    } else if (level < 500) {
+      return Severity.TRACE2;
+    } else if (level < 700) {
+      return Severity.DEBUG;
+    } else if (level < 800) {
+      return Severity.DEBUG2;
+    } else if (level < 900) {
+      return Severity.INFO;
+    } else if (level < 1000) {
+      return Severity.WARN;
+    } else if (level < 1200) {
+      return Severity.ERROR;
+    } else {
+      return Severity.FATAL;
+    }
+  }
+
+  /// Creates a zone specification that captures dart:developer logs.
+  ///
+  /// Use this to create a zone that automatically routes all
+  /// dart:developer.log calls through the bridge.
+  ///
+  /// Example:
+  /// ```dart
+  /// final bridge = DartLogBridge.install(logger);
+  /// runZoned(
+  ///   () {
+  ///     // Your app code here
+  ///     developer.log('This will be captured', name: 'my-app');
+  ///   },
+  ///   zoneSpecification: bridge.createZoneSpecification(),
+  /// );
+  /// ```
+  ZoneSpecification createZoneSpecification() {
+    return ZoneSpecification(
+      print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
+        // Capture print statements as INFO logs
+        if (_isActive) {
+          log(line, level: 800); // INFO level
+        }
+        // Still call the original print
+        parent.print(zone, line);
+      },
+    );
+  }
+}
+
+/// Extension to easily use the logging bridge with dart:developer.
+extension DartDeveloperLogBridge on developer.ServiceExtensionHandler {
+  /// Helper to emit a log that will be captured by the bridge if installed.
+  static void emitLog(
+    String message, {
+    DateTime? time,
+    int? sequenceNumber,
+    int level = 0,
+    String name = '',
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    // First, call the original dart:developer log
+    developer.log(
+      message,
+      time: time,
+      sequenceNumber: sequenceNumber,
+      level: level,
+      name: name,
+      error: error,
+      stackTrace: stackTrace,
+    );
+
+    // If bridge is installed, also log via OTel
+    DartLogBridge.current?.log(
+      message,
+      time: time,
+      sequenceNumber: sequenceNumber,
+      level: level,
+      name: name,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+}

--- a/lib/src/logs/bridge/dart_log_bridge.dart
+++ b/lib/src/logs/bridge/dart_log_bridge.dart
@@ -44,6 +44,11 @@ class DartLogBridge {
   /// Whether the bridge is active.
   bool _isActive = false;
 
+  /// Re-entrancy guard to prevent infinite recursion when OTelLog.logFunction
+  /// is set to print (e.g. via OTEL_LOG_LEVEL env var) and print is
+  /// intercepted by the zone — OTelLog.debug → print → zone → log → OTelLog.debug → …
+  bool _isLogging = false;
+
   /// Singleton instance for the installed bridge.
   static DartLogBridge? _instance;
 
@@ -248,9 +253,17 @@ class DartLogBridge {
   ZoneSpecification createZoneSpecification() {
     return ZoneSpecification(
       print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-        // Capture print statements as INFO logs
-        if (_isActive) {
-          log(line, level: 800); // INFO level
+        // Capture print statements as INFO logs.
+        // Guard against re-entrancy: if OTelLog.logFunction == print, the
+        // log() call below can trigger OTelLog.debug → print → this handler
+        // again, causing a stack overflow.
+        if (_isActive && !_isLogging) {
+          _isLogging = true;
+          try {
+            log(line, level: 800); // INFO level
+          } finally {
+            _isLogging = false;
+          }
         }
         // Still call the original print
         parent.print(zone, line);

--- a/lib/src/logs/export/batch_log_record_processor.dart
+++ b/lib/src/logs/export/batch_log_record_processor.dart
@@ -1,0 +1,247 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:synchronized/synchronized.dart';
+
+import '../log_record_processor.dart';
+import '../readable_log_record.dart';
+import 'log_record_exporter.dart';
+
+/// Configuration for the BatchLogRecordProcessor.
+///
+/// This class configures how the batch log record processor behaves, including
+/// queue size limits, export scheduling, and batch size parameters.
+class BatchLogRecordProcessorConfig {
+  /// The maximum queue size for log records. After this is reached,
+  /// log records will be dropped.
+  final int maxQueueSize;
+
+  /// The delay between two consecutive exports.
+  final Duration scheduleDelay;
+
+  /// The maximum batch size of log records that can be exported at once.
+  final int maxExportBatchSize;
+
+  /// The amount of time to wait for an export to complete before timing out.
+  final Duration exportTimeout;
+
+  /// Creates a new configuration for a BatchLogRecordProcessor.
+  ///
+  /// [maxQueueSize] The maximum number of log records that can be queued. Default is 2048.
+  /// [scheduleDelay] The time interval between exports. Default is 1 second.
+  /// [maxExportBatchSize] The maximum batch size per export. Default is 512.
+  /// [exportTimeout] The maximum time to wait for export. Default is 30 seconds.
+  const BatchLogRecordProcessorConfig({
+    this.maxQueueSize = 2048,
+    this.scheduleDelay = const Duration(milliseconds: 1000),
+    this.maxExportBatchSize = 512,
+    this.exportTimeout = const Duration(seconds: 30),
+  });
+}
+
+/// A LogRecordProcessor that batches log records before export.
+///
+/// This processor collects log records in a queue and exports them in batches
+/// at regular intervals, improving efficiency compared to exporting each log
+/// individually.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor
+class BatchLogRecordProcessor implements LogRecordProcessor {
+  /// The exporter used to send log records to the backend.
+  final LogRecordExporter exporter;
+
+  /// Configuration for the batch processor behavior.
+  final BatchLogRecordProcessorConfig _config;
+
+  /// Queue of log records waiting to be exported.
+  final Queue<ReadableLogRecord> _logQueue = Queue<ReadableLogRecord>();
+
+  /// Whether the processor has been shut down.
+  bool _isShutdown = false;
+
+  /// Timer for scheduling periodic exports.
+  Timer? _timer;
+
+  /// Lock for synchronizing queue access.
+  final _lock = Lock();
+
+  /// Creates a new BatchLogRecordProcessor with the specified exporter and configuration.
+  ///
+  /// A timer is started to trigger periodic batch exports.
+  ///
+  /// @param exporter The LogRecordExporter to use for exporting batches
+  /// @param config Optional configuration for the batch processor
+  BatchLogRecordProcessor(this.exporter,
+      [BatchLogRecordProcessorConfig? config])
+      : _config = config ?? const BatchLogRecordProcessorConfig() {
+    _timer = Timer.periodic(_config.scheduleDelay, (_) async {
+      try {
+        await _exportBatch();
+      } catch (e) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'BatchLogRecordProcessor: Error in batch export timer: $e');
+        }
+      }
+    });
+  }
+
+  @override
+  Future<void> onEmit(ReadWriteLogRecord logRecord, Context? context) async {
+    if (_isShutdown) {
+      return;
+    }
+
+    await _lock.synchronized(() {
+      if (_logQueue.length >= _config.maxQueueSize) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'BatchLogRecordProcessor: Queue full - dropping log record');
+        }
+        return;
+      }
+      // Clone the log record to avoid race conditions
+      _logQueue.add(logRecord.clone());
+    });
+  }
+
+  @override
+  bool enabled({
+    Context? context,
+    InstrumentationScope? instrumentationScope,
+    Severity? severityNumber,
+    String? eventName,
+  }) {
+    // Default to true - batch processor doesn't do filtering
+    return !_isShutdown;
+  }
+
+  /// Exports a batch of log records from the queue to the configured exporter.
+  Future<void> _exportBatch() async {
+    if (_isShutdown) {
+      return;
+    }
+
+    final List<ReadableLogRecord> logsToExport = [];
+
+    await _lock.synchronized(() {
+      final batchSize = _logQueue.length > _config.maxExportBatchSize
+          ? _config.maxExportBatchSize
+          : _logQueue.length;
+
+      for (var i = 0; i < batchSize; i++) {
+        if (_logQueue.isEmpty) break;
+        logsToExport.add(_logQueue.removeFirst());
+      }
+    });
+
+    if (logsToExport.isEmpty) {
+      return;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'BatchLogRecordProcessor: Exporting ${logsToExport.length} log records');
+    }
+
+    try {
+      final result = await exporter.export(logsToExport).timeout(
+        _config.exportTimeout,
+        onTimeout: () {
+          if (OTelLog.isError()) {
+            OTelLog.error('BatchLogRecordProcessor: Export timed out');
+          }
+          return ExportResult.failure;
+        },
+      );
+
+      if (result == ExportResult.failure && OTelLog.isError()) {
+        OTelLog.error('BatchLogRecordProcessor: Export failed');
+      }
+    } catch (e) {
+      if (OTelLog.isError()) {
+        OTelLog.error('BatchLogRecordProcessor: Error exporting batch: $e');
+      }
+    }
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    if (_isShutdown) {
+      return;
+    }
+
+    // Export all remaining batches
+    while (_logQueue.isNotEmpty) {
+      await _exportBatch();
+    }
+
+    await exporter.forceFlush();
+  }
+
+  @override
+  Future<void> shutdown() async {
+    if (_isShutdown) {
+      return;
+    }
+
+    // Cancel the timer first
+    _timer?.cancel();
+
+    // Export any remaining log records BEFORE setting _isShutdown
+    // so that forceFlush and _exportBatch will still work
+    while (_logQueue.isNotEmpty) {
+      await _exportBatchForShutdown();
+    }
+    await exporter.forceFlush();
+
+    // Now mark as shutdown
+    _isShutdown = true;
+
+    // Shutdown the exporter
+    await exporter.shutdown();
+  }
+
+  /// Internal export batch method for shutdown that doesn't check _isShutdown.
+  Future<void> _exportBatchForShutdown() async {
+    final List<ReadableLogRecord> logsToExport = [];
+
+    await _lock.synchronized(() {
+      final batchSize = _logQueue.length > _config.maxExportBatchSize
+          ? _config.maxExportBatchSize
+          : _logQueue.length;
+
+      for (var i = 0; i < batchSize; i++) {
+        if (_logQueue.isEmpty) break;
+        logsToExport.add(_logQueue.removeFirst());
+      }
+    });
+
+    if (logsToExport.isEmpty) {
+      return;
+    }
+
+    try {
+      await exporter.export(logsToExport).timeout(
+        _config.exportTimeout,
+        onTimeout: () {
+          if (OTelLog.isError()) {
+            OTelLog.error(
+                'BatchLogRecordProcessor: Export timed out during shutdown');
+          }
+          return ExportResult.failure;
+        },
+      );
+    } catch (e) {
+      if (OTelLog.isError()) {
+        OTelLog.error(
+            'BatchLogRecordProcessor: Error exporting batch during shutdown: $e');
+      }
+    }
+  }
+}

--- a/lib/src/logs/export/console_log_record_exporter.dart
+++ b/lib/src/logs/export/console_log_record_exporter.dart
@@ -1,0 +1,119 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import '../../../dartastic_opentelemetry.dart';
+
+/// A LogRecordExporter that outputs log records to the console.
+///
+/// This exporter is useful for debugging and development purposes.
+/// It formats log records in a human-readable format and prints them.
+class ConsoleLogRecordExporter implements LogRecordExporter {
+  /// Whether the exporter has been shut down.
+  bool _isShutdown = false;
+
+  /// Custom print function, allowing for testing and redirection.
+  final void Function(String) _printFunction;
+
+  /// Creates a new ConsoleLogRecordExporter.
+  ///
+  /// @param printFunction Optional custom print function (defaults to print)
+  ConsoleLogRecordExporter({void Function(String)? printFunction})
+      : _printFunction = printFunction ?? print;
+
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    for (final logRecord in logRecords) {
+      _printLogRecord(logRecord);
+    }
+
+    return ExportResult.success;
+  }
+
+  void _printLogRecord(ReadableLogRecord logRecord) {
+    final buffer = StringBuffer();
+
+    // Format timestamp
+    if (logRecord.observedTimestamp != null) {
+      final millis = logRecord.observedTimestamp!.toInt() ~/ 1000000;
+      final dateTime = DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true);
+      buffer.write('[${dateTime.toIso8601String()}] ');
+    }
+
+    // Format severity
+    if (logRecord.severityNumber != null) {
+      buffer.write(
+          '[${logRecord.severityText ?? logRecord.severityNumber!.name}] ');
+    }
+
+    // Format instrumentation scope
+    buffer.write('[${logRecord.instrumentationScope.name}');
+    if (logRecord.instrumentationScope.version != null) {
+      buffer.write(':${logRecord.instrumentationScope.version}');
+    }
+    buffer.write('] ');
+
+    // Format event name
+    if (logRecord.eventName != null) {
+      buffer.write('{${logRecord.eventName}} ');
+    }
+
+    // Format body
+    if (logRecord.body != null) {
+      buffer.write(logRecord.body);
+    }
+
+    // Format trace context
+    if (logRecord.traceId != null) {
+      buffer.write(' [trace_id=${logRecord.traceId}');
+      if (logRecord.spanId != null) {
+        buffer.write(', span_id=${logRecord.spanId}');
+      }
+      buffer.write(']');
+    }
+
+    // Format resource
+    if (logRecord.resource != null) {
+      final serviceName =
+          _getResourceAttribute(logRecord.resource!, 'service.name');
+      if (serviceName != null) {
+        buffer.write(' service=$serviceName');
+      }
+    }
+
+    // Format attributes
+    if (logRecord.attributes != null && logRecord.attributes!.length > 0) {
+      buffer.write(' {');
+      final attrs = logRecord.attributes!.toList();
+      for (var i = 0; i < attrs.length; i++) {
+        if (i > 0) buffer.write(', ');
+        buffer.write('${attrs[i].key}=${attrs[i].value}');
+      }
+      buffer.write('}');
+    }
+
+    _printFunction(buffer.toString());
+  }
+
+  String? _getResourceAttribute(Resource resource, String key) {
+    for (final attr in resource.attributes.toList()) {
+      if (attr.key == key) {
+        return attr.value.toString();
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    // Console exporter has no buffering, nothing to flush
+  }
+
+  @override
+  Future<void> shutdown() async {
+    _isShutdown = true;
+  }
+}

--- a/lib/src/logs/export/log_record_exporter.dart
+++ b/lib/src/logs/export/log_record_exporter.dart
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import '../../export/export_result.dart';
+import '../readable_log_record.dart';
+
+export '../../export/export_result.dart';
+
+/// A LogRecordExporter exports log records.
+///
+/// LogRecordExporters handle the protocol-specific details of exporting
+/// log records to a backend. They should be simple encoders and transmitters.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
+abstract class LogRecordExporter {
+  /// Exports a batch of log records.
+  ///
+  /// This method typically serializes and transmits data to a destination.
+  /// It should NOT be called concurrently with other Export calls.
+  /// It must NOT block indefinitely and should have a reasonable timeout.
+  /// It must NOT retry on failure (that's the processor's responsibility).
+  ///
+  /// @param logRecords The batch of log records to export
+  /// @return The result of the export operation
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords);
+
+  /// Forces the exporter to flush any pending log records.
+  ///
+  /// This method is a hint to ensure export of any log records the exporter
+  /// received before this call. Should be completed ASAP.
+  Future<void> forceFlush();
+
+  /// Shuts down the exporter.
+  ///
+  /// This method is called when the SDK is shut down. Implementations
+  /// should release any resources they hold. After shutdown, subsequent
+  /// Export calls should return Failure.
+  Future<void> shutdown();
+}

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -1,0 +1,202 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+import '../../environment/otel_env.dart';
+import '../../otel.dart';
+import '../../resource/resource.dart';
+import '../log_record_processor.dart';
+import '../logger_provider.dart';
+import 'batch_log_record_processor.dart';
+import 'console_log_record_exporter.dart';
+import 'log_record_exporter.dart';
+import 'otlp/http/otlp_http_log_record_exporter.dart';
+import 'otlp/http/otlp_http_log_record_exporter_config.dart';
+import 'otlp/otlp_grpc_log_record_exporter.dart';
+import 'otlp/otlp_grpc_log_record_exporter_config.dart';
+import 'simple_log_record_processor.dart';
+
+/// Configuration for logs exporters and processors.
+///
+/// This class provides methods to configure the LoggerProvider based on
+/// environment variables and explicit configuration parameters.
+class LogsConfiguration {
+  /// Configures a LoggerProvider with the given settings.
+  ///
+  /// This configures everything needed for the logs pipeline:
+  /// - An exporter (based on OTEL_LOGS_EXPORTER env var or defaults to OTLP)
+  /// - A processor (BatchLogRecordProcessor with BLRP env var config)
+  /// - Sets up resources on the LoggerProvider
+  ///
+  /// @param endpoint The endpoint URL for the exporter
+  /// @param secure Whether to use TLS for gRPC connections
+  /// @param logRecordExporter Optional custom exporter (overrides env var)
+  /// @param logRecordProcessor Optional custom processor (overrides env var)
+  /// @param resource Optional resource for the LoggerProvider
+  /// @return The configured LoggerProvider
+  static LoggerProvider configureLoggerProvider({
+    String endpoint = 'http://localhost:4318',
+    bool secure = false,
+    LogRecordExporter? logRecordExporter,
+    LogRecordProcessor? logRecordProcessor,
+    Resource? resource,
+  }) {
+    // Get the logger provider
+    final logProvider = OTel.loggerProvider();
+
+    // Set resource if provided
+    if (resource != null) {
+      logProvider.resource = resource;
+    }
+
+    // If a custom processor is provided, use it directly
+    if (logRecordProcessor != null) {
+      logProvider.addLogRecordProcessor(logRecordProcessor);
+      return logProvider;
+    }
+
+    // Determine exporter type from environment or use provided exporter
+    final exporterType = OTelEnv.getExporter(signal: 'logs') ?? 'otlp';
+
+    if (exporterType == 'none') {
+      // No exporter configured - return provider without processor
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'LogsConfiguration: OTEL_LOGS_EXPORTER=none, no processor added');
+      }
+      return logProvider;
+    }
+
+    // Create exporter if not provided
+    logRecordExporter ??= _createExporter(exporterType, endpoint, secure);
+
+    if (logRecordExporter == null) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'LogsConfiguration: No exporter created, no processor added');
+      }
+      return logProvider;
+    }
+
+    // Create processor with BLRP configuration from environment
+    final processor = _createProcessor(logRecordExporter);
+
+    // Add the processor
+    logProvider.addLogRecordProcessor(processor);
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'LogsConfiguration: Configured LoggerProvider with $exporterType exporter');
+    }
+
+    return logProvider;
+  }
+
+  /// Creates a log record exporter based on the exporter type.
+  static LogRecordExporter? _createExporter(
+    String exporterType,
+    String endpoint,
+    bool secure,
+  ) {
+    // Get OTLP config for logs signal
+    final otlpConfig = OTelEnv.getOtlpConfig(signal: 'logs');
+
+    // Use env endpoint if available, otherwise use provided endpoint
+    final effectiveEndpoint = otlpConfig['endpoint'] as String? ?? endpoint;
+    final envInsecure = otlpConfig['insecure'] as bool?;
+    final effectiveSecure = envInsecure != null ? !envInsecure : secure;
+
+    if (exporterType == 'console') {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('LogsConfiguration: Creating ConsoleLogRecordExporter');
+      }
+      return ConsoleLogRecordExporter();
+    }
+
+    if (exporterType == 'otlp') {
+      // Determine protocol - default to http/protobuf
+      final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
+
+      if (protocol == 'grpc') {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'LogsConfiguration: Creating OtlpGrpcLogRecordExporter');
+        }
+        return OtlpGrpcLogRecordExporter(
+          OtlpGrpcLogRecordExporterConfig(
+            endpoint: effectiveEndpoint,
+            insecure: !effectiveSecure,
+            headers: otlpConfig['headers'] as Map<String, String>? ?? {},
+            timeout: otlpConfig['timeout'] as Duration? ??
+                const Duration(seconds: 10),
+            compression: otlpConfig['compression'] == 'gzip',
+            certificate: otlpConfig['certificate'] as String?,
+            clientKey: otlpConfig['clientKey'] as String?,
+            clientCertificate: otlpConfig['clientCertificate'] as String?,
+          ),
+        );
+      } else {
+        // Default to http/protobuf
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'LogsConfiguration: Creating OtlpHttpLogRecordExporter');
+        }
+        return OtlpHttpLogRecordExporter(
+          OtlpHttpLogRecordExporterConfig(
+            endpoint: effectiveEndpoint,
+            headers: otlpConfig['headers'] as Map<String, String>? ?? {},
+            timeout: otlpConfig['timeout'] as Duration? ??
+                const Duration(seconds: 10),
+            compression: otlpConfig['compression'] == 'gzip',
+            certificate: otlpConfig['certificate'] as String?,
+            clientKey: otlpConfig['clientKey'] as String?,
+            clientCertificate: otlpConfig['clientCertificate'] as String?,
+          ),
+        );
+      }
+    }
+
+    // Unknown exporter type
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('LogsConfiguration: Unknown exporter type: $exporterType');
+    }
+    return null;
+  }
+
+  /// Creates a log record processor with BLRP configuration from environment.
+  static LogRecordProcessor _createProcessor(LogRecordExporter exporter) {
+    final blrpConfig = OTelEnv.getBlrpConfig();
+
+    if (blrpConfig.isEmpty) {
+      // Use defaults
+      return BatchLogRecordProcessor(
+        exporter,
+        const BatchLogRecordProcessorConfig(),
+      );
+    }
+
+    // Build config from environment
+    final scheduleDelay = blrpConfig['scheduleDelay'] as Duration?;
+    final exportTimeout = blrpConfig['exportTimeout'] as Duration?;
+    final maxQueueSize = blrpConfig['maxQueueSize'] as int?;
+    final maxExportBatchSize = blrpConfig['maxExportBatchSize'] as int?;
+
+    return BatchLogRecordProcessor(
+      exporter,
+      BatchLogRecordProcessorConfig(
+        scheduleDelay: scheduleDelay ?? const Duration(milliseconds: 1000),
+        exportTimeout: exportTimeout ?? const Duration(seconds: 30),
+        maxQueueSize: maxQueueSize ?? 2048,
+        maxExportBatchSize: maxExportBatchSize ?? 512,
+      ),
+    );
+  }
+
+  /// Creates a simple (synchronous) log record processor instead of batch.
+  ///
+  /// This is useful for development/debugging or when you want immediate export.
+  static LogRecordProcessor createSimpleProcessor(LogRecordExporter exporter) {
+    return SimpleLogRecordProcessor(exporter);
+  }
+}

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
@@ -1,0 +1,396 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    show OTelLog;
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+import '../../../../trace/export/otlp/certificate_utils.dart';
+import '../../../../util/zip/gzip.dart';
+import '../../../readable_log_record.dart';
+import '../../log_record_exporter.dart';
+import '../log_record_transformer.dart';
+import 'otlp_http_log_record_exporter_config.dart';
+
+/// An OpenTelemetry log record exporter that exports logs using OTLP over HTTP/protobuf.
+class OtlpHttpLogRecordExporter implements LogRecordExporter {
+  static const _retryableStatusCodes = [
+    429, // Too Many Requests
+    503, // Service Unavailable
+  ];
+
+  final OtlpHttpLogRecordExporterConfig _config;
+  bool _isShutdown = false;
+  final Random _random = Random();
+  final List<Future<void>> _pendingExports = [];
+  late final http.Client _client;
+
+  /// Creates a new OTLP HTTP log record exporter with the specified configuration.
+  /// If no configuration is provided, default settings will be used.
+  ///
+  /// @param config Optional configuration for the exporter
+  OtlpHttpLogRecordExporter([OtlpHttpLogRecordExporterConfig? config])
+      : _config = config ?? OtlpHttpLogRecordExporterConfig() {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Created with endpoint: ${_config.endpoint}');
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Configured headers count: ${_config.headers.length}');
+      _config.headers.forEach((key, value) {
+        if (key.toLowerCase() == 'authorization') {
+          OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
+        } else {
+          OTelLog.debug('  $key: $value');
+        }
+      });
+    }
+    _client = _createHttpClient();
+  }
+
+  /// Creates an HTTP client with custom certificates if configured.
+  http.Client _createHttpClient() {
+    if (_config.certificate == null &&
+        _config.clientKey == null &&
+        _config.clientCertificate == null) {
+      return http.Client();
+    }
+
+    try {
+      final context = CertificateUtils.createSecurityContext(
+        certificate: _config.certificate,
+        clientKey: _config.clientKey,
+        clientCertificate: _config.clientCertificate,
+      );
+
+      if (context == null) {
+        return http.Client();
+      }
+
+      final httpClient = HttpClient(context: context);
+      return IOClient(httpClient);
+    } catch (e) {
+      if (OTelLog.isError()) {
+        OTelLog.error(
+            'OtlpHttpLogRecordExporter: Failed to create HTTP client with certificates: $e');
+      }
+      return http.Client();
+    }
+  }
+
+  Duration _calculateJitteredDelay(int retries) {
+    final baseMs = _config.baseDelay.inMilliseconds;
+    final delay = baseMs * pow(2, retries);
+    final jitter = _random.nextDouble() * delay;
+    return Duration(milliseconds: (delay + jitter).toInt());
+  }
+
+  String _getEndpointUrl() {
+    // Ensure the endpoint ends with /v1/logs
+    String endpoint = _config.endpoint;
+    if (!endpoint.endsWith('/v1/logs')) {
+      if (endpoint.endsWith('/')) {
+        endpoint = endpoint.substring(0, endpoint.length - 1);
+      }
+      endpoint = '$endpoint/v1/logs';
+    }
+    return endpoint;
+  }
+
+  Future<ExportResult> _tryExport(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Preparing to export ${logRecords.length} log records');
+    }
+
+    final request = OtlpLogRecordTransformer.transformLogRecords(logRecords);
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Successfully transformed log records');
+    }
+
+    // Prepare headers
+    final headers = Map<String, String>.from(_config.headers);
+    headers['Content-Type'] = 'application/x-protobuf';
+
+    if (_config.compression) {
+      headers['Content-Encoding'] = 'gzip';
+    }
+
+    // Convert protobuf to bytes
+    final Uint8List messageBytes = request.writeToBuffer();
+    Uint8List bodyBytes = messageBytes;
+
+    // Apply gzip compression if configured
+    if (_config.compression) {
+      final gZip = GZip();
+      final listInt = await gZip.compress(messageBytes);
+      bodyBytes = Uint8List.fromList(listInt);
+    }
+
+    // Get the endpoint URL with the correct path
+    final endpointUrl = _getEndpointUrl();
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Sending export request to $endpointUrl');
+      OTelLog.debug('OtlpHttpLogRecordExporter: Request headers:');
+      headers.forEach((key, value) {
+        if (key.toLowerCase() == 'authorization') {
+          OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
+        } else {
+          OTelLog.debug('  $key: $value');
+        }
+      });
+    }
+
+    try {
+      final http.Response response = await _client
+          .post(
+            Uri.parse(endpointUrl),
+            headers: headers,
+            body: bodyBytes,
+          )
+          .timeout(_config.timeout);
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpHttpLogRecordExporter: Export request completed successfully');
+        }
+        return ExportResult.success;
+      } else {
+        final String errorMessage =
+            'OtlpHttpLogRecordExporter: Export request failed with status code ${response.statusCode}';
+        if (OTelLog.isError()) OTelLog.error(errorMessage);
+        throw http.ClientException(errorMessage);
+      }
+    } catch (e, stackTrace) {
+      if (OTelLog.isError()) {
+        OTelLog.error('OtlpHttpLogRecordExporter: Export request failed: $e');
+        OTelLog.error('Stack trace: $stackTrace');
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    if (logRecords.isEmpty) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('OtlpHttpLogRecordExporter: No log records to export');
+      }
+      return ExportResult.success;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Beginning export of ${logRecords.length} log records');
+    }
+
+    final exportFuture = _export(logRecords);
+    _pendingExports.add(exportFuture);
+
+    try {
+      final result = await exportFuture;
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpHttpLogRecordExporter: Export completed with result: $result');
+      }
+      return result;
+    } catch (e) {
+      if (_isShutdown &&
+          e is StateError &&
+          e.message.contains('shut down during')) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpHttpLogRecordExporter: Export was interrupted by shutdown');
+        }
+        return ExportResult.failure;
+      }
+      return ExportResult.failure;
+    } finally {
+      _pendingExports.remove(exportFuture);
+    }
+  }
+
+  Future<ExportResult> _export(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpHttpLogRecordExporter: Attempting to export ${logRecords.length} log records to ${_config.endpoint}');
+    }
+
+    var attempts = 0;
+    final maxAttempts = _config.maxRetries + 1;
+
+    while (attempts < maxAttempts) {
+      final wasShutdownDuringRetry = _isShutdown;
+
+      try {
+        if (wasShutdownDuringRetry && attempts > 0) {
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'OtlpHttpLogRecordExporter: Export interrupted by shutdown');
+          }
+          return ExportResult.failure;
+        }
+
+        return await _tryExport(logRecords);
+      } on http.ClientException catch (e, stackTrace) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpHttpLogRecordExporter: HTTP error during export: $e');
+          OTelLog.error('Stack trace: $stackTrace');
+        }
+
+        if (wasShutdownDuringRetry) {
+          return ExportResult.failure;
+        }
+
+        bool shouldRetry = false;
+        if (e.message.contains('status code')) {
+          for (final code in _retryableStatusCodes) {
+            if (e.message.contains('status code $code')) {
+              shouldRetry = true;
+              break;
+            }
+          }
+        }
+
+        if (!shouldRetry) {
+          if (OTelLog.isError()) {
+            OTelLog.error(
+                'OtlpHttpLogRecordExporter: Non-retryable HTTP error, stopping retry attempts');
+          }
+          return ExportResult.failure;
+        }
+
+        if (attempts >= maxAttempts - 1) {
+          if (OTelLog.isError()) {
+            OTelLog.error(
+                'OtlpHttpLogRecordExporter: Max attempts reached, giving up');
+          }
+          return ExportResult.failure;
+        }
+
+        final delay = _calculateJitteredDelay(attempts);
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpHttpLogRecordExporter: Retrying export after ${delay.inMilliseconds}ms...');
+        }
+        await Future<void>.delayed(delay);
+        attempts++;
+      } catch (e, stackTrace) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpHttpLogRecordExporter: Unexpected error during export: $e');
+          OTelLog.error('Stack trace: $stackTrace');
+        }
+
+        if (wasShutdownDuringRetry) {
+          return ExportResult.failure;
+        }
+
+        if (attempts >= maxAttempts - 1) {
+          return ExportResult.failure;
+        }
+
+        final delay = _calculateJitteredDelay(attempts);
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpHttpLogRecordExporter: Retrying export after ${delay.inMilliseconds}ms...');
+        }
+        await Future<void>.delayed(delay);
+        attempts++;
+      }
+    }
+
+    return ExportResult.failure;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OtlpHttpLogRecordExporter: Force flush requested');
+    }
+    if (_isShutdown) {
+      return;
+    }
+
+    if (_pendingExports.isNotEmpty) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpHttpLogRecordExporter: Waiting for ${_pendingExports.length} pending exports');
+      }
+      try {
+        await Future.wait(_pendingExports);
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpHttpLogRecordExporter: All pending exports completed');
+        }
+      } catch (e) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpHttpLogRecordExporter: Error during force flush: $e');
+        }
+      }
+    }
+  }
+
+  @override
+  Future<void> shutdown() async {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OtlpHttpLogRecordExporter: Shutdown requested');
+    }
+    if (_isShutdown) {
+      return;
+    }
+
+    _isShutdown = true;
+
+    final pendingExportsCopy = List<Future<void>>.of(_pendingExports);
+
+    if (pendingExportsCopy.isNotEmpty) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpHttpLogRecordExporter: Waiting for ${pendingExportsCopy.length} pending exports');
+      }
+      try {
+        await Future.wait(pendingExportsCopy)
+            .timeout(const Duration(seconds: 10), onTimeout: () {
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'OtlpHttpLogRecordExporter: Timeout waiting for exports to complete');
+          }
+          return Future.value([]);
+        });
+      } catch (e) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug('OtlpHttpLogRecordExporter: Error during shutdown: $e');
+        }
+      }
+    }
+
+    _client.close();
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OtlpHttpLogRecordExporter: Shutdown complete');
+    }
+  }
+}

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import '../../../../trace/export/otlp/certificate_utils.dart';
+
+/// Configuration for the OpenTelemetry log record exporter that exports logs using OTLP over HTTP/protobuf.
+class OtlpHttpLogRecordExporterConfig {
+  /// The endpoint to export logs to (e.g., 'http://localhost:4318/v1/logs')
+  /// Default: 'http://localhost:4318'
+  final String endpoint;
+
+  /// Additional HTTP headers to include in the export requests.
+  final Map<String, String> headers;
+
+  /// The timeout for export HTTP requests.
+  /// Default: 10 seconds
+  final Duration timeout;
+
+  /// Whether to use gzip compression for the HTTP body.
+  /// Default: false
+  final bool compression;
+
+  /// Maximum number of retries for failed export requests.
+  /// Default: 3
+  final int maxRetries;
+
+  /// Base delay for exponential backoff when retrying.
+  /// Default: 100 milliseconds
+  final Duration baseDelay;
+
+  /// Maximum delay for exponential backoff when retrying.
+  /// Default: 1 second
+  final Duration maxDelay;
+
+  /// Path to the TLS certificate file for secure connections.
+  final String? certificate;
+
+  /// Path to the client key file for secure connections with client authentication.
+  final String? clientKey;
+
+  /// Path to the client certificate file for secure connections with client authentication.
+  final String? clientCertificate;
+
+  /// Creates a new configuration for the OTLP HTTP log record exporter.
+  ///
+  /// The endpoint must be a valid URL and will default to http://localhost:4318
+  /// if not specified. The path '/v1/logs' will be appended if not already present.
+  OtlpHttpLogRecordExporterConfig({
+    String endpoint = 'http://localhost:4318',
+    Map<String, String>? headers,
+    Duration timeout = const Duration(seconds: 10),
+    this.compression = false,
+    int maxRetries = 3,
+    Duration baseDelay = const Duration(milliseconds: 100),
+    Duration maxDelay = const Duration(seconds: 1),
+    this.certificate,
+    this.clientKey,
+    this.clientCertificate,
+  })  : endpoint = _validateEndpoint(endpoint),
+        headers = _validateHeaders(headers ?? {}),
+        timeout = _validateTimeout(timeout),
+        maxRetries = _validateRetries(maxRetries),
+        baseDelay = _validateDelay(baseDelay, 'baseDelay'),
+        maxDelay = _validateDelay(maxDelay, 'maxDelay') {
+    if (baseDelay.compareTo(maxDelay) > 0) {
+      throw ArgumentError('maxDelay cannot be less than baseDelay');
+    }
+    _validateCertificates(certificate, clientKey, clientCertificate);
+  }
+
+  static Map<String, String> _validateHeaders(Map<String, String> headers) {
+    final normalized = <String, String>{};
+    for (final entry in headers.entries) {
+      if (entry.key.isEmpty || entry.value.isEmpty) {
+        throw ArgumentError('Header keys and values cannot be empty');
+      }
+      normalized[entry.key.toLowerCase()] = entry.value;
+    }
+    return normalized;
+  }
+
+  static String _validateEndpoint(String endpoint) {
+    if (endpoint.isEmpty) {
+      throw ArgumentError('Endpoint cannot be empty');
+    }
+
+    endpoint = endpoint.trim();
+
+    if (endpoint.contains(' ')) {
+      throw ArgumentError('Endpoint cannot contain spaces: $endpoint');
+    }
+
+    // Ensure endpoint starts with http:// or https://
+    final lcEndpoint = endpoint.toLowerCase();
+    if (!lcEndpoint.startsWith('http://') &&
+        !lcEndpoint.startsWith('https://')) {
+      endpoint = 'http://$endpoint';
+    }
+
+    // Default port for OTLP/HTTP is 4318
+    if (lcEndpoint == 'http://localhost' ||
+        lcEndpoint == 'http://127.0.0.1' ||
+        lcEndpoint == 'https://localhost' ||
+        lcEndpoint == 'https://127.0.0.1') {
+      return '$endpoint:4318';
+    }
+
+    try {
+      final uri = Uri.parse(endpoint);
+      if (uri.host.isEmpty) {
+        throw ArgumentError('Invalid host in endpoint: $endpoint');
+      }
+
+      if (uri.port == 0 && !endpoint.contains(':') && uri.path.isEmpty) {
+        return '${uri.scheme}://${uri.host}:4318';
+      }
+
+      return endpoint;
+    } catch (e) {
+      if (e is ArgumentError) rethrow;
+      throw ArgumentError('Invalid URL format in endpoint: $endpoint');
+    }
+  }
+
+  static Duration _validateTimeout(Duration timeout) {
+    if (timeout < const Duration(milliseconds: 1) ||
+        timeout > const Duration(minutes: 10)) {
+      throw ArgumentError('Timeout must be between 1ms and 10 minutes');
+    }
+    return timeout;
+  }
+
+  static int _validateRetries(int retries) {
+    if (retries < 0) {
+      throw ArgumentError('maxRetries cannot be negative');
+    }
+    return retries;
+  }
+
+  static Duration _validateDelay(Duration delay, String name) {
+    if (delay < const Duration(milliseconds: 1) ||
+        delay > const Duration(minutes: 5)) {
+      throw ArgumentError('$name must be between 1ms and 5 minutes');
+    }
+    return delay;
+  }
+
+  static void _validateCertificates(
+      String? cert, String? key, String? clientCert) {
+    CertificateUtils.validateCertificates(
+      certificate: cert,
+      clientKey: key,
+      clientCertificate: clientCert,
+    );
+  }
+}

--- a/lib/src/logs/export/otlp/log_record_transformer.dart
+++ b/lib/src/logs/export/otlp/log_record_transformer.dart
@@ -1,0 +1,319 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:fixnum/fixnum.dart';
+
+import '../../../../proto/opentelemetry_proto_dart.dart' as proto;
+import '../../../otel.dart';
+import '../../readable_log_record.dart';
+
+/// Transforms internal log record representation to OTLP format.
+///
+/// This transformer converts SDK log records to the OTLP protocol buffer
+/// format for export to OpenTelemetry collectors.
+class OtlpLogRecordTransformer {
+  /// Convert a list of log records to OTLP ExportLogsServiceRequest.
+  ///
+  /// @param logRecords The log records to transform
+  /// @return The OTLP export request
+  static proto.ExportLogsServiceRequest transformLogRecords(
+      List<ReadableLogRecord> logRecords) {
+    final request = proto.ExportLogsServiceRequest();
+    if (logRecords.isEmpty) return request;
+
+    // Group log records by their resource first
+    final resourceGroups = <String, List<ReadableLogRecord>>{};
+
+    for (final logRecord in logRecords) {
+      final resource = logRecord.resource;
+      final key = resource != null
+          ? _getResourceServiceName(resource.attributes)
+          : 'default-service';
+      resourceGroups.putIfAbsent(key, () => []).add(logRecord);
+    }
+
+    // Process each resource group
+    for (final resourceEntry in resourceGroups.entries) {
+      final logList = resourceEntry.value;
+      if (logList.isEmpty) continue;
+
+      // Extract resource attributes from the log record's resource
+      final resource = logList.first.resource;
+      final resourceAttrs = resource?.attributes ?? OTel.createAttributes();
+
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('LogRecordTransformer: Extracting resource attributes:');
+        resourceAttrs.toList().forEach((attr) {
+          if (attr.key == 'tenant_id' || attr.key == 'service.name') {
+            OTelLog.debug('  ${attr.key}: ${attr.value}');
+          }
+        });
+      }
+
+      // Create resource
+      final protoResource = proto.Resource()
+        ..attributes.addAll(_transformAttributeMap(resourceAttrs));
+
+      // Group log records by instrumentation scope
+      final scopeGroups = <String, List<ReadableLogRecord>>{};
+      for (final log in logList) {
+        final scopeKey = _instrumentationKey(log);
+        scopeGroups.putIfAbsent(scopeKey, () => []).add(log);
+      }
+
+      // Create ResourceLogs
+      final resourceLogs = proto.ResourceLogs()..resource = protoResource;
+
+      // Process each instrumentation scope group
+      for (final scopeEntry in scopeGroups.entries) {
+        final scopeLogList = scopeEntry.value;
+        if (scopeLogList.isEmpty) continue;
+
+        // Get instrumentation scope information from the first log record
+        final scope = scopeLogList.first.instrumentationScope;
+        final otlpScope = proto.InstrumentationScope()..name = scope.name;
+        if (scope.version != null) {
+          otlpScope.version = scope.version!;
+        }
+        if (scope.schemaUrl != null) {
+          resourceLogs.schemaUrl = scope.schemaUrl!;
+        }
+
+        // Transform all log records in this scope to OTLP format
+        final otlpLogRecords = <proto.LogRecord>[];
+        for (final logRecord in scopeLogList) {
+          otlpLogRecords.add(_transformLogRecord(logRecord));
+        }
+
+        // Create ScopeLogs
+        final otlpScopeLogs = proto.ScopeLogs()
+          ..scope = otlpScope
+          ..logRecords.addAll(otlpLogRecords);
+
+        resourceLogs.scopeLogs.add(otlpScopeLogs);
+      }
+
+      request.resourceLogs.add(resourceLogs);
+    }
+
+    return request;
+  }
+
+  /// Get service name from resource attributes.
+  static String _getResourceServiceName(Attributes attributes) {
+    for (final attr in attributes.toList()) {
+      if (attr.key == 'service.name') {
+        return attr.value.toString();
+      }
+    }
+    return 'default-service';
+  }
+
+  /// Creates a key for grouping log records by instrumentation scope.
+  static String _instrumentationKey(ReadableLogRecord logRecord) {
+    final scope = logRecord.instrumentationScope;
+    return '${scope.name}:${scope.version ?? ''}';
+  }
+
+  /// Convert a single log record to OTLP LogRecord.
+  static proto.LogRecord _transformLogRecord(ReadableLogRecord logRecord) {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('LogRecordTransformer: Transforming log record');
+    }
+
+    final otlpLog = proto.LogRecord();
+
+    // Set timestamps
+    if (logRecord.timestamp != null) {
+      otlpLog.timeUnixNano = logRecord.timestamp!;
+    }
+    if (logRecord.observedTimestamp != null) {
+      otlpLog.observedTimeUnixNano = logRecord.observedTimestamp!;
+    }
+
+    // Set severity
+    if (logRecord.severityNumber != null) {
+      otlpLog.severityNumber = _transformSeverity(logRecord.severityNumber!);
+    }
+    if (logRecord.severityText != null) {
+      otlpLog.severityText = logRecord.severityText!;
+    }
+
+    // Set body
+    if (logRecord.body != null) {
+      otlpLog.body = _transformBody(logRecord.body);
+    }
+
+    // Set attributes
+    if (logRecord.attributes != null) {
+      otlpLog.attributes.addAll(_transformAttributeMap(logRecord.attributes!));
+    }
+
+    // Set dropped attributes count
+    otlpLog.droppedAttributesCount = logRecord.droppedAttributesCount;
+
+    // Set trace context
+    if (logRecord.traceId != null && logRecord.traceId!.isValid) {
+      otlpLog.traceId = logRecord.traceId!.bytes;
+    }
+    if (logRecord.spanId != null && logRecord.spanId!.isValid) {
+      otlpLog.spanId = logRecord.spanId!.bytes;
+    }
+    if (logRecord.traceFlags != null) {
+      otlpLog.flags = logRecord.traceFlags!.asByte;
+    }
+
+    return otlpLog;
+  }
+
+  /// Transform severity to OTLP SeverityNumber.
+  static proto.SeverityNumber _transformSeverity(Severity severity) {
+    // Map API Severity to proto SeverityNumber
+    switch (severity) {
+      case Severity.UNSPECIFIED:
+        return proto.SeverityNumber.SEVERITY_NUMBER_UNSPECIFIED;
+      case Severity.TRACE:
+        return proto.SeverityNumber.SEVERITY_NUMBER_TRACE;
+      case Severity.TRACE2:
+        return proto.SeverityNumber.SEVERITY_NUMBER_TRACE2;
+      case Severity.TRACE3:
+        return proto.SeverityNumber.SEVERITY_NUMBER_TRACE3;
+      case Severity.TRACE4:
+        return proto.SeverityNumber.SEVERITY_NUMBER_TRACE4;
+      case Severity.DEBUG:
+        return proto.SeverityNumber.SEVERITY_NUMBER_DEBUG;
+      case Severity.DEBUG2:
+        return proto.SeverityNumber.SEVERITY_NUMBER_DEBUG2;
+      case Severity.DEBUG3:
+        return proto.SeverityNumber.SEVERITY_NUMBER_DEBUG3;
+      case Severity.DEBUG4:
+        return proto.SeverityNumber.SEVERITY_NUMBER_DEBUG4;
+      case Severity.INFO:
+        return proto.SeverityNumber.SEVERITY_NUMBER_INFO;
+      case Severity.INFO2:
+        return proto.SeverityNumber.SEVERITY_NUMBER_INFO2;
+      case Severity.INFO3:
+        return proto.SeverityNumber.SEVERITY_NUMBER_INFO3;
+      case Severity.INFO4:
+        return proto.SeverityNumber.SEVERITY_NUMBER_INFO4;
+      case Severity.WARN:
+        return proto.SeverityNumber.SEVERITY_NUMBER_WARN;
+      case Severity.WARN2:
+        return proto.SeverityNumber.SEVERITY_NUMBER_WARN2;
+      case Severity.WARN3:
+        return proto.SeverityNumber.SEVERITY_NUMBER_WARN3;
+      case Severity.WARN4:
+        return proto.SeverityNumber.SEVERITY_NUMBER_WARN4;
+      case Severity.ERROR:
+        return proto.SeverityNumber.SEVERITY_NUMBER_ERROR;
+      case Severity.ERROR2:
+        return proto.SeverityNumber.SEVERITY_NUMBER_ERROR2;
+      case Severity.ERROR3:
+        return proto.SeverityNumber.SEVERITY_NUMBER_ERROR3;
+      case Severity.ERROR4:
+        return proto.SeverityNumber.SEVERITY_NUMBER_ERROR4;
+      case Severity.FATAL:
+        return proto.SeverityNumber.SEVERITY_NUMBER_FATAL;
+      case Severity.FATAL2:
+        return proto.SeverityNumber.SEVERITY_NUMBER_FATAL2;
+      case Severity.FATAL3:
+        return proto.SeverityNumber.SEVERITY_NUMBER_FATAL3;
+      case Severity.FATAL4:
+        return proto.SeverityNumber.SEVERITY_NUMBER_FATAL4;
+    }
+  }
+
+  /// Transform body to OTLP AnyValue.
+  static proto.AnyValue _transformBody(dynamic body) {
+    final anyValue = proto.AnyValue();
+
+    if (body == null) {
+      return anyValue;
+    } else if (body is String) {
+      anyValue.stringValue = body;
+    } else if (body is bool) {
+      anyValue.boolValue = body;
+    } else if (body is int) {
+      anyValue.intValue = Int64(body);
+    } else if (body is double) {
+      anyValue.doubleValue = body;
+    } else if (body is List) {
+      final arrayValue = proto.ArrayValue();
+      for (final item in body) {
+        arrayValue.values.add(_transformBody(item));
+      }
+      anyValue.arrayValue = arrayValue;
+    } else if (body is Map) {
+      final kvList = proto.KeyValueList();
+      body.forEach((key, value) {
+        kvList.values.add(proto.KeyValue()
+          ..key = key.toString()
+          ..value = _transformBody(value));
+      });
+      anyValue.kvlistValue = kvList;
+    } else {
+      // For any other type, convert to string
+      anyValue.stringValue = body.toString();
+    }
+
+    return anyValue;
+  }
+
+  /// Convert attribute map to OTLP KeyValue list.
+  static List<proto.KeyValue> _transformAttributeMap(Attributes attributes) {
+    final result = <proto.KeyValue>[];
+
+    attributes.toList().forEach((attr) {
+      final keyValue = proto.KeyValue()
+        ..key = attr.key
+        ..value = _transformAttributeValue(attr);
+
+      result.add(keyValue);
+    });
+
+    return result;
+  }
+
+  /// Convert AttributeValue to OTLP AnyValue.
+  static proto.AnyValue _transformAttributeValue(Attribute attr) {
+    final anyValue = proto.AnyValue();
+
+    if (attr.value is String) {
+      anyValue.stringValue = attr.value as String;
+    } else if (attr.value is bool) {
+      anyValue.boolValue = attr.value as bool;
+    } else if (attr.value is int) {
+      anyValue.intValue = Int64(attr.value as int);
+    } else if (attr.value is double) {
+      anyValue.doubleValue = attr.value as double;
+    } else if (attr.value is List<String>) {
+      final arrayValue = proto.ArrayValue();
+      arrayValue.values.addAll((attr.value as List<String>)
+          .map((v) => proto.AnyValue()..stringValue = v));
+      anyValue.arrayValue = arrayValue;
+    } else if (attr.value is List<bool>) {
+      final arrayValue = proto.ArrayValue();
+      arrayValue.values.addAll((attr.value as List<bool>)
+          .map((v) => proto.AnyValue()..boolValue = v));
+      anyValue.arrayValue = arrayValue;
+    } else if (attr.value is List<int>) {
+      final arrayValue = proto.ArrayValue();
+      arrayValue.values.addAll((attr.value as List<int>)
+          .map((v) => proto.AnyValue()..intValue = Int64(v)));
+      anyValue.arrayValue = arrayValue;
+    } else if (attr.value is List<double>) {
+      final arrayValue = proto.ArrayValue();
+      arrayValue.values.addAll((attr.value as List<double>)
+          .map((v) => proto.AnyValue()..doubleValue = v));
+      anyValue.arrayValue = arrayValue;
+    } else {
+      // For any other type, convert to string
+      anyValue.stringValue = attr.value.toString();
+    }
+
+    return anyValue;
+  }
+}

--- a/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
@@ -1,0 +1,481 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:async';
+import 'dart:math';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    show OTelLog;
+import 'package:grpc/grpc.dart';
+
+import '../../../../proto/opentelemetry_proto_dart.dart' as proto;
+import '../../../trace/export/otlp/certificate_utils.dart';
+import '../../readable_log_record.dart';
+import '../log_record_exporter.dart';
+import 'log_record_transformer.dart';
+import 'otlp_grpc_log_record_exporter_config.dart';
+
+/// An OpenTelemetry log record exporter that exports logs using OTLP over gRPC.
+///
+/// This exporter sends log data to an OpenTelemetry collector or compatible backend
+/// using the OpenTelemetry Protocol (OTLP) over gRPC. It supports features such as:
+/// - Retrying failed exports with exponential backoff
+/// - Secure and insecure connections
+/// - Custom headers and timeouts
+/// - Compression
+class OtlpGrpcLogRecordExporter implements LogRecordExporter {
+  static const _retryableStatusCodes = [
+    StatusCode.resourceExhausted, // Maps to HTTP 429
+    StatusCode.unavailable, // Maps to HTTP 503
+  ];
+
+  final OtlpGrpcLogRecordExporterConfig _config;
+  ClientChannel? _channel;
+  proto.LogsServiceClient? _logsService;
+  bool _isShutdown = false;
+  final Random _random = Random();
+  final List<Future<void>> _pendingExports = [];
+  bool _initialized = false;
+
+  /// Creates a new OtlpGrpcLogRecordExporter with the specified configuration.
+  ///
+  /// If no configuration is provided, default values will be used.
+  ///
+  /// @param config Optional configuration for the exporter
+  OtlpGrpcLogRecordExporter([OtlpGrpcLogRecordExporterConfig? config])
+      : _config = config ?? OtlpGrpcLogRecordExporterConfig();
+
+  /// Creates channel credentials based on configuration.
+  ChannelCredentials _createChannelCredentials() {
+    if (_config.insecure) {
+      return const ChannelCredentials.insecure();
+    }
+
+    if (_config.certificate == null &&
+        _config.clientKey == null &&
+        _config.clientCertificate == null) {
+      return const ChannelCredentials.secure();
+    }
+
+    try {
+      final context = CertificateUtils.createSecurityContext(
+        certificate: _config.certificate,
+        clientKey: _config.clientKey,
+        clientCertificate: _config.clientCertificate,
+      );
+
+      if (context == null) {
+        return const ChannelCredentials.secure();
+      }
+
+      return const ChannelCredentials.secure(
+        certificates: null,
+        authority: null,
+        onBadCertificate: null,
+      );
+    } catch (e) {
+      if (OTelLog.isError()) {
+        OTelLog.error(
+            'OtlpGrpcLogRecordExporter: Failed to load certificates: $e');
+      }
+      return const ChannelCredentials.secure();
+    }
+  }
+
+  /// Cleanup the gRPC channel and release resources.
+  Future<void> _cleanupChannel() async {
+    if (_channel != null) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpGrpcLogRecordExporter: Shutting down existing channel');
+      }
+
+      try {
+        try {
+          await _channel!.shutdown();
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+        } catch (e) {
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'OtlpGrpcLogRecordExporter: Error during graceful shutdown: $e');
+          }
+        }
+
+        try {
+          _channel!.terminate();
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+        } catch (e) {
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'OtlpGrpcLogRecordExporter: Error terminating channel: $e');
+          }
+        }
+      } catch (e) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpGrpcLogRecordExporter: Error shutting down channel: $e');
+        }
+      }
+
+      _channel = null;
+      _logsService = null;
+    }
+  }
+
+  Future<void> _setupChannel() async {
+    if (_isShutdown) {
+      return;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpGrpcLogRecordExporter: Setting up gRPC channel with endpoint ${_config.endpoint}');
+    }
+
+    await _cleanupChannel();
+
+    String host;
+    int port;
+
+    try {
+      final endpoint = _config.endpoint
+          .trim()
+          .replaceAll(RegExp(r'^(http://|https://)'), '');
+      final parts = endpoint.split(':');
+      host = parts[0].isEmpty ? '127.0.0.1' : parts[0];
+      port = parts.length > 1 ? int.parse(parts[1]) : 4317;
+
+      if (host == 'localhost') {
+        host = '127.0.0.1';
+      }
+
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpGrpcLogRecordExporter: Setting up gRPC channel to $host:$port');
+      }
+
+      _channel ??= ClientChannel(
+        host,
+        port: port,
+        options: ChannelOptions(
+          credentials: _createChannelCredentials(),
+          connectTimeout: const Duration(seconds: 5),
+          idleTimeout: const Duration(seconds: 30),
+          codecRegistry: CodecRegistry(codecs: const [
+            GzipCodec(),
+            IdentityCodec(),
+          ]),
+        ),
+      );
+
+      try {
+        _logsService = proto.LogsServiceClient(_channel!);
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpGrpcLogRecordExporter: Successfully created LogsServiceClient');
+        }
+      } catch (e) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpGrpcLogRecordExporter: Failed to create LogsServiceClient: $e');
+        }
+        rethrow;
+      }
+    } catch (e, stackTrace) {
+      if (OTelLog.isError()) {
+        OTelLog.error(
+            'OtlpGrpcLogRecordExporter: Failed to setup gRPC channel: $e');
+        OTelLog.error('Stack trace: $stackTrace');
+      }
+      rethrow;
+    }
+  }
+
+  Future<void> _ensureChannel() async {
+    if (_isShutdown) {
+      throw StateError('Exporter is shutdown');
+    }
+
+    if (_initialized && _channel != null && _logsService != null) {
+      return;
+    }
+
+    _initialized = true;
+    if (_channel == null || _logsService == null) {
+      await _setupChannel();
+    }
+  }
+
+  Duration _calculateJitteredDelay(int retries) {
+    final baseMs = _config.baseDelay.inMilliseconds;
+    final delay = baseMs * pow(2, retries);
+    final jitter = _random.nextDouble() * delay;
+    return Duration(milliseconds: (delay + jitter).toInt());
+  }
+
+  Future<ExportResult> _tryExport(List<ReadableLogRecord> logRecords) async {
+    await _ensureChannel();
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpGrpcLogRecordExporter: Preparing to export ${logRecords.length} log records');
+    }
+
+    final request = OtlpLogRecordTransformer.transformLogRecords(logRecords);
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpGrpcLogRecordExporter: Successfully transformed log records');
+    }
+
+    // Add compression header if configured
+    final headers = Map<String, String>.from(_config.headers);
+    if (_config.compression) {
+      headers['grpc-encoding'] = 'gzip';
+    }
+
+    final CallOptions options = CallOptions(
+      timeout: _config.timeout,
+      metadata: headers,
+    );
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpGrpcLogRecordExporter: Sending export request to ${_config.endpoint}');
+    }
+
+    try {
+      if (_logsService == null) {
+        throw StateError('Logs service is null');
+      }
+
+      final response = await _logsService!.export(request, options: options);
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpGrpcLogRecordExporter: Export request completed successfully');
+        OTelLog.debug('OtlpGrpcLogRecordExporter: Response: $response');
+      }
+      return ExportResult.success;
+    } catch (e, stackTrace) {
+      if (OTelLog.isError()) {
+        OTelLog.error('OtlpGrpcLogRecordExporter: Export request failed: $e');
+        OTelLog.error('Stack trace: $stackTrace');
+      }
+
+      if (e is GrpcError &&
+          (e.code == StatusCode.unavailable ||
+              e.code == StatusCode.unknown ||
+              e.code == StatusCode.internal)) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpGrpcLogRecordExporter: Channel error, recreating channel');
+        }
+        await _cleanupChannel();
+        _initialized = false;
+      }
+
+      rethrow;
+    }
+  }
+
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    if (logRecords.isEmpty) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('OtlpGrpcLogRecordExporter: No log records to export');
+      }
+      return ExportResult.success;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpGrpcLogRecordExporter: Beginning export of ${logRecords.length} log records');
+    }
+
+    final exportFuture = _export(logRecords);
+    _pendingExports.add(exportFuture);
+
+    try {
+      final result = await exportFuture;
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpGrpcLogRecordExporter: Export completed with result: $result');
+      }
+      return result;
+    } catch (e) {
+      if (_isShutdown &&
+          e is StateError &&
+          e.message.contains('shut down during')) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpGrpcLogRecordExporter: Export was interrupted by shutdown');
+        }
+      }
+      return ExportResult.failure;
+    } finally {
+      _pendingExports.remove(exportFuture);
+    }
+  }
+
+  Future<ExportResult> _export(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OtlpGrpcLogRecordExporter: Attempting to export ${logRecords.length} log records');
+    }
+
+    var attempts = 0;
+    final maxAttempts = _config.maxRetries + 1;
+
+    while (attempts < maxAttempts) {
+      final wasShutdownDuringRetry = _isShutdown;
+
+      try {
+        if (wasShutdownDuringRetry && attempts > 0) {
+          return ExportResult.failure;
+        }
+
+        return await _tryExport(logRecords);
+      } on GrpcError catch (e, stackTrace) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpGrpcLogRecordExporter: gRPC error: ${e.code} - ${e.message}');
+          OTelLog.error('Stack trace: $stackTrace');
+        }
+
+        if (wasShutdownDuringRetry) {
+          return ExportResult.failure;
+        }
+
+        if (!_retryableStatusCodes.contains(e.code)) {
+          if (OTelLog.isError()) {
+            OTelLog.error(
+                'OtlpGrpcLogRecordExporter: Non-retryable gRPC error (${e.code})');
+          }
+          return ExportResult.failure;
+        }
+
+        if (attempts >= maxAttempts - 1) {
+          if (OTelLog.isError()) {
+            OTelLog.error(
+                'OtlpGrpcLogRecordExporter: Max attempts reached, giving up');
+          }
+          return ExportResult.failure;
+        }
+
+        final delay = _calculateJitteredDelay(attempts);
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpGrpcLogRecordExporter: Retrying after ${delay.inMilliseconds}ms');
+        }
+        await Future<void>.delayed(delay);
+        if (!_isShutdown) {
+          await _setupChannel();
+        }
+        attempts++;
+      } catch (e, stackTrace) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpGrpcLogRecordExporter: Unexpected error during export: $e');
+          OTelLog.error('Stack trace: $stackTrace');
+        }
+
+        if (wasShutdownDuringRetry) {
+          return ExportResult.failure;
+        }
+
+        if (attempts >= maxAttempts - 1) {
+          return ExportResult.failure;
+        }
+
+        final delay = _calculateJitteredDelay(attempts);
+        await Future<void>.delayed(delay);
+        if (!_isShutdown) {
+          await _setupChannel();
+        }
+        attempts++;
+      }
+    }
+
+    return ExportResult.failure;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OtlpGrpcLogRecordExporter: Force flush requested');
+    }
+    if (_isShutdown) {
+      return;
+    }
+
+    if (_pendingExports.isNotEmpty) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpGrpcLogRecordExporter: Waiting for ${_pendingExports.length} pending exports');
+      }
+      try {
+        await Future.wait(_pendingExports);
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'OtlpGrpcLogRecordExporter: All pending exports completed');
+        }
+      } catch (e) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'OtlpGrpcLogRecordExporter: Error during force flush: $e');
+        }
+      }
+    }
+  }
+
+  @override
+  Future<void> shutdown() async {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OtlpGrpcLogRecordExporter: Shutdown requested');
+    }
+    if (_isShutdown) {
+      return;
+    }
+
+    _isShutdown = true;
+
+    final pendingExportsCopy = List<Future<void>>.of(_pendingExports);
+
+    if (pendingExportsCopy.isNotEmpty) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'OtlpGrpcLogRecordExporter: Waiting for ${pendingExportsCopy.length} pending exports');
+      }
+      try {
+        await Future.wait(pendingExportsCopy)
+            .timeout(const Duration(seconds: 10), onTimeout: () {
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'OtlpGrpcLogRecordExporter: Timeout waiting for exports');
+          }
+          return Future.value([]);
+        });
+      } catch (e) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug('OtlpGrpcLogRecordExporter: Error during shutdown: $e');
+        }
+      }
+    }
+
+    await _cleanupChannel();
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OtlpGrpcLogRecordExporter: Shutdown complete');
+    }
+  }
+}

--- a/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter_config.dart
+++ b/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter_config.dart
@@ -1,0 +1,141 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import '../../../trace/export/otlp/certificate_utils.dart';
+
+/// Configuration for the OpenTelemetry log record exporter that exports logs using OTLP over gRPC.
+class OtlpGrpcLogRecordExporterConfig {
+  /// The endpoint to export logs to (e.g., 'localhost:4317').
+  /// Default: 'localhost:4317'
+  final String endpoint;
+
+  /// Additional gRPC headers to include in the export requests.
+  final Map<String, String> headers;
+
+  /// The timeout for export gRPC requests.
+  /// Default: 10 seconds
+  final Duration timeout;
+
+  /// Whether to use gzip compression for the gRPC messages.
+  /// Default: false
+  final bool compression;
+
+  /// Whether to use insecure credentials for the gRPC channel.
+  /// Default: true (for development)
+  final bool insecure;
+
+  /// Maximum number of retries for failed export requests.
+  /// Default: 3
+  final int maxRetries;
+
+  /// Base delay for exponential backoff when retrying.
+  /// Default: 100 milliseconds
+  final Duration baseDelay;
+
+  /// Maximum delay for exponential backoff when retrying.
+  /// Default: 1 second
+  final Duration maxDelay;
+
+  /// Path to the TLS certificate file for secure connections.
+  final String? certificate;
+
+  /// Path to the client key file for secure connections with client authentication.
+  final String? clientKey;
+
+  /// Path to the client certificate file for secure connections with client authentication.
+  final String? clientCertificate;
+
+  /// Creates a new configuration for the OTLP gRPC log record exporter.
+  ///
+  /// The endpoint should be in the format 'host:port'. Default port is 4317.
+  OtlpGrpcLogRecordExporterConfig({
+    String endpoint = 'localhost:4317',
+    Map<String, String>? headers,
+    Duration timeout = const Duration(seconds: 10),
+    this.compression = false,
+    this.insecure = true,
+    int maxRetries = 3,
+    Duration baseDelay = const Duration(milliseconds: 100),
+    Duration maxDelay = const Duration(seconds: 1),
+    this.certificate,
+    this.clientKey,
+    this.clientCertificate,
+  })  : endpoint = _validateEndpoint(endpoint),
+        headers = _validateHeaders(headers ?? {}),
+        timeout = _validateTimeout(timeout),
+        maxRetries = _validateRetries(maxRetries),
+        baseDelay = _validateDelay(baseDelay, 'baseDelay'),
+        maxDelay = _validateDelay(maxDelay, 'maxDelay') {
+    if (baseDelay.compareTo(maxDelay) > 0) {
+      throw ArgumentError('maxDelay cannot be less than baseDelay');
+    }
+    _validateCertificates(certificate, clientKey, clientCertificate);
+  }
+
+  static Map<String, String> _validateHeaders(Map<String, String> headers) {
+    final normalized = <String, String>{};
+    for (final entry in headers.entries) {
+      if (entry.key.isEmpty || entry.value.isEmpty) {
+        throw ArgumentError('Header keys and values cannot be empty');
+      }
+      normalized[entry.key.toLowerCase()] = entry.value;
+    }
+    return normalized;
+  }
+
+  static String _validateEndpoint(String endpoint) {
+    if (endpoint.isEmpty) {
+      throw ArgumentError('Endpoint cannot be empty');
+    }
+
+    endpoint = endpoint.trim();
+
+    if (endpoint.contains(' ')) {
+      throw ArgumentError('Endpoint cannot contain spaces: $endpoint');
+    }
+
+    // Strip http:// or https:// if present (gRPC endpoints don't use these)
+    endpoint = endpoint
+        .replaceAll(RegExp(r'^http://'), '')
+        .replaceAll(RegExp(r'^https://'), '');
+
+    // Add default port if not specified
+    if (!endpoint.contains(':')) {
+      endpoint = '$endpoint:4317';
+    }
+
+    return endpoint;
+  }
+
+  static Duration _validateTimeout(Duration timeout) {
+    if (timeout < const Duration(milliseconds: 1) ||
+        timeout > const Duration(minutes: 10)) {
+      throw ArgumentError('Timeout must be between 1ms and 10 minutes');
+    }
+    return timeout;
+  }
+
+  static int _validateRetries(int retries) {
+    if (retries < 0) {
+      throw ArgumentError('maxRetries cannot be negative');
+    }
+    return retries;
+  }
+
+  static Duration _validateDelay(Duration delay, String name) {
+    if (delay < const Duration(milliseconds: 1) ||
+        delay > const Duration(minutes: 5)) {
+      throw ArgumentError('$name must be between 1ms and 5 minutes');
+    }
+    return delay;
+  }
+
+  static void _validateCertificates(
+      String? cert, String? key, String? clientCert) {
+    CertificateUtils.validateCertificates(
+      certificate: cert,
+      clientKey: key,
+      clientCertificate: clientCert,
+    );
+  }
+}

--- a/lib/src/logs/export/simple_log_record_processor.dart
+++ b/lib/src/logs/export/simple_log_record_processor.dart
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+import '../log_record_processor.dart';
+import '../readable_log_record.dart';
+import 'log_record_exporter.dart';
+
+/// A simple LogRecordProcessor that exports log records immediately.
+///
+/// This processor passes finished log records to the configured LogRecordExporter
+/// as soon as they are emitted.
+///
+/// Use this processor for debugging or when immediate export is required.
+/// For production use, consider BatchLogRecordProcessor for better performance.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#simple-processor
+class SimpleLogRecordProcessor implements LogRecordProcessor {
+  /// The exporter used to send log records to the backend.
+  final LogRecordExporter exporter;
+
+  /// Whether the processor has been shut down.
+  bool _isShutdown = false;
+
+  /// Creates a new SimpleLogRecordProcessor with the specified exporter.
+  ///
+  /// @param exporter The LogRecordExporter to use for exporting log records
+  SimpleLogRecordProcessor(this.exporter);
+
+  @override
+  Future<void> onEmit(ReadWriteLogRecord logRecord, Context? context) async {
+    if (_isShutdown) {
+      return;
+    }
+
+    try {
+      final result = await exporter.export([logRecord]);
+      if (result == ExportResult.failure && OTelLog.isError()) {
+        OTelLog.error('SimpleLogRecordProcessor: Export failed');
+      }
+    } catch (e) {
+      if (OTelLog.isError()) {
+        OTelLog.error('SimpleLogRecordProcessor: Error exporting log: $e');
+      }
+    }
+  }
+
+  @override
+  bool enabled({
+    Context? context,
+    InstrumentationScope? instrumentationScope,
+    Severity? severityNumber,
+    String? eventName,
+  }) {
+    // Default to true - simple processor doesn't do filtering
+    return !_isShutdown;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    if (_isShutdown) {
+      return;
+    }
+
+    await exporter.forceFlush();
+  }
+
+  @override
+  Future<void> shutdown() async {
+    if (_isShutdown) {
+      return;
+    }
+
+    _isShutdown = true;
+
+    // Flush any pending exports
+    await forceFlush();
+
+    // Shutdown the exporter
+    await exporter.shutdown();
+  }
+}

--- a/lib/src/logs/log_record_processor.dart
+++ b/lib/src/logs/log_record_processor.dart
@@ -1,0 +1,63 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+import 'readable_log_record.dart';
+
+/// Interface for log record processors that handle log record lifecycle events.
+///
+/// Log record processors are invoked when a log record is emitted. They are
+/// responsible for performing additional processing on log records, such as
+/// filtering, batching, or exporting them.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordprocessor
+abstract class LogRecordProcessor {
+  /// Called when a log record is emitted.
+  ///
+  /// This method is called synchronously when a log record is emitted, allowing
+  /// for immediate processing of the log record. Implementations should be
+  /// lightweight and avoid blocking operations or excessive processing.
+  ///
+  /// The logRecord parameter is a ReadWriteLogRecord, allowing processors
+  /// to modify the log record. Mutations are visible in subsequent processors.
+  ///
+  /// @param logRecord The log record that was emitted (ReadWriteLogRecord)
+  /// @param context The context associated with the log record
+  Future<void> onEmit(ReadWriteLogRecord logRecord, Context? context);
+
+  /// Called to determine if the logger is enabled for a given configuration.
+  ///
+  /// This method supports filtering via Logger.enabled. It helps optimize
+  /// performance by allowing early filtering of log records.
+  ///
+  /// @param context The context (explicit or current)
+  /// @param instrumentationScope The instrumentation scope
+  /// @param severityNumber The severity number of the potential log
+  /// @param eventName The event name, if any
+  /// @return false if the log record should be filtered out, true otherwise
+  bool enabled({
+    Context? context,
+    InstrumentationScope? instrumentationScope,
+    Severity? severityNumber,
+    String? eventName,
+  }) {
+    // Default implementation returns true (indeterminate state)
+    return true;
+  }
+
+  /// Shuts down the log record processor.
+  ///
+  /// This method is called when the logger provider is shut down.
+  /// Implementations should release any resources they hold and perform
+  /// any final processing of log records.
+  Future<void> shutdown();
+
+  /// Forces the log record processor to flush any queued log records.
+  ///
+  /// This method is called when the logger provider's forceFlush method
+  /// is called. Implementations should ensure that any log records that have
+  /// been processed but not yet exported are exported immediately.
+  Future<void> forceFlush();
+}

--- a/lib/src/logs/logger.dart
+++ b/lib/src/logs/logger.dart
@@ -1,0 +1,248 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+library;
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:fixnum/fixnum.dart';
+
+import '../../dartastic_opentelemetry.dart';
+
+part 'logger_create.dart';
+
+/// SDK implementation of the APILogger interface.
+///
+/// The Logger is responsible for emitting log records. It holds a reference
+/// to the LoggerProvider to access resource, processors, and other configuration.
+///
+/// This implementation delegates some functionality to the API Logger
+/// implementation while adding SDK-specific behaviors like processor notification.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#logger
+class Logger implements APILogger {
+  /// The underlying API Logger implementation.
+  final APILogger _delegate;
+
+  /// The LoggerProvider that created this logger.
+  final LoggerProvider _provider;
+
+  /// Private constructor for creating Logger instances.
+  ///
+  /// @param delegate The API Logger implementation to delegate to
+  /// @param provider The LoggerProvider that created this logger
+  Logger._({
+    required APILogger delegate,
+    required LoggerProvider provider,
+  })  : _delegate = delegate,
+        _provider = provider {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('Logger: Created with name: ${delegate.name}');
+    }
+  }
+
+  /// Gets the LoggerProvider that created this logger.
+  LoggerProvider get provider => _provider;
+
+  /// Gets the resource associated with this logger.
+  Resource? get resource => _provider.resource;
+
+  @override
+  String get name => _delegate.name;
+
+  @override
+  String? get version => _delegate.version;
+
+  @override
+  String? get schemaUrl => _delegate.schemaUrl;
+
+  @override
+  Attributes? get attributes => _delegate.attributes;
+
+  @override
+  bool get enabled {
+    // Check if provider is enabled
+    if (!_provider.enabled || _provider.isShutdown) {
+      return false;
+    }
+
+    // Check if any processors are registered
+    if (_provider.logRecordProcessors.isEmpty) {
+      return false;
+    }
+
+    // Check if all processors return false for enabled
+    final allDisabled = _provider.logRecordProcessors.every(
+      (processor) => !processor.enabled(
+        instrumentationScope: OTel.instrumentationScope(
+          name: name,
+          version: version ?? '1.0.0',
+          schemaUrl: schemaUrl,
+          attributes: attributes,
+        ),
+      ),
+    );
+
+    return !allDisabled;
+  }
+
+  @override
+  void emit({
+    DateTime? timeStamp,
+    DateTime? observedTimestamp,
+    Context? context,
+    Severity? severityNumber,
+    String? severityText,
+    dynamic body,
+    Attributes? attributes,
+    String? eventName,
+  }) {
+    if (!enabled) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('Logger: emit called but logger is disabled');
+      }
+      return;
+    }
+
+    // Convert DateTime to nanoseconds since Unix epoch (Int64)
+    final timestampNanos = timeStamp != null
+        ? Int64(timeStamp.microsecondsSinceEpoch) * Int64(1000)
+        : null;
+
+    // Set observed timestamp to now if not provided
+    final observedNanos = observedTimestamp != null
+        ? Int64(observedTimestamp.microsecondsSinceEpoch) * Int64(1000)
+        : Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000);
+
+    // Use current context if not provided
+    final effectiveContext = context ?? Context.current;
+
+    // Create the instrumentation scope
+    final instrumentationScope = OTel.instrumentationScope(
+      name: name,
+      version: version ?? '1.0.0',
+      schemaUrl: schemaUrl,
+      attributes: this.attributes,
+    );
+
+    // Create the log record
+    final logRecord = SDKLogRecord(
+      instrumentationScope: instrumentationScope,
+      resource: _provider.resource,
+      timestamp: timestampNanos,
+      observedTimestamp: observedNanos,
+      context: effectiveContext,
+      severityNumber: severityNumber,
+      severityText: severityText,
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('Logger: Emitting log record: $logRecord');
+    }
+
+    // Notify all processors
+    for (final processor in _provider.logRecordProcessors) {
+      try {
+        processor.onEmit(logRecord, effectiveContext);
+      } catch (e) {
+        if (OTelLog.isError()) {
+          OTelLog.error(
+              'Logger: Error in processor ${processor.runtimeType}: $e');
+        }
+      }
+    }
+  }
+
+  /// Emits a log record with TRACE severity.
+  ///
+  /// @param body The log message body
+  /// @param attributes Optional attributes
+  /// @param eventName Optional event name
+  void trace(dynamic body, {Attributes? attributes, String? eventName}) {
+    emit(
+      severityNumber: Severity.TRACE,
+      severityText: 'TRACE',
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+  }
+
+  /// Emits a log record with DEBUG severity.
+  ///
+  /// @param body The log message body
+  /// @param attributes Optional attributes
+  /// @param eventName Optional event name
+  void debug(dynamic body, {Attributes? attributes, String? eventName}) {
+    emit(
+      severityNumber: Severity.DEBUG,
+      severityText: 'DEBUG',
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+  }
+
+  /// Emits a log record with INFO severity.
+  ///
+  /// @param body The log message body
+  /// @param attributes Optional attributes
+  /// @param eventName Optional event name
+  void info(dynamic body, {Attributes? attributes, String? eventName}) {
+    emit(
+      severityNumber: Severity.INFO,
+      severityText: 'INFO',
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+  }
+
+  /// Emits a log record with WARN severity.
+  ///
+  /// @param body The log message body
+  /// @param attributes Optional attributes
+  /// @param eventName Optional event name
+  void warn(dynamic body, {Attributes? attributes, String? eventName}) {
+    emit(
+      severityNumber: Severity.WARN,
+      severityText: 'WARN',
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+  }
+
+  /// Emits a log record with ERROR severity.
+  ///
+  /// @param body The log message body
+  /// @param attributes Optional attributes
+  /// @param eventName Optional event name
+  void error(dynamic body, {Attributes? attributes, String? eventName}) {
+    emit(
+      severityNumber: Severity.ERROR,
+      severityText: 'ERROR',
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+  }
+
+  /// Emits a log record with FATAL severity.
+  ///
+  /// @param body The log message body
+  /// @param attributes Optional attributes
+  /// @param eventName Optional event name
+  void fatal(dynamic body, {Attributes? attributes, String? eventName}) {
+    emit(
+      severityNumber: Severity.FATAL,
+      severityText: 'FATAL',
+      body: body,
+      attributes: attributes,
+      eventName: eventName,
+    );
+  }
+}

--- a/lib/src/logs/logger_create.dart
+++ b/lib/src/logs/logger_create.dart
@@ -1,0 +1,24 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+part of 'logger.dart';
+
+/// Factory for creating Logger instances.
+///
+/// This factory class provides a static create method for constructing
+/// properly configured Logger instances. It follows the factory
+/// pattern to separate the construction logic from the Logger
+/// class itself.
+class SDKLoggerCreate {
+  /// Creates a new Logger with the specified delegate and provider.
+  ///
+  /// @param delegate The API Logger implementation to delegate to
+  /// @param provider The LoggerProvider that created this logger
+  /// @return A new Logger instance
+  static Logger create({
+    required APILogger delegate,
+    required LoggerProvider provider,
+  }) {
+    return Logger._(delegate: delegate, provider: provider);
+  }
+}

--- a/lib/src/logs/logger_provider.dart
+++ b/lib/src/logs/logger_provider.dart
@@ -1,0 +1,269 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+library;
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+import '../../dartastic_opentelemetry.dart';
+
+part 'logger_provider_create.dart';
+
+/// SDK implementation of the APILoggerProvider interface.
+///
+/// The LoggerProvider is the entry point to the logging API. It is responsible
+/// for creating and managing Loggers, as well as configuring the logging
+/// pipeline via LogRecordProcessors and Exporters.
+///
+/// This implementation delegates some functionality to the API LoggerProvider
+/// implementation while adding SDK-specific behaviors like log processor management
+/// and resource association.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/
+class LoggerProvider implements APILoggerProvider {
+  /// Registry of loggers managed by this provider.
+  final Map<String, Logger> _loggers = {};
+
+  /// Log record processors registered with this provider.
+  final List<LogRecordProcessor> _logRecordProcessors = [];
+
+  /// The underlying API LoggerProvider implementation.
+  final APILoggerProvider _delegate;
+
+  /// The resource associated with this provider.
+  Resource? resource;
+
+  @override
+  bool get isShutdown => _delegate.isShutdown;
+
+  @override
+  set isShutdown(bool value) {
+    _delegate.isShutdown = value;
+  }
+
+  /// Private constructor for creating LoggerProvider instances.
+  ///
+  /// @param delegate The API LoggerProvider implementation to delegate to
+  /// @param resource Optional Resource describing the entity producing telemetry
+  LoggerProvider._({
+    required APILoggerProvider delegate,
+    this.resource,
+  }) : _delegate = delegate {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('LoggerProvider: Created with resource: $resource');
+      if (resource != null) {
+        OTelLog.debug('Resource attributes:');
+        resource!.attributes.toList().forEach((attr) {
+          OTelLog.debug('  ${attr.key}: ${attr.value}');
+        });
+      }
+    }
+  }
+
+  @override
+  Future<bool> shutdown() async {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'LoggerProvider: Shutting down with ${_logRecordProcessors.length} processors');
+    }
+
+    if (!isShutdown) {
+      // Shutdown all log record processors
+      for (final processor in _logRecordProcessors) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'LoggerProvider: Shutting down processor ${processor.runtimeType}');
+        }
+        try {
+          await processor.shutdown();
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'LoggerProvider: Successfully shut down processor ${processor.runtimeType}');
+          }
+        } catch (e) {
+          if (OTelLog.isDebug()) {
+            OTelLog.debug(
+                'LoggerProvider: Error shutting down processor ${processor.runtimeType}: $e');
+          }
+        }
+      }
+
+      // Clear cached loggers
+      _loggers.clear();
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('LoggerProvider: Cleared cached loggers');
+      }
+
+      try {
+        await _delegate.shutdown();
+        if (OTelLog.isDebug()) {
+          OTelLog.debug('LoggerProvider: Delegate shutdown complete');
+        }
+      } catch (e) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug('LoggerProvider: Error during delegate shutdown: $e');
+        }
+      }
+
+      isShutdown = true;
+      if (OTelLog.isDebug()) OTelLog.debug('LoggerProvider: Shutdown complete');
+    } else {
+      if (OTelLog.isDebug()) OTelLog.debug('LoggerProvider: Already shut down');
+    }
+    return isShutdown;
+  }
+
+  @override
+  Logger getLogger(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    Attributes? attributes,
+  }) {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'LoggerProvider: Getting logger with name: $name, version: $version, schemaUrl: $schemaUrl');
+    }
+    if (isShutdown) {
+      throw StateError('LoggerProvider has been shut down');
+    }
+
+    // Ensure resource is set before creating logger
+    ensureResourceIsSet();
+
+    final key = '$name:${version ?? ''}';
+    return _loggers.putIfAbsent(
+      key,
+      () => SDKLoggerCreate.create(
+        delegate: _delegate.getLogger(
+          name,
+          version: version,
+          schemaUrl: schemaUrl,
+          attributes: attributes,
+        ),
+        provider: this,
+      ),
+    );
+  }
+
+  /// Adds a log record processor to this provider.
+  ///
+  /// Log record processors are notified when log records are emitted and are
+  /// responsible for additional processing of logs, such as exporting them.
+  ///
+  /// @param processor The log record processor to add
+  void addLogRecordProcessor(LogRecordProcessor processor) {
+    if (isShutdown) {
+      throw StateError('LoggerProvider has been shut down');
+    }
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'LoggerProvider: Adding log record processor of type ${processor.runtimeType}');
+    }
+    _logRecordProcessors.add(processor);
+  }
+
+  /// Gets all registered log record processors.
+  ///
+  /// @return An unmodifiable list of all log record processors
+  List<LogRecordProcessor> get logRecordProcessors =>
+      List.unmodifiable(_logRecordProcessors);
+
+  /// Ensures the resource for this provider is properly set.
+  ///
+  /// If no resource has been set, the default resource will be used.
+  void ensureResourceIsSet() {
+    if (resource == null) {
+      resource = OTel.defaultResource;
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('LoggerProvider: Setting resource from default');
+        if (resource != null) {
+          OTelLog.debug('Resource attributes:');
+          resource!.attributes.toList().forEach((attr) {
+            if (attr.key == 'tenant_id' || attr.key == 'service.name') {
+              OTelLog.debug('  ${attr.key}: ${attr.value}');
+            }
+          });
+        }
+      }
+    }
+  }
+
+  @override
+  String get endpoint => _delegate.endpoint;
+
+  @override
+  set endpoint(String value) {
+    _delegate.endpoint = value;
+  }
+
+  @override
+  String get serviceName => _delegate.serviceName;
+
+  @override
+  set serviceName(String value) {
+    _delegate.serviceName = value;
+  }
+
+  @override
+  String? get serviceVersion => _delegate.serviceVersion;
+
+  @override
+  set serviceVersion(String? value) {
+    _delegate.serviceVersion = value;
+  }
+
+  @override
+  bool get enabled => _delegate.enabled;
+
+  @override
+  set enabled(bool value) {
+    _delegate.enabled = value;
+  }
+
+  /// Forces all log record processors to flush any queued log records.
+  ///
+  /// This method is useful for ensuring that all log records are exported
+  /// before the application terminates or when immediate visibility
+  /// of logs is required.
+  ///
+  /// @return A Future that completes when all processors have been flushed
+  Future<void> forceFlush() async {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'LoggerProvider: Force flushing ${_logRecordProcessors.length} processors');
+    }
+
+    if (isShutdown) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'LoggerProvider: Cannot force flush - provider is shut down');
+      }
+      return;
+    }
+
+    for (var processor in _logRecordProcessors) {
+      try {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'LoggerProvider: Flushing processor ${processor.runtimeType}');
+        }
+        await processor.forceFlush();
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'LoggerProvider: Successfully flushed processor ${processor.runtimeType}');
+        }
+      } catch (e) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'LoggerProvider: Error flushing processor ${processor.runtimeType}: $e');
+        }
+      }
+    }
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('LoggerProvider: Force flush complete');
+    }
+  }
+}

--- a/lib/src/logs/logger_provider_create.dart
+++ b/lib/src/logs/logger_provider_create.dart
@@ -1,0 +1,24 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+part of 'logger_provider.dart';
+
+/// Factory for creating LoggerProvider instances.
+///
+/// This factory class provides a static create method for constructing
+/// properly configured LoggerProvider instances. It follows the factory
+/// pattern to separate the construction logic from the LoggerProvider
+/// class itself.
+class SDKLoggerProviderCreate {
+  /// Creates a new LoggerProvider with the specified delegate and resource.
+  ///
+  /// @param delegate The API LoggerProvider implementation to delegate to
+  /// @param resource Optional Resource describing the entity producing telemetry
+  /// @return A new LoggerProvider instance
+  static LoggerProvider create({
+    required APILoggerProvider delegate,
+    Resource? resource,
+  }) {
+    return LoggerProvider._(delegate: delegate, resource: resource);
+  }
+}

--- a/lib/src/logs/readable_log_record.dart
+++ b/lib/src/logs/readable_log_record.dart
@@ -1,0 +1,349 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:fixnum/fixnum.dart';
+
+import '../../dartastic_opentelemetry.dart';
+
+/// A read-only view of a log record.
+///
+/// This interface provides read-only access to all LogRecord information
+/// for exporters and processors that only need to read the data.
+///
+/// Implementations can access InstrumentationScope and Resource implicitly.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#readablelogrecord
+abstract class ReadableLogRecord implements LogRecord {
+  /// The instrumentation scope associated with this log record.
+  InstrumentationScope get instrumentationScope;
+
+  /// The resource associated with this log record.
+  Resource? get resource;
+
+  /// The count of attributes that were dropped due to limits.
+  int get droppedAttributesCount;
+
+  /// The trace ID associated with this log record, if any.
+  TraceId? get traceId;
+
+  /// The span ID associated with this log record, if any.
+  SpanId? get spanId;
+
+  /// The trace flags associated with this log record, if any.
+  TraceFlags? get traceFlags;
+}
+
+/// A mutable view of a log record.
+///
+/// This interface extends ReadableLogRecord to provide write access to
+/// log record fields. It is used by LogRecordProcessors that need to
+/// modify log records.
+///
+/// Implementations are NOT required to be concurrent-safe. Asynchronous
+/// processors should clone the log record if needed.
+///
+/// More information:
+/// https://opentelemetry.io/docs/specs/otel/logs/sdk/#readwritelogrecord
+abstract class ReadWriteLogRecord implements ReadableLogRecord {
+  /// Sets the timestamp of when the event occurred.
+  set timestamp(Int64? value);
+
+  /// Sets the timestamp of when the event was observed.
+  set observedTimestamp(Int64? value);
+
+  /// Sets the severity number.
+  set severityNumber(Severity? value);
+
+  /// Sets the severity text.
+  set severityText(String? value);
+
+  /// Sets the body of the log record.
+  set body(dynamic value);
+
+  /// Sets the attributes of the log record.
+  set attributes(Attributes? value);
+
+  /// Sets the event name.
+  set eventName(String? value);
+
+  /// Sets the trace ID.
+  set traceId(TraceId? value);
+
+  /// Sets the span ID.
+  set spanId(SpanId? value);
+
+  /// Sets the trace flags.
+  set traceFlags(TraceFlags? value);
+
+  /// Adds an attribute to the log record.
+  ///
+  /// @param attribute The attribute to add
+  void addAttribute(Attribute attribute);
+
+  /// Removes an attribute from the log record by key.
+  ///
+  /// @param key The key of the attribute to remove
+  void removeAttribute(String key);
+
+  /// Creates a deep clone of this log record.
+  ///
+  /// This is useful for async processors that need to avoid race conditions.
+  ReadWriteLogRecord clone();
+}
+
+/// SDK implementation of ReadWriteLogRecord.
+///
+/// This class provides the concrete implementation of a log record with
+/// both read and write capabilities.
+class SDKLogRecord implements ReadWriteLogRecord {
+  Int64? _timestamp;
+  Int64? _observedTimestamp;
+  final Context? _context;
+  Severity? _severityNumber;
+  String? _severityText;
+  dynamic _body;
+  Attributes? _attributes;
+  String? _eventName;
+  TraceId? _traceId;
+  SpanId? _spanId;
+  TraceFlags? _traceFlags;
+  int _droppedAttributesCount = 0;
+
+  final InstrumentationScope _instrumentationScope;
+  Resource? _resource;
+
+  /// Maximum number of attributes allowed per log record.
+  /// This can be configured via LogRecordLimits.
+  static int maxAttributeCount = 128;
+
+  /// Maximum length of attribute values.
+  /// This can be configured via LogRecordLimits.
+  static int? maxAttributeValueLength;
+
+  /// Creates a new SDK log record.
+  ///
+  /// @param instrumentationScope The instrumentation scope for this log record
+  /// @param resource The resource associated with this log record
+  /// @param timestamp When the event occurred
+  /// @param observedTimestamp When the event was observed
+  /// @param context The context associated with this log record
+  /// @param severityNumber The severity level
+  /// @param severityText The severity text
+  /// @param body The log message body
+  /// @param attributes Additional attributes
+  /// @param eventName The event name
+  SDKLogRecord({
+    required InstrumentationScope instrumentationScope,
+    Resource? resource,
+    Int64? timestamp,
+    Int64? observedTimestamp,
+    Context? context,
+    Severity? severityNumber,
+    String? severityText,
+    dynamic body,
+    Attributes? attributes,
+    String? eventName,
+  })  : _instrumentationScope = instrumentationScope,
+        _resource = resource,
+        _timestamp = timestamp,
+        _observedTimestamp = observedTimestamp,
+        _context = context,
+        _severityNumber = severityNumber,
+        _severityText = severityText,
+        _body = body,
+        _attributes = attributes,
+        _eventName = eventName {
+    // Extract trace context from Context if available
+    if (_context != null) {
+      final spanContext = _context!.spanContext;
+      if (spanContext != null && spanContext.isValid) {
+        _traceId = spanContext.traceId;
+        _spanId = spanContext.spanId;
+        _traceFlags = spanContext.traceFlags;
+      }
+    }
+
+    // Apply attribute limits
+    _applyAttributeLimits();
+  }
+
+  void _applyAttributeLimits() {
+    if (_attributes == null) return;
+
+    final attrList = _attributes!.toList();
+    if (attrList.length > maxAttributeCount) {
+      final dropped = attrList.length - maxAttributeCount;
+      _droppedAttributesCount += dropped;
+      _attributes =
+          OTel.attributesFromList(attrList.take(maxAttributeCount).toList());
+
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'SDKLogRecord: Dropped $dropped attributes due to limit ($maxAttributeCount)');
+      }
+    }
+  }
+
+  @override
+  Int64? get timestamp => _timestamp;
+
+  @override
+  set timestamp(Int64? value) {
+    _timestamp = value;
+  }
+
+  @override
+  Int64? get observedTimestamp => _observedTimestamp;
+
+  @override
+  set observedTimestamp(Int64? value) {
+    _observedTimestamp = value;
+  }
+
+  @override
+  Context? get context => _context;
+
+  @override
+  Severity? get severityNumber => _severityNumber;
+
+  @override
+  set severityNumber(Severity? value) {
+    _severityNumber = value;
+  }
+
+  @override
+  String? get severityText => _severityText;
+
+  @override
+  set severityText(String? value) {
+    _severityText = value;
+  }
+
+  @override
+  dynamic get body => _body;
+
+  @override
+  set body(dynamic value) {
+    _body = value;
+  }
+
+  @override
+  Attributes? get attributes => _attributes;
+
+  @override
+  set attributes(Attributes? value) {
+    _attributes = value;
+    _applyAttributeLimits();
+  }
+
+  @override
+  String? get eventName => _eventName;
+
+  @override
+  set eventName(String? value) {
+    _eventName = value;
+  }
+
+  @override
+  InstrumentationScope get instrumentationScope => _instrumentationScope;
+
+  @override
+  Resource? get resource => _resource;
+
+  /// Sets the resource for this log record.
+  set resource(Resource? value) {
+    _resource = value;
+  }
+
+  @override
+  int get droppedAttributesCount => _droppedAttributesCount;
+
+  @override
+  TraceId? get traceId => _traceId;
+
+  @override
+  set traceId(TraceId? value) {
+    _traceId = value;
+  }
+
+  @override
+  SpanId? get spanId => _spanId;
+
+  @override
+  set spanId(SpanId? value) {
+    _spanId = value;
+  }
+
+  @override
+  TraceFlags? get traceFlags => _traceFlags;
+
+  @override
+  set traceFlags(TraceFlags? value) {
+    _traceFlags = value;
+  }
+
+  @override
+  void addAttribute(Attribute attribute) {
+    if (_attributes == null) {
+      _attributes = OTel.attributesFromList([attribute]);
+    } else {
+      final currentList = _attributes!.toList();
+      if (currentList.length >= maxAttributeCount) {
+        _droppedAttributesCount++;
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'SDKLogRecord: Dropped attribute ${attribute.key} due to limit');
+        }
+        return;
+      }
+      _attributes = OTel.attributesFromList([...currentList, attribute]);
+    }
+  }
+
+  @override
+  void removeAttribute(String key) {
+    if (_attributes == null) return;
+    final filtered = _attributes!.toList().where((a) => a.key != key).toList();
+    _attributes = OTel.attributesFromList(filtered);
+  }
+
+  @override
+  ReadWriteLogRecord clone() {
+    return SDKLogRecord(
+      instrumentationScope: _instrumentationScope,
+      resource: _resource,
+      timestamp: _timestamp,
+      observedTimestamp: _observedTimestamp,
+      context: _context,
+      severityNumber: _severityNumber,
+      severityText: _severityText,
+      body: _body,
+      attributes: _attributes,
+      eventName: _eventName,
+    )
+      .._traceId = _traceId
+      .._spanId = _spanId
+      .._traceFlags = _traceFlags
+      .._droppedAttributesCount = _droppedAttributesCount;
+  }
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('SDKLogRecord{');
+    buffer.write('timestamp: $timestamp');
+    buffer.write(', observedTimestamp: $observedTimestamp');
+    buffer.write(', severity: $severityNumber');
+    if (severityText != null) buffer.write(' ($severityText)');
+    if (body != null) buffer.write(', body: $body');
+    if (eventName != null) buffer.write(', eventName: $eventName');
+    if (traceId != null) buffer.write(', traceId: $traceId');
+    if (spanId != null) buffer.write(', spanId: $spanId');
+    if (attributes != null && attributes!.length > 0) {
+      buffer.write(', attributes: ${attributes!.length} items');
+    }
+    buffer.write('}');
+    return buffer.toString();
+  }
+}

--- a/lib/src/metrics/data/exemplar.dart
+++ b/lib/src/metrics/data/exemplar.dart
@@ -51,8 +51,9 @@ class Exemplar {
   }) {
     // Determine which attributes are filtered out
     final filteredAttrs = _filterAttributes(
-        measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
-        aggregationAttributes);
+      measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
+      aggregationAttributes,
+    );
 
     return Exemplar(
       attributes: aggregationAttributes,
@@ -66,7 +67,9 @@ class Exemplar {
 
   /// Filters attributes to get those that are not included in the aggregation.
   static Attributes _filterAttributes(
-      Attributes measurementAttrs, Attributes aggregationAttrs) {
+    Attributes measurementAttrs,
+    Attributes aggregationAttrs,
+  ) {
     final result = <Attribute<Object>>[];
 
     // Get the attribute keys that are in the measurement but not in the aggregation

--- a/lib/src/metrics/data/metric_data.dart
+++ b/lib/src/metrics/data/metric_data.dart
@@ -13,10 +13,7 @@ class MetricData {
   final List<Metric> metrics;
 
   /// Creates a new MetricData instance.
-  MetricData({
-    this.resource,
-    required this.metrics,
-  });
+  MetricData({this.resource, required this.metrics});
 
   /// Creates an empty MetricData instance.
   factory MetricData.empty() {

--- a/lib/src/metrics/export/composite_metric_exporter.dart
+++ b/lib/src/metrics/export/composite_metric_exporter.dart
@@ -43,7 +43,8 @@ class CompositeMetricExporter implements MetricExporter {
     if (_shutdown) {
       if (OTelLog.isLogExport()) {
         OTelLog.logExport(
-            'CompositeMetricExporter: Cannot export after shutdown');
+          'CompositeMetricExporter: Cannot export after shutdown',
+        );
       }
       return false;
     }
@@ -56,7 +57,8 @@ class CompositeMetricExporter implements MetricExporter {
       } catch (e) {
         if (OTelLog.isLogExport()) {
           OTelLog.logExport(
-              'CompositeMetricExporter: Export failed for $exporter: $e');
+            'CompositeMetricExporter: Export failed for $exporter: $e',
+          );
         }
         success = false;
       }

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -60,9 +60,6 @@ class MetricsConfiguration {
     );
 
     // Use a composite exporter for both OTLP and Console output
-    return CompositeMetricExporter([
-      otlpExporter,
-      ConsoleMetricExporter(),
-    ]);
+    return CompositeMetricExporter([otlpExporter, ConsoleMetricExporter()]);
   }
 }

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
@@ -70,7 +70,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
     } catch (e) {
       if (OTelLog.isError()) {
         OTelLog.error(
-            'OtlpHttpMetricExporter: Failed to create HTTP client with certificates: $e');
+          'OtlpHttpMetricExporter: Failed to create HTTP client with certificates: $e',
+        );
       }
       // Fall back to default client on error
       return http.Client();
@@ -112,7 +113,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpMetricExporter: Beginning export of ${metrics.metrics.length} metrics');
+        'OtlpHttpMetricExporter: Beginning export of ${metrics.metrics.length} metrics',
+      );
     }
 
     try {
@@ -128,7 +130,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         // Gracefully handle the case where shutdown interrupted the export
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: Export was interrupted by shutdown, suppressing error');
+            'OtlpHttpMetricExporter: Export was interrupted by shutdown, suppressing error',
+          );
         }
         return false;
       } else {
@@ -145,7 +148,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpMetricExporter: Attempting to export ${metrics.metrics.length} metrics to ${_config.endpoint}');
+        'OtlpHttpMetricExporter: Attempting to export ${metrics.metrics.length} metrics to ${_config.endpoint}',
+      );
     }
 
     var attempts = 0;
@@ -160,7 +164,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         if (wasShutdownDuringRetry && attempts > 0) {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'OtlpHttpMetricExporter: Export interrupted by shutdown');
+              'OtlpHttpMetricExporter: Export interrupted by shutdown',
+            );
           }
           throw StateError('Exporter was shut down during export');
         }
@@ -168,7 +173,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         final success = await _tryExport(metrics);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: Successfully exported metrics');
+            'OtlpHttpMetricExporter: Successfully exported metrics',
+          );
         }
         return success;
       } on http.ClientException catch (e, stackTrace) {
@@ -181,7 +187,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         if (wasShutdownDuringRetry) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpHttpMetricExporter: Export interrupted by shutdown');
+              'OtlpHttpMetricExporter: Export interrupted by shutdown',
+            );
           }
           throw StateError('Exporter was shut down during export');
         }
@@ -200,7 +207,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         if (!shouldRetry) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpHttpMetricExporter: Non-retryable HTTP error, stopping retry attempts');
+              'OtlpHttpMetricExporter: Non-retryable HTTP error, stopping retry attempts',
+            );
           }
           return false;
         }
@@ -208,7 +216,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         if (attempts >= maxAttempts - 1) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpHttpMetricExporter: Max attempts reached ($attempts out of $maxAttempts), giving up');
+              'OtlpHttpMetricExporter: Max attempts reached ($attempts out of $maxAttempts), giving up',
+            );
           }
           return false;
         }
@@ -216,14 +225,16 @@ class OtlpHttpMetricExporter implements MetricExporter {
         final delay = _calculateJitteredDelay(attempts);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: Retrying export after ${delay.inMilliseconds}ms...');
+            'OtlpHttpMetricExporter: Retrying export after ${delay.inMilliseconds}ms...',
+          );
         }
         await Future<void>.delayed(delay);
         attempts++;
       } catch (e, stackTrace) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'OtlpHttpMetricExporter: Unexpected error during export: $e');
+            'OtlpHttpMetricExporter: Unexpected error during export: $e',
+          );
         }
         if (OTelLog.isError()) OTelLog.error('Stack trace: $stackTrace');
 
@@ -239,7 +250,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         final delay = _calculateJitteredDelay(attempts);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: Retrying export after ${delay.inMilliseconds}ms...');
+            'OtlpHttpMetricExporter: Retrying export after ${delay.inMilliseconds}ms...',
+          );
         }
         await Future<void>.delayed(delay);
         attempts++;
@@ -256,12 +268,14 @@ class OtlpHttpMetricExporter implements MetricExporter {
 
     if (OTelLog.isLogMetrics()) {
       OTelLog.logMetric(
-          "Exporting metrics via HTTP: ${metrics.metrics.length} metrics");
+        "Exporting metrics via HTTP: ${metrics.metrics.length} metrics",
+      );
     }
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpMetricExporter: Preparing to export ${metrics.metrics.length} metrics');
+        'OtlpHttpMetricExporter: Preparing to export ${metrics.metrics.length} metrics',
+      );
     }
 
     if (OTelLog.isDebug()) {
@@ -274,11 +288,13 @@ class OtlpHttpMetricExporter implements MetricExporter {
 
     // Add resource
     if (metrics.resource != null) {
-      resourceMetrics.resource =
-          MetricTransformer.transformResource(metrics.resource!);
+      resourceMetrics.resource = MetricTransformer.transformResource(
+        metrics.resource!,
+      );
     } else {
-      resourceMetrics.resource =
-          MetricTransformer.transformResource(OTel.resource(null));
+      resourceMetrics.resource = MetricTransformer.transformResource(
+        OTel.resource(null),
+      );
     }
 
     // Create scope metrics
@@ -329,22 +345,20 @@ class OtlpHttpMetricExporter implements MetricExporter {
     final endpointUrl = _getEndpointUrl();
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpMetricExporter: Sending export request to $endpointUrl');
+        'OtlpHttpMetricExporter: Sending export request to $endpointUrl',
+      );
     }
 
     try {
       final http.Response response = await _client
-          .post(
-            Uri.parse(endpointUrl),
-            headers: headers,
-            body: bodyBytes,
-          )
+          .post(Uri.parse(endpointUrl), headers: headers, body: bodyBytes)
           .timeout(_config.timeout);
 
       if (response.statusCode >= 200 && response.statusCode < 300) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: Export request completed successfully');
+            'OtlpHttpMetricExporter: Export request completed successfully',
+          );
         }
         return true;
       } else {
@@ -373,7 +387,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpHttpMetricExporter: Exporter is already shut down, nothing to flush');
+          'OtlpHttpMetricExporter: Exporter is already shut down, nothing to flush',
+        );
       }
       return true;
     }
@@ -382,13 +397,15 @@ class OtlpHttpMetricExporter implements MetricExporter {
     if (_pendingExports.isNotEmpty) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpHttpMetricExporter: Waiting for ${_pendingExports.length} pending exports to complete');
+          'OtlpHttpMetricExporter: Waiting for ${_pendingExports.length} pending exports to complete',
+        );
       }
       try {
         await Future.wait(_pendingExports);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: All pending exports completed');
+            'OtlpHttpMetricExporter: All pending exports completed',
+          );
         }
         return true;
       } catch (e) {
@@ -415,7 +432,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
     }
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpMetricExporter: Shutting down - waiting for ${_pendingExports.length} pending exports');
+        'OtlpHttpMetricExporter: Shutting down - waiting for ${_pendingExports.length} pending exports',
+      );
     }
 
     // Set shutdown flag first
@@ -429,22 +447,27 @@ class OtlpHttpMetricExporter implements MetricExporter {
     if (pendingExportsCopy.isNotEmpty) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpHttpMetricExporter: Waiting for ${pendingExportsCopy.length} pending exports with timeout');
+          'OtlpHttpMetricExporter: Waiting for ${pendingExportsCopy.length} pending exports with timeout',
+        );
       }
       try {
         // Use a generous timeout but don't wait forever
-        await Future.wait(pendingExportsCopy)
-            .timeout(const Duration(seconds: 10), onTimeout: () {
-          if (OTelLog.isDebug()) {
-            OTelLog.debug(
-                'OtlpHttpMetricExporter: Timeout waiting for exports to complete');
-          }
-          return Future.value([]);
-        });
+        await Future.wait(pendingExportsCopy).timeout(
+          const Duration(seconds: 10),
+          onTimeout: () {
+            if (OTelLog.isDebug()) {
+              OTelLog.debug(
+                'OtlpHttpMetricExporter: Timeout waiting for exports to complete',
+              );
+            }
+            return Future.value([]);
+          },
+        );
       } catch (e) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpMetricExporter: Error during shutdown while waiting for exports: $e');
+            'OtlpHttpMetricExporter: Error during shutdown while waiting for exports: $e',
+          );
         }
         // Don't return false here - we still want to close the client
       }

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter_config.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter_config.dart
@@ -152,7 +152,10 @@ class OtlpHttpMetricExporterConfig {
   }
 
   static void _validateCertificates(
-      String? cert, String? key, String? clientCert) {
+    String? cert,
+    String? key,
+    String? clientCert,
+  ) {
     CertificateUtils.validateCertificates(
       certificate: cert,
       clientKey: key,

--- a/lib/src/metrics/export/otlp/metric_transformer.dart
+++ b/lib/src/metrics/export/otlp/metric_transformer.dart
@@ -20,10 +20,9 @@ class MetricTransformer {
     final attributes = resource.attributes;
 
     resourceProto.attributes.addAll(
-      attributes
-          .toMap()
-          .entries
-          .map((entry) => _createKeyValue(entry.key, entry.value.value)),
+      attributes.toMap().entries.map(
+            (entry) => _createKeyValue(entry.key, entry.value.value),
+          ),
     );
 
     return resourceProto;
@@ -44,7 +43,8 @@ class MetricTransformer {
 
     if (OTelLog.isLogMetrics()) {
       OTelLog.logMetric(
-          'MetricTransformer: Transforming metric ${metric.name} of type ${metric.type}');
+        'MetricTransformer: Transforming metric ${metric.name} of type ${metric.type}',
+      );
     }
 
     // Set data based on metric type
@@ -112,7 +112,8 @@ class MetricTransformer {
 
   /// Creates a histogram data point for the given MetricPoint.
   static proto.HistogramDataPoint _createHistogramDataPoint(
-      MetricPoint<dynamic> point) {
+    MetricPoint<dynamic> point,
+  ) {
     final histogramValue = point.value as HistogramValue;
 
     // Prepare attributes
@@ -154,7 +155,8 @@ class MetricTransformer {
 
   /// Creates a number data point for the given MetricPoint.
   static proto.NumberDataPoint _createNumberDataPoint(
-      MetricPoint<dynamic> point) {
+    MetricPoint<dynamic> point,
+  ) {
     // Prepare attributes
     final attributes = point.attributes.toMap();
     final attributeKeyValues = attributes.entries

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
@@ -29,7 +29,8 @@ class OtlpGrpcMetricExporter implements MetricExporter {
   /// If insecure is true, returns insecure credentials.
   /// Otherwise, creates secure credentials with optional custom certificates for mTLS.
   static ChannelCredentials _createChannelCredentials(
-      OtlpGrpcMetricExporterConfig config) {
+    OtlpGrpcMetricExporterConfig config,
+  ) {
     if (config.insecure) {
       return const ChannelCredentials.insecure();
     }
@@ -60,7 +61,8 @@ class OtlpGrpcMetricExporter implements MetricExporter {
     } catch (e) {
       if (OTelLog.isError()) {
         OTelLog.error(
-            'OtlpGrpcMetricExporter: Failed to load certificates: $e');
+          'OtlpGrpcMetricExporter: Failed to load certificates: $e',
+        );
       }
       // Fall back to default secure credentials on error
       return const ChannelCredentials.secure();
@@ -68,7 +70,8 @@ class OtlpGrpcMetricExporter implements MetricExporter {
   }
 
   static MetricsServiceClient _createClient(
-      OtlpGrpcMetricExporterConfig config) {
+    OtlpGrpcMetricExporterConfig config,
+  ) {
     final channelOptions = ChannelOptions(
       credentials: _createChannelCredentials(config),
       codecRegistry: CodecRegistry(codecs: const [GzipCodec()]),
@@ -82,15 +85,12 @@ class OtlpGrpcMetricExporter implements MetricExporter {
 
     if (OTelLog.isLogExport()) {
       OTelLog.logExport(
-          'OtlpGrpcMetricExporter: Creating client for $host:$port');
+        'OtlpGrpcMetricExporter: Creating client for $host:$port',
+      );
     }
 
     // We store the channel separately to be able to shut it down later
-    _channel = ClientChannel(
-      host,
-      port: port,
-      options: channelOptions,
-    );
+    _channel = ClientChannel(host, port: port, options: channelOptions);
 
     // Build call options with headers and compression
     final callOptionsBuilder = CallOptions(
@@ -121,7 +121,8 @@ class OtlpGrpcMetricExporter implements MetricExporter {
     if (_shutdown) {
       if (OTelLog.isLogExport()) {
         OTelLog.logExport(
-            'OtlpGrpcMetricExporter: Cannot export after shutdown');
+          'OtlpGrpcMetricExporter: Cannot export after shutdown',
+        );
       }
       return false;
     }
@@ -136,10 +137,12 @@ class OtlpGrpcMetricExporter implements MetricExporter {
     try {
       if (OTelLog.isLogExport()) {
         OTelLog.logExport(
-            'OtlpGrpcMetricExporter: Exporting ${data.metrics.length} metrics');
+          'OtlpGrpcMetricExporter: Exporting ${data.metrics.length} metrics',
+        );
         for (final metric in data.metrics) {
           OTelLog.logExport(
-              '  - ${metric.name} (${metric.type}): ${metric.points.length} data points');
+            '  - ${metric.name} (${metric.type}): ${metric.points.length} data points',
+          );
         }
       }
 
@@ -169,18 +172,21 @@ class OtlpGrpcMetricExporter implements MetricExporter {
 
     // Add resource
     if (data.resource != null) {
-      resourceMetrics.resource =
-          MetricTransformer.transformResource(data.resource!);
+      resourceMetrics.resource = MetricTransformer.transformResource(
+        data.resource!,
+      );
     } else {
       // Create empty resource if none provided
-      resourceMetrics.resource =
-          MetricTransformer.transformResource(OTel.resource(null));
+      resourceMetrics.resource = MetricTransformer.transformResource(
+        OTel.resource(null),
+      );
     }
 
     // Add scope metrics
     final scopeMetrics = proto.ScopeMetrics();
-    scopeMetrics.metrics
-        .addAll(data.metrics.map(MetricTransformer.transformMetric));
+    scopeMetrics.metrics.addAll(
+      data.metrics.map(MetricTransformer.transformMetric),
+    );
 
     // Add instrumentation scope (hardcoded for now)
     final scope = common_proto.InstrumentationScope();

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter_config.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter_config.dart
@@ -44,7 +44,10 @@ class OtlpGrpcMetricExporterConfig {
   }
 
   static void _validateCertificates(
-      String? cert, String? key, String? clientCert) {
+    String? cert,
+    String? key,
+    String? clientCert,
+  ) {
     CertificateUtils.validateCertificates(
       certificate: cert,
       clientKey: key,

--- a/lib/src/metrics/export/prometheus/prometheus_exporter.dart
+++ b/lib/src/metrics/export/prometheus/prometheus_exporter.dart
@@ -72,7 +72,8 @@ class PrometheusExporter implements MetricExporter {
     try {
       if (OTelLog.isLogExport()) {
         OTelLog.logExport(
-            'PrometheusExporter: Exporting ${data.metrics.length} metrics');
+          'PrometheusExporter: Exporting ${data.metrics.length} metrics',
+        );
       }
 
       // Convert metrics to Prometheus format
@@ -98,12 +99,14 @@ class PrometheusExporter implements MetricExporter {
       // Add HELP comment
       if (metric.description != null) {
         buffer.writeln(
-            '# HELP ${_sanitizeName(metric.name)} ${_sanitizeComment(metric.description!)}');
+          '# HELP ${_sanitizeName(metric.name)} ${_sanitizeComment(metric.description!)}',
+        );
       }
 
       // Add TYPE comment
       buffer.writeln(
-          '# TYPE ${_sanitizeName(metric.name)} ${_getPrometheusType(metric)}');
+        '# TYPE ${_sanitizeName(metric.name)} ${_getPrometheusType(metric)}',
+      );
 
       // Add metric data points
       for (final point in metric.points) {
@@ -119,7 +122,10 @@ class PrometheusExporter implements MetricExporter {
 
   /// Writes a metric point in Prometheus format.
   void _writeMetricPoint(
-      StringBuffer buffer, Metric metric, MetricPoint<dynamic> point) {
+    StringBuffer buffer,
+    Metric metric,
+    MetricPoint<dynamic> point,
+  ) {
     final metricName = _sanitizeName(metric.name);
 
     // Add labels
@@ -140,12 +146,14 @@ class PrometheusExporter implements MetricExporter {
         final boundary = histogram.boundaries[i];
         final count = histogram.bucketCounts[i];
         buffer.writeln(
-            '${metricName}_bucket{${_formatLabelsWithLe(point.attributes.toMap(), boundary)}} $count');
+          '${metricName}_bucket{${_formatLabelsWithLe(point.attributes.toMap(), boundary)}} $count',
+        );
       }
 
       // Add +Inf bucket
       buffer.writeln(
-          '${metricName}_bucket{${_formatLabelsWithLe(point.attributes.toMap(), double.infinity)}} ${histogram.count}');
+        '${metricName}_bucket{${_formatLabelsWithLe(point.attributes.toMap(), double.infinity)}} ${histogram.count}',
+      );
     } else {
       // Simple metrics (counters, gauges)
       buffer.writeln('$metricName$labels ${point.value}');
@@ -216,9 +224,10 @@ class PrometheusExporter implements MetricExporter {
     if (value.toString().startsWith('AttributeValue(') &&
         value.toString().endsWith(')')) {
       // Extract the value inside AttributeValue(...)
-      final rawValue = value
-          .toString()
-          .substring('AttributeValue('.length, value.toString().length - 1);
+      final rawValue = value.toString().substring(
+            'AttributeValue('.length,
+            value.toString().length - 1,
+          );
       value = rawValue;
     }
 

--- a/lib/src/metrics/instruments/counter.dart
+++ b/lib/src/metrics/instruments/counter.dart
@@ -38,10 +38,8 @@ class Counter<T extends num> implements APICounter<T>, SDKInstrument {
   ///
   /// @param apiCounter The API Counter to delegate API calls to
   /// @param meter The Meter that created this Counter
-  Counter({
-    required APICounter<T> apiCounter,
-    required Meter meter,
-  })  : _apiCounter = apiCounter,
+  Counter({required APICounter<T> apiCounter, required Meter meter})
+      : _apiCounter = apiCounter,
         _meter = meter {
     _meter.provider.registerInstrument(_meter.name, this);
   }

--- a/lib/src/metrics/instruments/gauge.dart
+++ b/lib/src/metrics/instruments/gauge.dart
@@ -24,10 +24,8 @@ class Gauge<T extends num> implements APIGauge<T>, SDKInstrument {
   final GaugeStorage<T> _storage = GaugeStorage<T>();
 
   /// Creates a new Gauge instance.
-  Gauge({
-    required APIGauge<T> apiGauge,
-    required Meter meter,
-  })  : _apiGauge = apiGauge,
+  Gauge({required APIGauge<T> apiGauge, required Meter meter})
+      : _apiGauge = apiGauge,
         _meter = meter {
     // Register this instrument with the meter provider
     _meter.provider.registerInstrument(_meter.name, this);

--- a/lib/src/metrics/instruments/histogram.dart
+++ b/lib/src/metrics/instruments/histogram.dart
@@ -54,7 +54,7 @@ class Histogram<T extends num> implements APIHistogram<T>, SDKInstrument {
     2500,
     5000,
     7500,
-    10000
+    10000,
   ];
 
   @override

--- a/lib/src/metrics/instruments/observable_counter.dart
+++ b/lib/src/metrics/instruments/observable_counter.dart
@@ -77,9 +77,10 @@ class ObservableCounter<T extends num>
 
     if (attributes == null) {
       // For no attributes, sum all points
-      value = _storage
-          .collectPoints()
-          .fold<num>(0, (sum, point) => sum + point.value);
+      value = _storage.collectPoints().fold<num>(
+            0,
+            (sum, point) => sum + point.value,
+          );
     } else {
       // For specific attributes, get that value
       value = _storage.getValue(attributes);
@@ -189,7 +190,8 @@ class ObservableCounter<T extends num>
         }
       } catch (e) {
         print(
-            'Error collecting measurements from ObservableCounter callback: $e');
+          'Error collecting measurements from ObservableCounter callback: $e',
+        );
       }
     }
 
@@ -220,7 +222,7 @@ class ObservableCounter<T extends num>
         temporality: AggregationTemporality.cumulative,
         points: points,
         isMonotonic: true, // Counters are monotonic
-      )
+      ),
     ];
   }
 

--- a/lib/src/metrics/instruments/observable_gauge.dart
+++ b/lib/src/metrics/instruments/observable_gauge.dart
@@ -142,7 +142,8 @@ class ObservableGauge<T extends num>
         }
       } catch (e) {
         print(
-            'Error collecting measurements from ObservableGauge callback: $e');
+          'Error collecting measurements from ObservableGauge callback: $e',
+        );
       }
     }
 
@@ -171,7 +172,7 @@ class ObservableGauge<T extends num>
         description: description,
         unit: unit,
         points: points,
-      )
+      ),
     ];
   }
 

--- a/lib/src/metrics/instruments/observable_up_down_counter.dart
+++ b/lib/src/metrics/instruments/observable_up_down_counter.dart
@@ -77,9 +77,10 @@ class ObservableUpDownCounter<T extends num>
 
     if (attributes == null) {
       // For no attributes, sum all points
-      value = _storage
-          .collectPoints()
-          .fold<num>(0, (sum, point) => sum + point.value);
+      value = _storage.collectPoints().fold<num>(
+            0,
+            (sum, point) => sum + point.value,
+          );
     } else {
       // For specific attributes, get that value
       value = _storage.getValue(attributes);
@@ -160,7 +161,8 @@ class ObservableUpDownCounter<T extends num>
         }
       } catch (e) {
         print(
-            'Error collecting measurements from ObservableUpDownCounter callback: $e');
+          'Error collecting measurements from ObservableUpDownCounter callback: $e',
+        );
       }
     }
 
@@ -202,7 +204,7 @@ class ObservableUpDownCounter<T extends num>
         temporality: AggregationTemporality.cumulative,
         points: points,
         isMonotonic: false, // Up/down counters are non-monotonic
-      )
+      ),
     ];
   }
 

--- a/lib/src/metrics/instruments/up_down_counter.dart
+++ b/lib/src/metrics/instruments/up_down_counter.dart
@@ -25,10 +25,8 @@ class UpDownCounter<T extends num>
   final SumStorage<T> _storage = SumStorage<T>(isMonotonic: false);
 
   /// Creates a new UpDownCounter instance.
-  UpDownCounter({
-    required APIUpDownCounter<T> apiCounter,
-    required Meter meter,
-  })  : _apiCounter = apiCounter,
+  UpDownCounter({required APIUpDownCounter<T> apiCounter, required Meter meter})
+      : _apiCounter = apiCounter,
         _meter = meter {
     // Register this instrument with the meter provider
     _meter.provider.registerInstrument(_meter.name, this);

--- a/lib/src/metrics/meter.dart
+++ b/lib/src/metrics/meter.dart
@@ -38,10 +38,8 @@ class Meter implements APIMeter {
   ///
   /// @param delegate The API Meter implementation to delegate to
   /// @param provider The MeterProvider that created this Meter
-  Meter._({
-    required APIMeter delegate,
-    required MeterProvider provider,
-  })  : _delegate = delegate,
+  Meter._({required APIMeter delegate, required MeterProvider provider})
+      : _delegate = delegate,
         _provider = provider;
 
   /// Gets the name of the instrumentation scope.
@@ -95,17 +93,20 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#counter
   @override
-  APICounter<T> createCounter<T extends num>(
-      {required String name, String? unit, String? description}) {
+  APICounter<T> createCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+  }) {
     // First call the API implementation to get the API object
     final apiCounter = _delegate.createCounter<T>(
-        name: name, unit: unit, description: description);
+      name: name,
+      unit: unit,
+      description: description,
+    );
 
     // Now wrap it with our SDK implementation
-    return Counter<T>(
-      apiCounter: apiCounter,
-      meter: this,
-    );
+    return Counter<T>(apiCounter: apiCounter, meter: this);
   }
 
   /// Creates an UpDownCounter instrument for recording cumulative values that can increase or decrease.
@@ -121,17 +122,20 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
   @override
-  APIUpDownCounter<T> createUpDownCounter<T extends num>(
-      {required String name, String? unit, String? description}) {
+  APIUpDownCounter<T> createUpDownCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+  }) {
     // First call the API implementation to get the API object
     final apiCounter = _delegate.createUpDownCounter<T>(
-        name: name, unit: unit, description: description);
+      name: name,
+      unit: unit,
+      description: description,
+    );
 
     // Now wrap it with our SDK implementation
-    return UpDownCounter<T>(
-      apiCounter: apiCounter,
-      meter: this,
-    );
+    return UpDownCounter<T>(apiCounter: apiCounter, meter: this);
   }
 
   /// Creates a Histogram instrument for recording a distribution of values.
@@ -149,17 +153,19 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram
   @override
-  APIHistogram<T> createHistogram<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      List<double>? boundaries}) {
+  APIHistogram<T> createHistogram<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    List<double>? boundaries,
+  }) {
     // First call the API implementation to get the API object
     final apiHistogram = _delegate.createHistogram<T>(
-        name: name,
-        unit: unit,
-        description: description,
-        boundaries: boundaries);
+      name: name,
+      unit: unit,
+      description: description,
+      boundaries: boundaries,
+    );
 
     // Now wrap it with our SDK implementation
     return Histogram<T>(
@@ -182,17 +188,20 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge
   @override
-  APIGauge<T> createGauge<T extends num>(
-      {required String name, String? unit, String? description}) {
+  APIGauge<T> createGauge<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+  }) {
     // First call the API implementation to get the API object
     final apiGauge = _delegate.createGauge<T>(
-        name: name, unit: unit, description: description);
+      name: name,
+      unit: unit,
+      description: description,
+    );
 
     // Now wrap it with our SDK implementation
-    return Gauge<T>(
-      apiGauge: apiGauge,
-      meter: this,
-    );
+    return Gauge<T>(apiGauge: apiGauge, meter: this);
   }
 
   /// Creates an ObservableCounter instrument for asynchronously recording cumulative, monotonically increasing values.
@@ -210,11 +219,12 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-counter
   @override
-  APIObservableCounter<T> createObservableCounter<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      ObservableCallback<T>? callback}) {
+  APIObservableCounter<T> createObservableCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    ObservableCallback<T>? callback,
+  }) {
     // First call the API implementation to get the API object
     final apiCounter = _delegate.createObservableCounter<T>(
       name: name,
@@ -224,10 +234,7 @@ class Meter implements APIMeter {
     );
 
     // Now wrap it with our SDK implementation
-    final counter = ObservableCounter<T>(
-      apiCounter: apiCounter,
-      meter: this,
-    );
+    final counter = ObservableCounter<T>(apiCounter: apiCounter, meter: this);
 
     // Register the instrument with the meter provider
     _provider.registerInstrument(name, counter);
@@ -250,11 +257,12 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-updowncounter
   @override
-  APIObservableUpDownCounter<T> createObservableUpDownCounter<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      ObservableCallback<T>? callback}) {
+  APIObservableUpDownCounter<T> createObservableUpDownCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    ObservableCallback<T>? callback,
+  }) {
     // First call the API implementation to get the API object
     final apiCounter = _delegate.createObservableUpDownCounter<T>(
       name: name,
@@ -290,11 +298,12 @@ class Meter implements APIMeter {
   /// More information:
   /// https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-gauge
   @override
-  APIObservableGauge<T> createObservableGauge<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      ObservableCallback<T>? callback}) {
+  APIObservableGauge<T> createObservableGauge<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    ObservableCallback<T>? callback,
+  }) {
     // First call the API implementation to get the API object
     final apiGauge = _delegate.createObservableGauge<T>(
       name: name,
@@ -304,10 +313,7 @@ class Meter implements APIMeter {
     );
 
     // Now wrap it with our SDK implementation
-    final gauge = ObservableGauge<T>(
-      apiGauge: apiGauge,
-      meter: this,
-    );
+    final gauge = ObservableGauge<T>(apiGauge: apiGauge, meter: this);
 
     // Register the instrument with the meter provider
     _provider.registerInstrument(name, gauge);
@@ -345,72 +351,97 @@ class NoopMeter implements APIMeter {
   /// @param name The name of the instrumentation scope
   /// @param version Optional version of the instrumentation scope
   /// @param schemaUrl Optional URL of the schema defining the instrumentation scope
-  NoopMeter({
-    required this.name,
-    this.version,
-    this.schemaUrl,
-  });
+  NoopMeter({required this.name, this.version, this.schemaUrl});
 
   @override
-  APICounter<T> createCounter<T extends num>(
-      {required String name, String? unit, String? description}) {
+  APICounter<T> createCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+  }) {
     return NoopCounter<T>(name: name, unit: unit, description: description);
   }
 
   @override
-  APIUpDownCounter<T> createUpDownCounter<T extends num>(
-      {required String name, String? unit, String? description}) {
+  APIUpDownCounter<T> createUpDownCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+  }) {
     return NoopUpDownCounter<T>(
-        name: name, unit: unit, description: description);
+      name: name,
+      unit: unit,
+      description: description,
+    );
   }
 
   @override
-  APIHistogram<T> createHistogram<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      List<double>? boundaries}) {
+  APIHistogram<T> createHistogram<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    List<double>? boundaries,
+  }) {
     return NoopHistogram<T>(
-        name: name,
-        unit: unit,
-        description: description,
-        boundaries: boundaries);
+      name: name,
+      unit: unit,
+      description: description,
+      boundaries: boundaries,
+    );
   }
 
   @override
-  APIGauge<T> createGauge<T extends num>(
-      {required String name, String? unit, String? description}) {
+  APIGauge<T> createGauge<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+  }) {
     return NoopGauge<T>(name: name, unit: unit, description: description);
   }
 
   @override
-  APIObservableCounter<T> createObservableCounter<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      ObservableCallback<T>? callback}) {
+  APIObservableCounter<T> createObservableCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    ObservableCallback<T>? callback,
+  }) {
     return NoopObservableCounter<T>(
-        name: name, unit: unit, description: description, callback: callback);
+      name: name,
+      unit: unit,
+      description: description,
+      callback: callback,
+    );
   }
 
   @override
-  APIObservableUpDownCounter<T> createObservableUpDownCounter<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      ObservableCallback<T>? callback}) {
+  APIObservableUpDownCounter<T> createObservableUpDownCounter<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    ObservableCallback<T>? callback,
+  }) {
     return NoopObservableUpDownCounter<T>(
-        name: name, unit: unit, description: description, callback: callback);
+      name: name,
+      unit: unit,
+      description: description,
+      callback: callback,
+    );
   }
 
   @override
-  APIObservableGauge<T> createObservableGauge<T extends num>(
-      {required String name,
-      String? unit,
-      String? description,
-      ObservableCallback<T>? callback}) {
+  APIObservableGauge<T> createObservableGauge<T extends num>({
+    required String name,
+    String? unit,
+    String? description,
+    ObservableCallback<T>? callback,
+  }) {
     return NoopObservableGauge<T>(
-        name: name, unit: unit, description: description, callback: callback);
+      name: name,
+      unit: unit,
+      description: description,
+      callback: callback,
+    );
   }
 }
 
@@ -561,9 +592,12 @@ class NoopHistogram<T extends num> implements APIHistogram<T> {
   /// @param unit Optional unit of measurement
   /// @param description Optional description of what the instrument measures
   /// @param boundaries Optional explicit histogram bucket boundaries
-  NoopHistogram(
-      {required this.name, this.unit, this.description, this.boundaries})
-      : meter = NoopMeter(name: 'noop-meter');
+  NoopHistogram({
+    required this.name,
+    this.unit,
+    this.description,
+    this.boundaries,
+  }) : meter = NoopMeter(name: 'noop-meter');
 
   /// Records a measurement (no-op implementation).
   ///
@@ -683,12 +717,12 @@ class NoopObservableCounter<T extends num> implements APIObservableCounter<T> {
   /// @param unit Optional unit of measurement
   /// @param description Optional description of what the instrument measures
   /// @param callback Optional callback function that will be called when measurements are collected
-  NoopObservableCounter(
-      {required this.name,
-      this.unit,
-      this.description,
-      ObservableCallback<T>? callback})
-      : meter = NoopMeter(name: 'noop-meter') {
+  NoopObservableCounter({
+    required this.name,
+    this.unit,
+    this.description,
+    ObservableCallback<T>? callback,
+  }) : meter = NoopMeter(name: 'noop-meter') {
     if (callback != null) {
       addCallback(callback);
     }
@@ -756,12 +790,12 @@ class NoopObservableUpDownCounter<T extends num>
   /// @param unit Optional unit of measurement
   /// @param description Optional description of what the instrument measures
   /// @param callback Optional callback function that will be called when measurements are collected
-  NoopObservableUpDownCounter(
-      {required this.name,
-      this.unit,
-      this.description,
-      ObservableCallback<T>? callback})
-      : meter = NoopMeter(name: 'noop-meter') {
+  NoopObservableUpDownCounter({
+    required this.name,
+    this.unit,
+    this.description,
+    ObservableCallback<T>? callback,
+  }) : meter = NoopMeter(name: 'noop-meter') {
     if (callback != null) {
       addCallback(callback);
     }
@@ -828,12 +862,12 @@ class NoopObservableGauge<T extends num> implements APIObservableGauge<T> {
   /// @param unit Optional unit of measurement
   /// @param description Optional description of what the instrument measures
   /// @param callback Optional callback function that will be called when measurements are collected
-  NoopObservableGauge(
-      {required this.name,
-      this.unit,
-      this.description,
-      ObservableCallback<T>? callback})
-      : meter = NoopMeter(name: 'noop-meter') {
+  NoopObservableGauge({
+    required this.name,
+    this.unit,
+    this.description,
+    ObservableCallback<T>? callback,
+  }) : meter = NoopMeter(name: 'noop-meter') {
     if (callback != null) {
       addCallback(callback);
     }

--- a/lib/src/metrics/meter_create.dart
+++ b/lib/src/metrics/meter_create.dart
@@ -18,9 +18,6 @@ class MeterCreate {
     required APIMeter delegate,
     required MeterProvider provider,
   }) {
-    return Meter._(
-      delegate: delegate,
-      provider: provider,
-    );
+    return Meter._(delegate: delegate, provider: provider);
   }
 }

--- a/lib/src/metrics/meter_provider.dart
+++ b/lib/src/metrics/meter_provider.dart
@@ -36,10 +36,7 @@ class MeterProvider implements APIMeterProvider {
   ///
   /// @param delegate The API MeterProvider implementation to delegate to
   /// @param resource Optional Resource describing the entity producing telemetry
-  MeterProvider._({
-    required this.delegate,
-    this.resource,
-  }) {
+  MeterProvider._({required this.delegate, this.resource}) {
     if (OTelLog.isDebug()) {
       OTelLog.debug('MeterProvider: Created with resource: $resource');
     }
@@ -84,17 +81,19 @@ class MeterProvider implements APIMeterProvider {
   set isShutdown(bool value) => delegate.isShutdown = value;
 
   @override
-  APIMeter getMeter(
-      {required String name,
-      String? version,
-      String? schemaUrl,
-      Attributes? attributes}) {
+  APIMeter getMeter({
+    required String name,
+    String? version,
+    String? schemaUrl,
+    Attributes? attributes,
+  }) {
     // Check if provider is shutdown
     if (isShutdown) {
       // Return a no-op meter instead of throwing
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'MeterProvider: Attempting to get meter "$name" after shutdown. Returning a no-op meter.');
+          'MeterProvider: Attempting to get meter "$name" after shutdown. Returning a no-op meter.',
+        );
       }
       return NoopMeter(name: name, version: version, schemaUrl: schemaUrl);
     }
@@ -109,16 +108,14 @@ class MeterProvider implements APIMeterProvider {
 
     // Call the API implementation first
     final apiMeter = delegate.getMeter(
-        name: name,
-        version: version,
-        schemaUrl: schemaUrl,
-        attributes: attributes);
+      name: name,
+      version: version,
+      schemaUrl: schemaUrl,
+      attributes: attributes,
+    );
 
     // Wrap it with our SDK implementation
-    final meter = MeterCreate.create(
-      delegate: apiMeter,
-      provider: this,
-    );
+    final meter = MeterCreate.create(delegate: apiMeter, provider: this);
 
     // Store the meter in the registry
     _meters[meterKey] = meter;
@@ -128,7 +125,8 @@ class MeterProvider implements APIMeterProvider {
 
     if (OTelLog.isLogMetrics()) {
       OTelLog.logMetric(
-          'MeterProvider: Created meter "$name" (version: $version)');
+        'MeterProvider: Created meter "$name" (version: $version)',
+      );
     }
 
     return meter;
@@ -191,7 +189,8 @@ class MeterProvider implements APIMeterProvider {
 
     if (OTelLog.isLogMetrics()) {
       OTelLog.logMetric(
-          'MeterProvider: Registered instrument "${instrument.name}" for meter "${instrument.meter.name}"');
+        'MeterProvider: Registered instrument "${instrument.name}" for meter "${instrument.meter.name}"',
+      );
     }
   }
 
@@ -214,7 +213,8 @@ class MeterProvider implements APIMeterProvider {
 
       if (OTelLog.isLogMetrics()) {
         OTelLog.logMetric(
-            'MeterProvider: Collecting metrics from ${instruments.length} instruments in meter "$meterName"');
+          'MeterProvider: Collecting metrics from ${instruments.length} instruments in meter "$meterName"',
+        );
       }
 
       // Collect metrics from each instrument
@@ -226,13 +226,15 @@ class MeterProvider implements APIMeterProvider {
 
             if (OTelLog.isLogMetrics()) {
               OTelLog.logMetric(
-                  'MeterProvider: Collected ${metrics.length} metrics from instrument "${instrument.name}"');
+                'MeterProvider: Collected ${metrics.length} metrics from instrument "${instrument.name}"',
+              );
             }
           }
         } catch (e) {
           if (OTelLog.isLogMetrics()) {
             OTelLog.logMetric(
-                'MeterProvider: Error collecting metrics from instrument "${instrument.name}": $e');
+              'MeterProvider: Error collecting metrics from instrument "${instrument.name}": $e',
+            );
           }
         }
       }
@@ -240,7 +242,8 @@ class MeterProvider implements APIMeterProvider {
 
     if (OTelLog.isLogMetrics()) {
       OTelLog.logMetric(
-          'MeterProvider: Collected ${allMetrics.length} total metrics');
+        'MeterProvider: Collected ${allMetrics.length} total metrics',
+      );
     }
 
     return allMetrics;
@@ -263,7 +266,8 @@ class MeterProvider implements APIMeterProvider {
 
     if (OTelLog.isLogExport()) {
       OTelLog.logExport(
-          'MeterProvider: Force flushing metrics through ${_metricReaders.length} readers');
+        'MeterProvider: Force flushing metrics through ${_metricReaders.length} readers',
+      );
     }
 
     bool success = true;

--- a/lib/src/metrics/meter_provider_create.dart
+++ b/lib/src/metrics/meter_provider_create.dart
@@ -6,8 +6,10 @@ part of 'meter_provider.dart';
 /// Internal constructor access for TracerProvider
 class SDKMeterProviderCreate {
   /// Creates a TracerProvider, only accessible within library
-  static MeterProvider create(
-      {required APIMeterProvider delegate, Resource? resource}) {
+  static MeterProvider create({
+    required APIMeterProvider delegate,
+    Resource? resource,
+  }) {
     return MeterProvider._(delegate: delegate, resource: resource);
   }
 }

--- a/lib/src/metrics/metric_exporter.dart
+++ b/lib/src/metrics/metric_exporter.dart
@@ -5,14 +5,7 @@ import 'dart:async';
 
 import 'data/metric_data.dart';
 
-/// Defines the result of a metric export operation.
-enum ExportResult {
-  /// The export was successful.
-  success,
-
-  /// The export failed.
-  failure
-}
+export '../export/export_result.dart';
 
 /// MetricExporter is responsible for sending metrics to a backend.
 abstract class MetricExporter {

--- a/lib/src/metrics/metric_reader.dart
+++ b/lib/src/metrics/metric_reader.dart
@@ -91,10 +91,13 @@ class PeriodicExportingMetricReader extends MetricReader {
         final exportFuture = _exporter.export(data);
 
         // Apply timeout to export
-        await exportFuture.timeout(_timeout, onTimeout: () {
-          print('Metric export timed out after $_timeout');
-          return false;
-        });
+        await exportFuture.timeout(
+          _timeout,
+          onTimeout: () {
+            print('Metric export timed out after $_timeout');
+            return false;
+          },
+        );
       }
     } catch (e) {
       print('Error during metric collection/export: $e');
@@ -106,7 +109,8 @@ class PeriodicExportingMetricReader extends MetricReader {
     if (meterProvider == null) {
       if (OTelLog.isLogMetrics()) {
         OTelLog.logMetric(
-            'PeriodicExportingMetricReader: No meter provider registered');
+          'PeriodicExportingMetricReader: No meter provider registered',
+        );
       }
       // Return an empty container with no metrics
       return MetricData.empty();
@@ -120,13 +124,11 @@ class PeriodicExportingMetricReader extends MetricReader {
 
     if (OTelLog.isLogMetrics()) {
       OTelLog.logMetric(
-          'PeriodicExportingMetricReader: Collected ${metrics.length} metrics');
+        'PeriodicExportingMetricReader: Collected ${metrics.length} metrics',
+      );
     }
 
-    return MetricData(
-      resource: meterProvider!.resource,
-      metrics: metrics,
-    );
+    return MetricData(resource: meterProvider!.resource, metrics: metrics);
   }
 
   @override

--- a/lib/src/metrics/observe/observable_result.dart
+++ b/lib/src/metrics/observe/observable_result.dart
@@ -28,14 +28,17 @@ class ObservableResult<T extends num> implements APIObservableResult<T> {
     if (OTelFactory.otelFactory == null) {
       if (OTelLog.isWarn()) {
         OTelLog.warn(
-            'Warning: OTelFactory.otelFactory is null in ObservableResult.observe');
+          'Warning: OTelFactory.otelFactory is null in ObservableResult.observe',
+        );
       }
       return;
     }
 
     // Add the measurement
-    final measurement =
-        OTelFactory.otelFactory!.createMeasurement<T>(value, attributes);
+    final measurement = OTelFactory.otelFactory!.createMeasurement<T>(
+      value,
+      attributes,
+    );
     _measurements.add(measurement);
   }
 

--- a/lib/src/metrics/storage/gauge_storage.dart
+++ b/lib/src/metrics/storage/gauge_storage.dart
@@ -22,10 +22,7 @@ class GaugeStorage<T extends num> extends NumericStorage<T> {
     final key = attributes ?? _emptyAttributes();
 
     // Always update with the latest value
-    _points[key] = _GaugePointData<T>(
-      value: value,
-      updateTime: DateTime.now(),
-    );
+    _points[key] = _GaugePointData<T>(value: value, updateTime: DateTime.now());
   }
 
   /// Helper to get empty attributes safely
@@ -121,8 +118,5 @@ class _GaugePointData<T extends num> {
   /// Exemplars for this point.
   final List<Exemplar> exemplars = [];
 
-  _GaugePointData({
-    required this.value,
-    required this.updateTime,
-  });
+  _GaugePointData({required this.value, required this.updateTime});
 }

--- a/lib/src/metrics/storage/histogram_storage.dart
+++ b/lib/src/metrics/storage/histogram_storage.dart
@@ -22,10 +22,7 @@ class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
   final DateTime _startTime = DateTime.now();
 
   /// Creates a new HistogramStorage instance.
-  HistogramStorage({
-    required this.boundaries,
-    this.recordMinMax = true,
-  });
+  HistogramStorage({required this.boundaries, this.recordMinMax = true});
 
   /// Records a measurement with the given attributes.
   @override
@@ -73,14 +70,20 @@ class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
   HistogramValue getValue([Attributes? attributes]) {
     if (attributes == null) {
       // Combine across all attribute sets
-      final num totalSum =
-          _points.values.fold<num>(0, (sum, data) => sum + data.sum);
-      final int totalCount =
-          _points.values.fold<int>(0, (count, data) => count + data.count);
+      final num totalSum = _points.values.fold<num>(
+        0,
+        (sum, data) => sum + data.sum,
+      );
+      final int totalCount = _points.values.fold<int>(
+        0,
+        (count, data) => count + data.count,
+      );
 
       // Combine bucket counts
-      final List<int> combinedCounts =
-          List<int>.filled(boundaries.length + 1, 0);
+      final List<int> combinedCounts = List<int>.filled(
+        boundaries.length + 1,
+        0,
+      );
       for (final data in _points.values) {
         for (int i = 0; i < data.counts.length; i++) {
           combinedCounts[i] += data.counts[i];
@@ -225,10 +228,7 @@ class _HistogramPointData<T extends num> {
   /// Exemplars for this point.
   final List<Exemplar> exemplars = [];
 
-  _HistogramPointData({
-    required this.boundaries,
-    required this.recordMinMax,
-  }) {
+  _HistogramPointData({required this.boundaries, required this.recordMinMax}) {
     // Initialize count array with one more than boundaries
     // (for the +Inf bucket)
     counts = List<int>.filled(boundaries.length + 1, 0);

--- a/lib/src/metrics/storage/sum_storage.dart
+++ b/lib/src/metrics/storage/sum_storage.dart
@@ -36,9 +36,7 @@ class SumStorage<T extends num> extends NumericStorage<T> {
   /// Creates a new SumStorage instance.
   ///
   /// @param isMonotonic Whether this storage is for a monotonic sum
-  SumStorage({
-    required this.isMonotonic,
-  });
+  SumStorage({required this.isMonotonic});
 
   /// Records a measurement with the given attributes.
   ///
@@ -51,8 +49,10 @@ class SumStorage<T extends num> extends NumericStorage<T> {
   void record(T value, [Attributes? attributes]) {
     // Check constraints for monotonic counters
     if (isMonotonic && value < 0) {
-      print('Warning: Negative value $value provided to monotonic sum storage. '
-          'This will be ignored.');
+      print(
+        'Warning: Negative value $value provided to monotonic sum storage. '
+        'This will be ignored.',
+      );
       return;
     }
 
@@ -178,10 +178,7 @@ class _SumPointData<T extends num> {
   ///
   /// @param value The initial value
   /// @param lastUpdateTime The time of the initial value
-  _SumPointData({
-    required this.value,
-    required this.lastUpdateTime,
-  });
+  _SumPointData({required this.value, required this.lastUpdateTime});
 
   /// Adds a value to this point (for synchronous counters).
   ///

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -98,6 +98,10 @@ class OTel {
   /// @param metricExporter Custom metric exporter for metrics
   /// @param metricReader Custom metric reader for metrics
   /// @param enableMetrics Whether to enable metrics collection (default: true)
+  /// @param enableLogs Whether to enable logs collection and auto-configure exporter (default: true).
+  ///   When enabled, the logs exporter is configured based on OTEL_LOGS_EXPORTER env var.
+  /// @param logRecordExporter Custom log record exporter (overrides OTEL_LOGS_EXPORTER)
+  /// @param logRecordProcessor Custom log record processor (overrides auto-configuration)
   /// @param dartasticApiKey API key for Dartastic.io backend
   /// @param tenantId Tenant ID for multi-tenant backends (required for Dartastic.io)
   /// @param detectPlatformResources Whether to detect platform resources (default: true)
@@ -123,6 +127,9 @@ class OTel {
     MetricExporter? metricExporter,
     MetricReader? metricReader,
     bool enableMetrics = true,
+    bool enableLogs = true,
+    LogRecordExporter? logRecordExporter,
+    LogRecordProcessor? logRecordProcessor,
     String? dartasticApiKey,
     String? tenantId,
     bool detectPlatformResources = true,
@@ -421,6 +428,22 @@ class OTel {
           resource: OTel.defaultResource,
         );
       }
+    }
+
+    // Configure logs if enabled
+    if (enableLogs) {
+      // For HTTP, adjust endpoint if it's the gRPC default
+      String logsEndpoint = endpoint;
+      if (endpoint == defaultEndpoint) {
+        logsEndpoint = 'http://localhost:4318';
+      }
+      LogsConfiguration.configureLoggerProvider(
+        endpoint: logsEndpoint,
+        secure: secure,
+        logRecordExporter: logRecordExporter,
+        logRecordProcessor: logRecordProcessor,
+        resource: OTel.defaultResource,
+      );
     }
 
     // Store print interception configuration (lazily initialized when needed)

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -1,6 +1,7 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
@@ -38,6 +39,18 @@ import 'package:meta/meta.dart';
 class OTel {
   static OTelSDKFactory? _otelFactory;
   static Sampler? _defaultSampler;
+
+  /// Whether print interception is enabled (set via initialize).
+  static bool _logPrintEnabled = false;
+
+  /// Logger name for print interception (set via initialize).
+  static String _logPrintLoggerName = 'dart.print';
+
+  /// Lazily initialized DartLogBridge for print interception.
+  static DartLogBridge? _logBridge;
+
+  /// Lazily initialized zone specification for print interception.
+  static ZoneSpecification? _printInterceptionZoneSpec;
 
   /// Default resource for the SDK.
   ///
@@ -88,6 +101,10 @@ class OTel {
   /// @param dartasticApiKey API key for Dartastic.io backend
   /// @param tenantId Tenant ID for multi-tenant backends (required for Dartastic.io)
   /// @param detectPlatformResources Whether to detect platform resources (default: true)
+  /// @param logPrint Whether to intercept print() calls and route them to OTel logs (default: false).
+  ///   When enabled, all print() calls within [runWithPrintInterception] will be captured
+  ///   as INFO level logs. Set to true to automatically bridge print statements to OpenTelemetry.
+  /// @param logPrintLoggerName Logger name for print-intercepted logs (default: 'dart.print')
   /// @param oTelFactoryCreationFunction Factory function for creating OTelSDKFactory instances
   /// @return A Future that completes when initialization is done
   /// @throws StateError if called more than once
@@ -109,6 +126,8 @@ class OTel {
     String? dartasticApiKey,
     String? tenantId,
     bool detectPlatformResources = true,
+    bool logPrint = false,
+    String logPrintLoggerName = 'dart.print',
     OTelFactoryCreationFunction? oTelFactoryCreationFunction =
         otelSDKFactoryFactoryFunction,
   }) async {
@@ -403,6 +422,33 @@ class OTel {
         );
       }
     }
+
+    // Store print interception configuration (lazily initialized when needed)
+    _logPrintEnabled = logPrint;
+    _logPrintLoggerName = logPrintLoggerName;
+
+    if (logPrint && OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OTel: Print interception enabled with logger: $logPrintLoggerName');
+    }
+  }
+
+  /// Ensures the print interception bridge is initialized.
+  /// Called lazily when runWithPrintInterception is first used.
+  static void _ensurePrintInterceptionInitialized() {
+    if (_logBridge != null) return;
+
+    final logger = OTel.logger(_logPrintLoggerName);
+    _logBridge = DartLogBridge.install(
+      logger,
+      minimumSeverity: Severity.TRACE,
+    );
+    _printInterceptionZoneSpec = _logBridge!.createZoneSpecification();
+
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OTel: Print interception bridge initialized with logger: $_logPrintLoggerName');
+    }
   }
 
   /// Creates a Resource with the specified attributes and schema URL.
@@ -589,6 +635,120 @@ class OTel {
     return meterProvider().getMeter(
         name: name ?? defaultTracerName,
         version: defaultTracerVersion) as Meter;
+  }
+
+  /// Gets a LoggerProvider for creating Loggers.
+  ///
+  /// If name is null, this returns the global default LoggerProvider, which shares
+  /// the endpoint, serviceName, serviceVersion and resource set in initialize().
+  /// If the name is not null, it returns a LoggerProvider for the name that was added
+  /// with addLoggerProvider.
+  ///
+  /// @param name Optional name of a specific LoggerProvider
+  /// @return The LoggerProvider instance
+  static LoggerProvider loggerProvider({String? name}) {
+    final logProvider = OTelAPI.loggerProvider(name) as LoggerProvider;
+    logProvider.resource ??= defaultResource;
+    return logProvider;
+  }
+
+  /// Adds or replaces a named LoggerProvider.
+  ///
+  /// This allows for creating multiple LoggerProviders with different configurations,
+  /// which can be useful for sending logs to different backends or with different
+  /// settings.
+  ///
+  /// @param name The name of the LoggerProvider
+  /// @param endpoint Optional custom endpoint URL
+  /// @param serviceName Optional custom service name
+  /// @param serviceVersion Optional custom service version
+  /// @param resource Optional custom resource
+  /// @return The newly created or replaced LoggerProvider
+  static LoggerProvider addLoggerProvider(
+    String name, {
+    String? endpoint,
+    String? serviceName,
+    String? serviceVersion,
+    Resource? resource,
+  }) {
+    _getAndCacheOtelFactory();
+    final lp = _otelFactory!.addLogProvider(name,
+        endpoint: endpoint,
+        serviceName: serviceName,
+        serviceVersion: serviceVersion) as LoggerProvider;
+    lp.resource = resource ?? defaultResource;
+    return lp;
+  }
+
+  /// Gets the default Logger from the default LoggerProvider.
+  ///
+  /// This is a convenience method for getting a Logger with the default configuration.
+  /// The endpoint, serviceName, serviceVersion and resource all flow down from
+  /// the OTel defaults set during initialization.
+  ///
+  /// @param name Optional custom name for the logger (defaults to defaultTracerName)
+  /// @return The default Logger instance
+  static Logger logger([String? name]) {
+    return loggerProvider().getLogger(
+      name ?? defaultTracerName,
+      version: defaultTracerVersion,
+    );
+  }
+
+  /// Whether print interception is enabled.
+  ///
+  /// Returns true if [initialize] was called with `logPrint: true`.
+  static bool get isLogPrintEnabled => _logPrintEnabled;
+
+  /// Gets the current DartLogBridge instance, if print interception is enabled.
+  ///
+  /// Returns null if print interception was not enabled during initialization.
+  static DartLogBridge? get logBridge => _logBridge;
+
+  /// Runs the given callback in a zone that intercepts print() calls.
+  ///
+  /// When [initialize] is called with `logPrint: true`, this method runs
+  /// the callback in a zone where all `print()` calls are captured and
+  /// routed to OpenTelemetry logs as INFO level messages.
+  ///
+  /// If print interception is not enabled, the callback is run directly
+  /// without any interception.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// await OTel.initialize(
+  ///   serviceName: 'my-service',
+  ///   logPrint: true,
+  /// );
+  ///
+  /// OTel.runWithPrintInterception(() {
+  ///   print('This will be captured as an OTel log');
+  /// });
+  /// ```
+  ///
+  /// @param callback The code to run with print interception
+  /// @return The result of the callback
+  static R runWithPrintInterception<R>(R Function() callback) {
+    if (!_logPrintEnabled) {
+      return callback();
+    }
+    _ensurePrintInterceptionInitialized();
+    return runZoned(callback, zoneSpecification: _printInterceptionZoneSpec);
+  }
+
+  /// Runs the given async callback in a zone that intercepts print() calls.
+  ///
+  /// This is the async version of [runWithPrintInterception].
+  ///
+  /// @param callback The async code to run with print interception
+  /// @return A Future containing the result of the callback
+  static Future<R> runWithPrintInterceptionAsync<R>(
+      Future<R> Function() callback) {
+    if (!_logPrintEnabled) {
+      return callback();
+    }
+    _ensurePrintInterceptionInitialized();
+    return runZoned(callback, zoneSpecification: _printInterceptionZoneSpec);
   }
 
   /// Creates a SpanContext with the specified parameters.
@@ -1054,6 +1214,15 @@ class OTel {
     _defaultSampler = null;
     defaultResource = null;
     dartasticApiKey = null;
+
+    // Reset print interception state
+    if (_logBridge != null) {
+      DartLogBridge.uninstall();
+    }
+    _logBridge = null;
+    _printInterceptionZoneSpec = null;
+    _logPrintEnabled = false;
+    _logPrintLoggerName = 'dart.print';
     if (OTelLog.isDebug()) OTelLog.debug('OTel: Reset static fields');
 
     // Reset API state

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -178,7 +178,8 @@ class OTel {
       }
       if (envServiceVersion != null) {
         OTelLog.debug(
-            'Using service version from environment: $serviceVersion');
+          'Using service version from environment: $serviceVersion',
+        );
       }
       if (envEndpoint != null) {
         OTelLog.debug('Using endpoint from environment: $endpoint');
@@ -207,12 +208,14 @@ class OTel {
     }
     if (OTelFactory.otelFactory != null) {
       throw StateError(
-          'OTelAPI can only be initialized once. If you need multiple endpoints or service names or versions create a named TracerProvider');
+        'OTelAPI can only be initialized once. If you need multiple endpoints or service names or versions create a named TracerProvider',
+      );
     }
 
     if (endpoint.isEmpty) {
       throw ArgumentError(
-          'endpoint must not be the empty string.'); //TODO validate url
+        'endpoint must not be the empty string.',
+      ); //TODO validate url
     }
     if (serviceName.isEmpty) {
       throw ArgumentError('serviceName must not be the empty string.');
@@ -231,13 +234,15 @@ class OTel {
     initializeLogging();
 
     OTelFactory.otelFactory = factoryFactory(
-        apiEndpoint: endpoint,
-        apiServiceName: serviceName,
-        apiServiceVersion: serviceVersion);
+      apiEndpoint: endpoint,
+      apiServiceName: serviceName,
+      apiServiceVersion: serviceVersion,
+    );
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OTel initialized with endpoint: $endpoint, service: $serviceName');
+        'OTel initialized with endpoint: $endpoint, service: $serviceName',
+      );
     }
 
     final serviceResourceAttributes = {
@@ -245,16 +250,19 @@ class OTel {
       'service.version': serviceVersion,
     };
     // Create initial resource with service attributes
-    var baseResource =
-        OTel.resource(OTel.attributesFromMap(serviceResourceAttributes));
+    var baseResource = OTel.resource(
+      OTel.attributesFromMap(serviceResourceAttributes),
+    );
 
     if (tenantId != null) {
       // Create a separate tenant_id resource to ensure it's preserved
-      final tenantResource =
-          OTel.resource(OTel.attributesFromMap({'tenant_id': tenantId}));
+      final tenantResource = OTel.resource(
+        OTel.attributesFromMap({'tenant_id': tenantId}),
+      );
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OTel.initialize: Creating tenant_id resource with: $tenantId');
+          'OTel.initialize: Creating tenant_id resource with: $tenantId',
+        );
       }
       // Merge tenant into the base resource
       baseResource = baseResource.merge(tenantResource);
@@ -303,7 +311,8 @@ class OTel {
             hasTenantId = true;
             if (OTelLog.isDebug()) {
               OTelLog.debug(
-                  'Final resource check - tenant_id is present: ${attr.value}');
+                'Final resource check - tenant_id is present: ${attr.value}',
+              );
             }
           }
         });
@@ -313,8 +322,9 @@ class OTel {
           if (OTelLog.isDebug()) {
             OTelLog.debug('tenant_id was missing - adding it as fallback');
           }
-          final tenantResource =
-              OTel.resource(OTel.attributesFromMap({'tenant_id': tenantId}));
+          final tenantResource = OTel.resource(
+            OTel.attributesFromMap({'tenant_id': tenantId}),
+          );
           OTel.defaultResource = OTel.defaultResource!.merge(tenantResource);
         }
       }
@@ -377,18 +387,17 @@ class OTel {
         } else {
           // Fallback to gRPC for backward compatibility
           exporter = OtlpGrpcSpanExporter(
-            OtlpGrpcExporterConfig(
-              endpoint: endpoint,
-              insecure: !secure,
-            ),
+            OtlpGrpcExporterConfig(endpoint: endpoint, insecure: !secure),
           );
         }
 
         // Only add ConsoleExporter in debug mode or if explicitly requested
         final exporters = <SpanExporter>[exporter];
         if (OTelLog.isDebug() ||
-            const bool.fromEnvironment('OTEL_CONSOLE_EXPORTER',
-                defaultValue: false)) {
+            const bool.fromEnvironment(
+              'OTEL_CONSOLE_EXPORTER',
+              defaultValue: false,
+            )) {
           exporters.add(ConsoleExporter());
         }
 
@@ -485,8 +494,10 @@ class OTel {
   /// @return A new Resource instance
   static Resource resource(Attributes? attributes, [String? schemaUrl]) {
     _getAndCacheOtelFactory();
-    return (_otelFactory as OTelSDKFactory)
-        .resource(attributes ?? OTel.attributes(), schemaUrl);
+    return (_otelFactory as OTelSDKFactory).resource(
+      attributes ?? OTel.attributes(),
+      schemaUrl,
+    );
   }
 
   /// Creates a new ContextKey with the given name.
@@ -633,10 +644,12 @@ class OTel {
     Resource? resource,
   }) {
     _getAndCacheOtelFactory();
-    final mp = _otelFactory!.addMeterProvider(name,
-        endpoint: endpoint,
-        serviceName: serviceName,
-        serviceVersion: serviceVersion) as MeterProvider;
+    final mp = _otelFactory!.addMeterProvider(
+      name,
+      endpoint: endpoint,
+      serviceName: serviceName,
+      serviceVersion: serviceVersion,
+    ) as MeterProvider;
     mp.resource = resource ?? defaultResource;
     return mp;
   }
@@ -656,8 +669,9 @@ class OTel {
   /// @return The default Meter instance
   static Meter meter([String? name]) {
     return meterProvider().getMeter(
-        name: name ?? defaultTracerName,
-        version: defaultTracerVersion) as Meter;
+      name: name ?? defaultTracerName,
+      version: defaultTracerVersion,
+    ) as Meter;
   }
 
   /// Gets a LoggerProvider for creating Loggers.
@@ -787,13 +801,14 @@ class OTel {
   /// @param traceState Trace state
   /// @param isRemote Whether this context was received from a remote source
   /// @return A new SpanContext instance
-  static SpanContext spanContext(
-      {TraceId? traceId,
-      SpanId? spanId,
-      SpanId? parentSpanId,
-      TraceFlags? traceFlags,
-      TraceState? traceState,
-      bool? isRemote}) {
+  static SpanContext spanContext({
+    TraceId? traceId,
+    SpanId? spanId,
+    SpanId? parentSpanId,
+    TraceFlags? traceFlags,
+    TraceState? traceState,
+    bool? isRemote,
+  }) {
     return OTelAPI.spanContext(
       traceId: traceId ?? OTel.traceId(),
       spanId: spanId ?? OTel.spanId(),
@@ -848,8 +863,11 @@ class OTel {
   /// @param attributes Optional attributes to associate with the event
   /// @param timestamp Optional timestamp for the event (defaults to null)
   /// @return A new SpanEvent instance
-  static SpanEvent spanEvent(String name,
-      [Attributes? attributes, DateTime? timestamp]) {
+  static SpanEvent spanEvent(
+    String name, [
+    Attributes? attributes,
+    DateTime? timestamp,
+  ]) {
     _getAndCacheOtelFactory();
     return _otelFactory!.spanEvent(name, attributes, timestamp);
   }
@@ -939,7 +957,9 @@ class OTel {
   /// @param value The list of string values
   /// @return A new Attribute instance
   static Attribute<List<String>> attributeStringList(
-      String name, List<String> value) {
+    String name,
+    List<String> value,
+  ) {
     _getAndCacheOtelFactory();
     return _otelFactory!.attributeStringList(name, value);
   }
@@ -950,7 +970,9 @@ class OTel {
   /// @param value The list of boolean values
   /// @return A new Attribute instance
   static Attribute<List<bool>> attributeBoolList(
-      String name, List<bool> value) {
+    String name,
+    List<bool> value,
+  ) {
     _getAndCacheOtelFactory();
     return _otelFactory!.attributeBoolList(name, value);
   }
@@ -971,7 +993,9 @@ class OTel {
   /// @param value The list of double values
   /// @return A new Attribute instance
   static Attribute<List<double>> attributeDoubleList(
-      String name, List<double> value) {
+    String name,
+    List<double> value,
+  ) {
     _getAndCacheOtelFactory();
     return _otelFactory!.attributeDoubleList(name, value);
   }
@@ -1066,7 +1090,8 @@ class OTel {
     _getAndCacheOtelFactory();
     if (traceId.length != TraceId.traceIdLength) {
       throw ArgumentError(
-          'Trace ID must be exactly ${TraceId.traceIdLength} bytes, got ${traceId.length} bytes');
+        'Trace ID must be exactly ${TraceId.traceIdLength} bytes, got ${traceId.length} bytes',
+      );
     }
     return OTelFactory.otelFactory!.traceId(traceId);
   }
@@ -1102,7 +1127,8 @@ class OTel {
     _getAndCacheOtelFactory();
     if (spanId.length != 8) {
       throw ArgumentError(
-          'Span ID must be exactly 8 bytes, got ${spanId.length} bytes');
+        'Span ID must be exactly 8 bytes, got ${spanId.length} bytes',
+      );
     }
     return _otelFactory!.spanId(spanId);
   }
@@ -1274,15 +1300,17 @@ class OTel {
   /// [version] is optional and specifies the version of the instrumentation scope, defaults to '1.0.0'
   /// [schemaUrl] is optional and specifies the Schema URL
   /// [attributes] is optional and specifies instrumentation scope attributes
-  static InstrumentationScope instrumentationScope(
-      {required String name,
-      String version = '1.0.0',
-      String? schemaUrl,
-      Attributes? attributes}) {
+  static InstrumentationScope instrumentationScope({
+    required String name,
+    String version = '1.0.0',
+    String? schemaUrl,
+    Attributes? attributes,
+  }) {
     return OTelAPI.instrumentationScope(
-        name: name,
-        version: version,
-        schemaUrl: schemaUrl,
-        attributes: attributes);
+      name: name,
+      version: version,
+      schemaUrl: schemaUrl,
+      attributes: attributes,
+    );
   }
 }

--- a/lib/src/resource/resource.dart
+++ b/lib/src/resource/resource.dart
@@ -86,8 +86,10 @@ class Resource {
       mergedSchemaUrl = other._schemaUrl;
     }
 
-    final result =
-        Resource._(OTel.attributesFromMap(mergedMap), mergedSchemaUrl);
+    final result = Resource._(
+      OTel.attributesFromMap(mergedMap),
+      mergedSchemaUrl,
+    );
 
     if (OTelLog.isDebug()) {
       OTelLog.debug('Resource merge result attributes:');

--- a/lib/src/resource/resource_detector.dart
+++ b/lib/src/resource/resource_detector.dart
@@ -36,13 +36,15 @@ class ProcessResourceDetector implements ResourceDetector {
     if (OTelFactory.otelFactory == null) {
       throw 'OTel initialize must be called first.';
     }
-    return ResourceCreate.create(OTelFactory.otelFactory!.attributesFromMap({
-      'process.executable.name': io.Platform.executable,
-      'process.command_line': io.Platform.executableArguments.join(' '),
-      'process.runtime.name': 'dart',
-      'process.runtime.version': io.Platform.version,
-      'process.num_threads': io.Platform.numberOfProcessors.toString(),
-    }));
+    return ResourceCreate.create(
+      OTelFactory.otelFactory!.attributesFromMap({
+        'process.executable.name': io.Platform.executable,
+        'process.command_line': io.Platform.executableArguments.join(' '),
+        'process.runtime.name': 'dart',
+        'process.runtime.version': io.Platform.version,
+        'process.num_threads': io.Platform.numberOfProcessors.toString(),
+      }),
+    );
   }
 }
 
@@ -83,7 +85,8 @@ class HostResourceDetector implements ResourceDetector {
     attributes['os.version'] = io.Platform.operatingSystemVersion;
 
     return ResourceCreate.create(
-        OTelFactory.otelFactory!.attributesFromMap(attributes));
+      OTelFactory.otelFactory!.attributesFromMap(attributes),
+    );
   }
 }
 
@@ -112,8 +115,9 @@ class EnvVarResourceDetector implements ResourceDetector {
     }
 
     //TODO - OTEL_RESOURCE_ATTRIBUTES?
-    final resourceAttrs =
-        _environmentService.getValue('OTEL_RESOURCE_ATTRIBUTES');
+    final resourceAttrs = _environmentService.getValue(
+      'OTEL_RESOURCE_ATTRIBUTES',
+    );
     if (resourceAttrs == null || resourceAttrs.isEmpty) {
       return Resource.empty;
     }
@@ -207,17 +211,12 @@ class PlatformResourceDetector {
   ///
   /// @return A ResourceDetector that combines all appropriate detectors
   static ResourceDetector create() {
-    final detectors = <ResourceDetector>[
-      EnvVarResourceDetector(),
-    ];
+    final detectors = <ResourceDetector>[EnvVarResourceDetector()];
 
     // For non-web platforms (native)
     if (!const bool.fromEnvironment('dart.library.js_interop')) {
       try {
-        detectors.addAll([
-          ProcessResourceDetector(),
-          HostResourceDetector(),
-        ]);
+        detectors.addAll([ProcessResourceDetector(), HostResourceDetector()]);
       } catch (e) {
         if (OTelLog.isError()) {
           OTelLog.error('Error adding native detectors: $e');

--- a/lib/src/resource/web_detector_impl.dart
+++ b/lib/src/resource/web_detector_impl.dart
@@ -33,16 +33,20 @@ extension NavigatorJSExtension on NavigatorJS {
 }
 
 // Pure JS function to safely get languages as string
-@JS('function() { '
-    'var langs = window.navigator.languages;'
-    'return (langs && Array.isArray(langs)) ? langs.join(",") : "";'
-    '}')
+@JS(
+  'function() { '
+  'var langs = window.navigator.languages;'
+  'return (langs && Array.isArray(langs)) ? langs.join(",") : "";'
+  '}',
+)
 external String _getLanguagesString();
 
 // Pure JS function to check if mobile
-@JS('function() { '
-    'return /Mobile|Android|iPhone|iPad|iPod|Windows Phone/i.test(window.navigator.userAgent) ? "true" : "false";'
-    '}')
+@JS(
+  'function() { '
+  'return /Mobile|Android|iPhone|iPad|iPod|Windows Phone/i.test(window.navigator.userAgent) ? "true" : "false";'
+  '}',
+)
 external String _isMobile();
 
 /// Detects browser and web-specific resource information.
@@ -88,6 +92,7 @@ class WebResourceDetector implements ResourceDetector {
     }
 
     return ResourceCreate.create(
-        OTelFactory.otelFactory!.attributesFromMap(attributes));
+      OTelFactory.otelFactory!.attributesFromMap(attributes),
+    );
   }
 }

--- a/lib/src/resource/web_detector_stub.dart
+++ b/lib/src/resource/web_detector_stub.dart
@@ -17,6 +17,7 @@ class WebResourceDetector implements ResourceDetector {
   @override
   Future<Resource> detect() async {
     throw UnsupportedError(
-        'WebResourceDetector is only available on web platforms');
+      'WebResourceDetector is only available on web platforms',
+    );
   }
 }

--- a/lib/src/trace/export/console_exporter.dart
+++ b/lib/src/trace/export/console_exporter.dart
@@ -47,7 +47,8 @@ class ConsoleExporter extends SpanExporter {
       buffer.writeln('End Time: ${span.endTime!.toIso8601String()}');
       final duration = span.endTime!.difference(span.startTime);
       buffer.writeln(
-          'Duration: ${duration.inMicroseconds}μs (${duration.inMilliseconds}ms)');
+        'Duration: ${duration.inMicroseconds}μs (${duration.inMilliseconds}ms)',
+      );
     } else {
       buffer.writeln('End Time: (not ended)');
     }
@@ -82,7 +83,8 @@ class ConsoleExporter extends SpanExporter {
       buffer.writeln('Links:');
       for (final link in links) {
         buffer.writeln(
-            '  -> Trace: ${link.spanContext.traceId}, Span: ${link.spanContext.spanId}');
+          '  -> Trace: ${link.spanContext.traceId}, Span: ${link.spanContext.spanId}',
+        );
         for (final attr in link.attributes.toList()) {
           buffer.writeln('    ${attr.key}: ${attr.value}');
         }

--- a/lib/src/trace/export/otlp/certificate_utils.dart
+++ b/lib/src/trace/export/otlp/certificate_utils.dart
@@ -38,14 +38,16 @@ class CertificateUtils {
       if (certificate.startsWith('test://')) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'CertificateUtils: Using test certificate: $certificate');
+            'CertificateUtils: Using test certificate: $certificate',
+          );
         }
       } else {
         final certFile = File(certificate);
         context.setTrustedCertificatesBytes(certFile.readAsBytesSync());
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'CertificateUtils: Loaded CA certificate from $certificate');
+            'CertificateUtils: Loaded CA certificate from $certificate',
+          );
         }
       }
     }
@@ -57,7 +59,8 @@ class CertificateUtils {
           clientKey.startsWith('test://')) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'CertificateUtils: Using test client certificate and key');
+            'CertificateUtils: Using test client certificate and key',
+          );
         }
       } else {
         final certFile = File(clientCertificate);
@@ -66,7 +69,8 @@ class CertificateUtils {
         context.usePrivateKeyBytes(keyFile.readAsBytesSync());
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'CertificateUtils: Loaded client certificate from $clientCertificate and key from $clientKey');
+            'CertificateUtils: Loaded client certificate from $clientCertificate and key from $clientKey',
+          );
         }
       }
     }
@@ -103,7 +107,8 @@ class CertificateUtils {
     }
     if (!isValidPath(clientCertificate)) {
       throw ArgumentError(
-          'Client certificate file not found: $clientCertificate');
+        'Client certificate file not found: $clientCertificate',
+      );
     }
   }
 }

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
@@ -40,9 +40,11 @@ class OtlpHttpSpanExporter implements SpanExporter {
       : _config = config ?? OtlpHttpExporterConfig() {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Created with endpoint: ${_config.endpoint}');
+        'OtlpHttpSpanExporter: Created with endpoint: ${_config.endpoint}',
+      );
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Configured headers count: ${_config.headers.length}');
+        'OtlpHttpSpanExporter: Configured headers count: ${_config.headers.length}',
+      );
       _config.headers.forEach((key, value) {
         if (key.toLowerCase() == 'authorization') {
           OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
@@ -85,7 +87,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
     } catch (e) {
       if (OTelLog.isError()) {
         OTelLog.error(
-            'OtlpHttpSpanExporter: Failed to create HTTP client with certificates: $e');
+          'OtlpHttpSpanExporter: Failed to create HTTP client with certificates: $e',
+        );
       }
       // Fall back to default client on error
       return http.Client();
@@ -123,10 +126,12 @@ class OtlpHttpSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Preparing to export ${spans.length} spans');
+        'OtlpHttpSpanExporter: Preparing to export ${spans.length} spans',
+      );
       for (var span in spans) {
         OTelLog.debug(
-            '  Span: ${span.name}, spanId: ${span.spanContext.spanId}, traceId: ${span.spanContext.traceId}');
+          '  Span: ${span.name}, spanId: ${span.spanContext.spanId}, traceId: ${span.spanContext.traceId}',
+        );
       }
     }
 
@@ -161,7 +166,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
     final endpointUrl = _getEndpointUrl();
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Sending export request to $endpointUrl');
+        'OtlpHttpSpanExporter: Sending export request to $endpointUrl',
+      );
       OTelLog.debug('OtlpHttpSpanExporter: Request headers:');
       headers.forEach((key, value) {
         // Mask authorization header value for security, but show it exists
@@ -175,17 +181,14 @@ class OtlpHttpSpanExporter implements SpanExporter {
 
     try {
       final http.Response response = await _client
-          .post(
-            Uri.parse(endpointUrl),
-            headers: headers,
-            body: bodyBytes,
-          )
+          .post(Uri.parse(endpointUrl), headers: headers, body: bodyBytes)
           .timeout(_config.timeout);
 
       if (response.statusCode >= 200 && response.statusCode < 300) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpSpanExporter: Export request completed successfully');
+            'OtlpHttpSpanExporter: Export request completed successfully',
+          );
         }
       } else {
         final String errorMessage =
@@ -217,7 +220,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Beginning export of ${spans.length} spans');
+        'OtlpHttpSpanExporter: Beginning export of ${spans.length} spans',
+      );
     }
     final exportFuture = _export(spans);
 
@@ -235,7 +239,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
         // Gracefully handle the case where shutdown interrupted the export
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpSpanExporter: Export was interrupted by shutdown, suppressing error');
+            'OtlpHttpSpanExporter: Export was interrupted by shutdown, suppressing error',
+          );
         }
       } else {
         // Re-throw other errors
@@ -253,7 +258,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Attempting to export ${spans.length} spans to ${_config.endpoint}');
+        'OtlpHttpSpanExporter: Attempting to export ${spans.length} spans to ${_config.endpoint}',
+      );
     }
 
     var attempts = 0;
@@ -268,7 +274,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
         if (wasShutdownDuringRetry && attempts > 0) {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'OtlpHttpSpanExporter: Export interrupted by shutdown');
+              'OtlpHttpSpanExporter: Export interrupted by shutdown',
+            );
           }
           throw StateError('Exporter was shut down during export');
         }
@@ -288,7 +295,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
         if (wasShutdownDuringRetry) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpHttpSpanExporter: Export interrupted by shutdown');
+              'OtlpHttpSpanExporter: Export interrupted by shutdown',
+            );
           }
           throw StateError('Exporter was shut down during export');
         }
@@ -307,7 +315,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
         if (!shouldRetry) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpHttpSpanExporter: Non-retryable HTTP error, stopping retry attempts');
+              'OtlpHttpSpanExporter: Non-retryable HTTP error, stopping retry attempts',
+            );
           }
           rethrow;
         }
@@ -315,7 +324,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
         if (attempts >= maxAttempts - 1) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpHttpSpanExporter: Max attempts reached ($attempts out of $maxAttempts), giving up');
+              'OtlpHttpSpanExporter: Max attempts reached ($attempts out of $maxAttempts), giving up',
+            );
           }
           rethrow;
         }
@@ -323,14 +333,16 @@ class OtlpHttpSpanExporter implements SpanExporter {
         final delay = _calculateJitteredDelay(attempts);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpSpanExporter: Retrying export after ${delay.inMilliseconds}ms...');
+            'OtlpHttpSpanExporter: Retrying export after ${delay.inMilliseconds}ms...',
+          );
         }
         await Future<void>.delayed(delay);
         attempts++;
       } catch (e, stackTrace) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'OtlpHttpSpanExporter: Unexpected error during export: $e');
+            'OtlpHttpSpanExporter: Unexpected error during export: $e',
+          );
         }
         if (OTelLog.isError()) OTelLog.error('Stack trace: $stackTrace');
 
@@ -346,7 +358,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
         final delay = _calculateJitteredDelay(attempts);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpSpanExporter: Retrying export after ${delay.inMilliseconds}ms...');
+            'OtlpHttpSpanExporter: Retrying export after ${delay.inMilliseconds}ms...',
+          );
         }
         await Future<void>.delayed(delay);
         attempts++;
@@ -363,7 +376,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpHttpSpanExporter: Exporter is already shut down, nothing to flush');
+          'OtlpHttpSpanExporter: Exporter is already shut down, nothing to flush',
+        );
       }
       return;
     }
@@ -372,7 +386,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
     if (_pendingExports.isNotEmpty) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpHttpSpanExporter: Waiting for ${_pendingExports.length} pending exports to complete');
+          'OtlpHttpSpanExporter: Waiting for ${_pendingExports.length} pending exports to complete',
+        );
       }
       try {
         await Future.wait(_pendingExports);
@@ -401,7 +416,8 @@ class OtlpHttpSpanExporter implements SpanExporter {
     }
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpHttpSpanExporter: Shutting down - waiting for ${_pendingExports.length} pending exports');
+        'OtlpHttpSpanExporter: Shutting down - waiting for ${_pendingExports.length} pending exports',
+      );
     }
 
     // Set shutdown flag first
@@ -415,22 +431,27 @@ class OtlpHttpSpanExporter implements SpanExporter {
     if (pendingExportsCopy.isNotEmpty) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpHttpSpanExporter: Waiting for ${pendingExportsCopy.length} pending exports with timeout');
+          'OtlpHttpSpanExporter: Waiting for ${pendingExportsCopy.length} pending exports with timeout',
+        );
       }
       try {
         // Use a generous timeout but don't wait forever
-        await Future.wait(pendingExportsCopy)
-            .timeout(const Duration(seconds: 10), onTimeout: () {
-          if (OTelLog.isDebug()) {
-            OTelLog.debug(
-                'OtlpHttpSpanExporter: Timeout waiting for exports to complete');
-          }
-          return Future.value([]);
-        });
+        await Future.wait(pendingExportsCopy).timeout(
+          const Duration(seconds: 10),
+          onTimeout: () {
+            if (OTelLog.isDebug()) {
+              OTelLog.debug(
+                'OtlpHttpSpanExporter: Timeout waiting for exports to complete',
+              );
+            }
+            return Future.value([]);
+          },
+        );
       } catch (e) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpHttpSpanExporter: Error during shutdown while waiting for exports: $e');
+            'OtlpHttpSpanExporter: Error during shutdown while waiting for exports: $e',
+          );
         }
       }
     }

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter_config.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter_config.dart
@@ -150,7 +150,10 @@ class OtlpHttpExporterConfig {
   }
 
   static void _validateCertificates(
-      String? cert, String? key, String? clientCert) {
+    String? cert,
+    String? key,
+    String? clientCert,
+  ) {
     CertificateUtils.validateCertificates(
       certificate: cert,
       clientKey: key,

--- a/lib/src/trace/export/otlp/otlp_grpc_span_exporter.dart
+++ b/lib/src/trace/export/otlp/otlp_grpc_span_exporter.dart
@@ -100,15 +100,18 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         try {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'OtlpGrpcSpanExporter: Attempting graceful channel shutdown');
+              'OtlpGrpcSpanExporter: Attempting graceful channel shutdown',
+            );
           }
           await _channel!.shutdown();
-          await Future<void>.delayed(const Duration(
-              milliseconds: 100)); // Brief delay for shutdown to complete
+          await Future<void>.delayed(
+            const Duration(milliseconds: 100),
+          ); // Brief delay for shutdown to complete
         } catch (e) {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'OtlpGrpcSpanExporter: Error during graceful shutdown: $e');
+              'OtlpGrpcSpanExporter: Error during graceful shutdown: $e',
+            );
           }
         }
 
@@ -118,18 +121,21 @@ class OtlpGrpcSpanExporter implements SpanExporter {
             OTelLog.debug('OtlpGrpcSpanExporter: Terminating channel');
           }
           _channel!.terminate();
-          await Future<void>.delayed(const Duration(
-              milliseconds: 100)); // Brief delay for termination to complete
+          await Future<void>.delayed(
+            const Duration(milliseconds: 100),
+          ); // Brief delay for termination to complete
         } catch (e) {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'OtlpGrpcSpanExporter: Error terminating channel: $e');
+              'OtlpGrpcSpanExporter: Error terminating channel: $e',
+            );
           }
         }
       } catch (e) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'OtlpGrpcSpanExporter: Error shutting down existing channel: $e');
+            'OtlpGrpcSpanExporter: Error shutting down existing channel: $e',
+          );
         }
       }
 
@@ -157,14 +163,16 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Not setting up channel - exporter is shut down');
+          'OtlpGrpcSpanExporter: Not setting up channel - exporter is shut down',
+        );
       }
       return;
     }
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpGrpcSpanExporter: Setting up gRPC channel with endpoint ${_config.endpoint}');
+        'OtlpGrpcSpanExporter: Setting up gRPC channel with endpoint ${_config.endpoint}',
+      );
     }
 
     // First, clean up any existing channel
@@ -174,9 +182,10 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     int port;
 
     try {
-      final endpoint = _config.endpoint
-          .trim()
-          .replaceAll(RegExp(r'^(http://|https://)'), '');
+      final endpoint = _config.endpoint.trim().replaceAll(
+            RegExp(r'^(http://|https://)'),
+            '',
+          );
       final parts = endpoint.split(':');
       host = parts[0].isEmpty ? '127.0.0.1' : parts[0];
       port = parts.length > 1 ? int.parse(parts[1]) : 4317;
@@ -188,7 +197,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
 
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Setting up gRPC channel to $host:$port');
+          'OtlpGrpcSpanExporter: Setting up gRPC channel to $host:$port',
+        );
       }
 
       // Create a channel
@@ -200,10 +210,9 @@ class OtlpGrpcSpanExporter implements SpanExporter {
           connectTimeout: const Duration(seconds: 5),
           // Keep connection alive better
           idleTimeout: const Duration(seconds: 30),
-          codecRegistry: CodecRegistry(codecs: const [
-            GzipCodec(),
-            IdentityCodec(),
-          ]),
+          codecRegistry: CodecRegistry(
+            codecs: const [GzipCodec(), IdentityCodec()],
+          ),
         ),
       );
 
@@ -211,23 +220,27 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         _traceService = proto.TraceServiceClient(_channel!);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpGrpcSpanExporter: Successfully created TraceServiceClient');
+            'OtlpGrpcSpanExporter: Successfully created TraceServiceClient',
+          );
         }
       } catch (e) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'OtlpGrpcSpanExporter: Failed to create TraceServiceClient: $e');
+            'OtlpGrpcSpanExporter: Failed to create TraceServiceClient: $e',
+          );
         }
         rethrow;
       }
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Successfully created gRPC channel and trace service');
+          'OtlpGrpcSpanExporter: Successfully created gRPC channel and trace service',
+        );
       }
     } catch (e, stackTrace) {
       if (OTelLog.isError()) {
         OTelLog.error(
-            ('OtlpGrpcSpanExporter: Failed to setup gRPC channel: $e'));
+          ('OtlpGrpcSpanExporter: Failed to setup gRPC channel: $e'),
+        );
       }
       if (OTelLog.isError()) OTelLog.error('Stack trace: $stackTrace');
       rethrow;
@@ -238,7 +251,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Not ensuring channel - exporter is shut down');
+          'OtlpGrpcSpanExporter: Not ensuring channel - exporter is shut down',
+        );
       }
       throw StateError('Exporter is shutdown');
     }
@@ -271,10 +285,12 @@ class OtlpGrpcSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpGrpcSpanExporter: Preparing to export ${spans.length} spans');
+        'OtlpGrpcSpanExporter: Preparing to export ${spans.length} spans',
+      );
       for (var span in spans) {
         OTelLog.debug(
-            '  Span: ${span.name}, spanId: ${span.spanContext.spanId}, traceId: ${span.spanContext.traceId}');
+          '  Span: ${span.name}, spanId: ${span.spanContext.spanId}, traceId: ${span.spanContext.traceId}',
+        );
       }
     }
 
@@ -319,18 +335,21 @@ class OtlpGrpcSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpGrpcSpanExporter: Sending export request to ${_config.endpoint}');
+        'OtlpGrpcSpanExporter: Sending export request to ${_config.endpoint}',
+      );
     }
     try {
       if (_traceService == null) {
         throw StateError(
-            'Trace service is null, channel may not be properly initialized');
+          'Trace service is null, channel may not be properly initialized',
+        );
       }
 
       final response = await _traceService!.export(request, options: options);
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Export request completed successfully');
+          'OtlpGrpcSpanExporter: Export request completed successfully',
+        );
       }
       if (OTelLog.isDebug()) {
         OTelLog.debug('OtlpGrpcSpanExporter: Response: $response');
@@ -348,7 +367,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
               e.code == StatusCode.internal)) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpGrpcSpanExporter: Channel error detected, recreating channel');
+            'OtlpGrpcSpanExporter: Channel error detected, recreating channel',
+          );
         }
         // Force channel recreation
         await _cleanupChannel();
@@ -374,7 +394,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpGrpcSpanExporter: Beginning export of ${spans.length} spans');
+        'OtlpGrpcSpanExporter: Beginning export of ${spans.length} spans',
+      );
     }
     final exportFuture = _export(spans);
 
@@ -392,7 +413,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         // Gracefully handle the case where shutdown interrupted the export
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpGrpcSpanExporter: Export was interrupted by shutdown, suppressing error');
+            'OtlpGrpcSpanExporter: Export was interrupted by shutdown, suppressing error',
+          );
         }
       } else {
         // Re-throw other errors
@@ -410,7 +432,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpGrpcSpanExporter: Attempting to export ${spans.length} spans to ${_config.endpoint}');
+        'OtlpGrpcSpanExporter: Attempting to export ${spans.length} spans to ${_config.endpoint}',
+      );
     }
 
     var attempts = 0;
@@ -425,7 +448,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         if (wasShutdownDuringRetry && attempts > 0) {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'OtlpGrpcSpanExporter: Export interrupted by shutdown');
+              'OtlpGrpcSpanExporter: Export interrupted by shutdown',
+            );
           }
           throw StateError('Exporter was shut down during export');
         }
@@ -438,7 +462,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
       } on GrpcError catch (e, stackTrace) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'OtlpGrpcSpanExporter: gRPC error during export: ${e.code} - ${e.message}');
+            'OtlpGrpcSpanExporter: gRPC error during export: ${e.code} - ${e.message}',
+          );
         }
         if (OTelLog.isError()) OTelLog.error('Stack trace: $stackTrace');
 
@@ -446,7 +471,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         if (wasShutdownDuringRetry) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpGrpcSpanExporter: Export interrupted by shutdown');
+              'OtlpGrpcSpanExporter: Export interrupted by shutdown',
+            );
           }
           throw StateError('Exporter was shut down during export');
         }
@@ -454,7 +480,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         if (!_retryableStatusCodes.contains(e.code)) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpGrpcSpanExporter: Non-retryable gRPC error (${e.code}), stopping retry attempts');
+              'OtlpGrpcSpanExporter: Non-retryable gRPC error (${e.code}), stopping retry attempts',
+            );
           }
           rethrow;
         }
@@ -462,7 +489,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         if (attempts >= maxAttempts - 1) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'OtlpGrpcSpanExporter: Max attempts reached ($attempts out of $maxAttempts), giving up');
+              'OtlpGrpcSpanExporter: Max attempts reached ($attempts out of $maxAttempts), giving up',
+            );
           }
           rethrow;
         }
@@ -470,7 +498,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         final delay = _calculateJitteredDelay(attempts);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpGrpcSpanExporter: Retrying export after ${delay.inMilliseconds}ms...');
+            'OtlpGrpcSpanExporter: Retrying export after ${delay.inMilliseconds}ms...',
+          );
         }
         await Future<void>.delayed(delay);
         if (!_isShutdown) {
@@ -481,7 +510,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
       } catch (e, stackTrace) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'OtlpGrpcSpanExporter: Unexpected error during export: $e');
+            'OtlpGrpcSpanExporter: Unexpected error during export: $e',
+          );
         }
         if (OTelLog.isError()) OTelLog.error('Stack trace: $stackTrace');
 
@@ -497,7 +527,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         final delay = _calculateJitteredDelay(attempts);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpGrpcSpanExporter: Retrying export after ${delay.inMilliseconds}ms...');
+            'OtlpGrpcSpanExporter: Retrying export after ${delay.inMilliseconds}ms...',
+          );
         }
         await Future<void>.delayed(delay);
         if (!_isShutdown) {
@@ -518,7 +549,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Exporter is already shut down, nothing to flush');
+          'OtlpGrpcSpanExporter: Exporter is already shut down, nothing to flush',
+        );
       }
       return;
     }
@@ -527,7 +559,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     if (_pendingExports.isNotEmpty) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Waiting for ${_pendingExports.length} pending exports to complete');
+          'OtlpGrpcSpanExporter: Waiting for ${_pendingExports.length} pending exports to complete',
+        );
       }
       try {
         await Future.wait(_pendingExports);
@@ -556,7 +589,8 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     }
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'OtlpGrpcSpanExporter: Shutting down - waiting for ${_pendingExports.length} pending exports');
+        'OtlpGrpcSpanExporter: Shutting down - waiting for ${_pendingExports.length} pending exports',
+      );
     }
 
     // Set shutdown flag first
@@ -570,22 +604,27 @@ class OtlpGrpcSpanExporter implements SpanExporter {
     if (pendingExportsCopy.isNotEmpty) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'OtlpGrpcSpanExporter: Waiting for ${pendingExportsCopy.length} pending exports with timeout');
+          'OtlpGrpcSpanExporter: Waiting for ${pendingExportsCopy.length} pending exports with timeout',
+        );
       }
       try {
         // Use a generous timeout but don't wait forever
-        await Future.wait(pendingExportsCopy)
-            .timeout(const Duration(seconds: 10), onTimeout: () {
-          if (OTelLog.isDebug()) {
-            OTelLog.debug(
-                'OtlpGrpcSpanExporter: Timeout waiting for exports to complete');
-          }
-          return Future.value([]);
-        });
+        await Future.wait(pendingExportsCopy).timeout(
+          const Duration(seconds: 10),
+          onTimeout: () {
+            if (OTelLog.isDebug()) {
+              OTelLog.debug(
+                'OtlpGrpcSpanExporter: Timeout waiting for exports to complete',
+              );
+            }
+            return Future.value([]);
+          },
+        );
       } catch (e) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'OtlpGrpcSpanExporter: Error during shutdown while waiting for exports: $e');
+            'OtlpGrpcSpanExporter: Error during shutdown while waiting for exports: $e',
+          );
         }
       }
     }

--- a/lib/src/trace/export/otlp/otlp_grpc_span_exporter_config.dart
+++ b/lib/src/trace/export/otlp/otlp_grpc_span_exporter_config.dart
@@ -134,7 +134,8 @@ class OtlpGrpcExporterConfig {
           final portStr = endpoint.split(':').last;
           if (int.tryParse(portStr) == null) {
             throw ArgumentError(
-                'Invalid port format in endpoint URL: $endpoint');
+              'Invalid port format in endpoint URL: $endpoint',
+            );
           }
         }
         return endpoint;
@@ -163,13 +164,15 @@ class OtlpGrpcExporterConfig {
       }
 
       throw ArgumentError(
-          'Invalid endpoint format: $endpoint. Expected format: "host:port" or a valid URI');
+        'Invalid endpoint format: $endpoint. Expected format: "host:port" or a valid URI',
+      );
     } catch (e) {
       if (e is ArgumentError) rethrow; // Re-throw our own errors
 
       // Any other parsing error
       throw ArgumentError(
-          'Invalid endpoint format: $endpoint. Expected format: "host:port" or a valid URI');
+        'Invalid endpoint format: $endpoint. Expected format: "host:port" or a valid URI',
+      );
     }
   }
 
@@ -197,7 +200,10 @@ class OtlpGrpcExporterConfig {
   }
 
   static void _validateCertificates(
-      String? cert, String? key, String? clientCert) {
+    String? cert,
+    String? key,
+    String? clientCert,
+  ) {
     CertificateUtils.validateCertificates(
       certificate: cert,
       clientKey: key,

--- a/lib/src/trace/export/otlp/span_transformer.dart
+++ b/lib/src/trace/export/otlp/span_transformer.dart
@@ -132,8 +132,9 @@ class OtlpSpanTransformer {
       ..startTimeUnixNano = Int64(span.startTime.microsecondsSinceEpoch * 1000);
 
     if (span.endTime != null) {
-      otlpSpan.endTimeUnixNano =
-          Int64(span.endTime!.microsecondsSinceEpoch * 1000);
+      otlpSpan.endTimeUnixNano = Int64(
+        span.endTime!.microsecondsSinceEpoch * 1000,
+      );
     }
 
     // First check if we have a parent span
@@ -177,7 +178,9 @@ class OtlpSpanTransformer {
 
   /// Convert span status to OTLP Status
   static proto.Status transformStatus(
-      SpanStatusCode status, String? description) {
+    SpanStatusCode status,
+    String? description,
+  ) {
     final otlpStatus = proto.Status();
 
     switch (status) {
@@ -277,23 +280,33 @@ class OtlpSpanTransformer {
       anyValue.doubleValue = attr.value as double;
     } else if (attr.value is List<String>) {
       final arrayValue = proto.ArrayValue();
-      arrayValue.values.addAll((attr.value as List<String>)
-          .map((v) => proto.AnyValue()..stringValue = v));
+      arrayValue.values.addAll(
+        (attr.value as List<String>).map(
+          (v) => proto.AnyValue()..stringValue = v,
+        ),
+      );
       anyValue.arrayValue = arrayValue;
     } else if (attr.value is List<bool>) {
       final arrayValue = proto.ArrayValue();
-      arrayValue.values.addAll((attr.value as List<bool>)
-          .map((v) => proto.AnyValue()..boolValue = v));
+      arrayValue.values.addAll(
+        (attr.value as List<bool>).map((v) => proto.AnyValue()..boolValue = v),
+      );
       anyValue.arrayValue = arrayValue;
     } else if (attr.value is List<int>) {
       final arrayValue = proto.ArrayValue();
-      arrayValue.values.addAll((attr.value as List<int>)
-          .map((v) => proto.AnyValue()..intValue = Int64(v)));
+      arrayValue.values.addAll(
+        (attr.value as List<int>).map(
+          (v) => proto.AnyValue()..intValue = Int64(v),
+        ),
+      );
       anyValue.arrayValue = arrayValue;
     } else if (attr.value is List<double>) {
       final arrayValue = proto.ArrayValue();
-      arrayValue.values.addAll((attr.value as List<double>)
-          .map((v) => proto.AnyValue()..doubleValue = v));
+      arrayValue.values.addAll(
+        (attr.value as List<double>).map(
+          (v) => proto.AnyValue()..doubleValue = v,
+        ),
+      );
       anyValue.arrayValue = arrayValue;
     } else {
       // For any other type, convert to string

--- a/lib/src/trace/export/simple_span_processor.dart
+++ b/lib/src/trace/export/simple_span_processor.dart
@@ -23,7 +23,8 @@ class SimpleSpanProcessor implements SpanProcessor {
   Future<void> onStart(Span span, Context? parentContext) async {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SimpleSpanProcessor: onStart called for span ${span.spanContext.spanId}, traceId: ${span.spanContext.traceId}');
+        'SimpleSpanProcessor: onStart called for span ${span.spanContext.spanId}, traceId: ${span.spanContext.traceId}',
+      );
     }
   }
 
@@ -31,12 +32,14 @@ class SimpleSpanProcessor implements SpanProcessor {
   Future<void> onEnd(Span span) async {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SimpleSpanProcessor: onEnd called for span ${span.name} with ID ${span.spanContext.spanId}');
+        'SimpleSpanProcessor: onEnd called for span ${span.name} with ID ${span.spanContext.spanId}',
+      );
     }
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'SimpleSpanProcessor: Skipping export - processor is shutdown');
+          'SimpleSpanProcessor: Skipping export - processor is shutdown',
+        );
       }
       print('SimpleSpanProcessor: Skipping export - processor is shutdown');
       return;
@@ -46,14 +49,16 @@ class SimpleSpanProcessor implements SpanProcessor {
     if (span.endTime == null) {
       if (OTelLog.isWarn()) {
         OTelLog.warn(
-            'SimpleSpanProcessor: Span ${span.name} with ID ${span.spanContext.spanId} has no end time, which suggests it may not be properly ended');
+          'SimpleSpanProcessor: Span ${span.name} with ID ${span.spanContext.spanId} has no end time, which suggests it may not be properly ended',
+        );
       }
       // Continue with export anyway
     }
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SimpleSpanProcessor: Exporting span ${span.spanContext.spanId} with name ${span.name}');
+        'SimpleSpanProcessor: Exporting span ${span.spanContext.spanId} with name ${span.name}',
+      );
     }
 
     try {
@@ -67,37 +72,43 @@ class SimpleSpanProcessor implements SpanProcessor {
       _pendingExports.add(pendingExport);
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'SimpleSpanProcessor: Added export to pending exports list');
+          'SimpleSpanProcessor: Added export to pending exports list',
+        );
       }
 
       // Directly await the export for better reliability in tests
       try {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'SimpleSpanProcessor: Awaiting export completion for span ${span.name}');
+            'SimpleSpanProcessor: Awaiting export completion for span ${span.name}',
+          );
         }
         await pendingExport;
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'SimpleSpanProcessor: Successfully exported span ${span.name} with ID ${span.spanContext.spanId}');
+            'SimpleSpanProcessor: Successfully exported span ${span.name} with ID ${span.spanContext.spanId}',
+          );
         }
       } catch (e, stackTrace) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'SimpleSpanProcessor: Export error while processing span ${span.spanContext.spanId}: $e');
+            'SimpleSpanProcessor: Export error while processing span ${span.spanContext.spanId}: $e',
+          );
           OTelLog.error('Stack trace: $stackTrace');
         }
       } finally {
         _pendingExports.remove(pendingExport);
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'SimpleSpanProcessor: Removed export from pending list');
+            'SimpleSpanProcessor: Removed export from pending list',
+          );
         }
       }
     } catch (e, stackTrace) {
       if (OTelLog.isError()) {
         OTelLog.error(
-            'SimpleSpanProcessor: Failed to start export for span ${span.spanContext.spanId}: $e');
+          'SimpleSpanProcessor: Failed to start export for span ${span.spanContext.spanId}: $e',
+        );
         OTelLog.error('Stack trace: $stackTrace');
       }
     }
@@ -109,7 +120,8 @@ class SimpleSpanProcessor implements SpanProcessor {
     // since it only processes spans when they end
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SimpleSpanProcessor: Name updated for span ${span.spanContext.spanId} to $newName');
+        'SimpleSpanProcessor: Name updated for span ${span.spanContext.spanId} to $newName',
+      );
     }
   }
 
@@ -124,7 +136,8 @@ class SimpleSpanProcessor implements SpanProcessor {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SimpleSpanProcessor: Shutting down - waiting for ${_pendingExports.length} pending exports');
+        'SimpleSpanProcessor: Shutting down - waiting for ${_pendingExports.length} pending exports',
+      );
     }
     _isShutdown = true;
 
@@ -132,7 +145,8 @@ class SimpleSpanProcessor implements SpanProcessor {
       if (_pendingExports.isNotEmpty) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'SimpleSpanProcessor: Waiting for ${_pendingExports.length} pending exports to complete');
+            'SimpleSpanProcessor: Waiting for ${_pendingExports.length} pending exports to complete',
+          );
         }
         try {
           await Future.wait(_pendingExports);
@@ -142,7 +156,8 @@ class SimpleSpanProcessor implements SpanProcessor {
         } catch (e) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'SimpleSpanProcessor: Error waiting for pending exports: $e');
+              'SimpleSpanProcessor: Error waiting for pending exports: $e',
+            );
           }
         }
       }
@@ -158,7 +173,8 @@ class SimpleSpanProcessor implements SpanProcessor {
       } catch (e) {
         if (OTelLog.isError()) {
           OTelLog.error(
-              'SimpleSpanProcessor: Error shutting down exporter: $e');
+            'SimpleSpanProcessor: Error shutting down exporter: $e',
+          );
         }
       }
 
@@ -178,14 +194,16 @@ class SimpleSpanProcessor implements SpanProcessor {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'SimpleSpanProcessor: Cannot force flush - processor is shut down');
+          'SimpleSpanProcessor: Cannot force flush - processor is shut down',
+        );
       }
       return;
     }
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SimpleSpanProcessor: Force flushing - waiting for ${_pendingExports.length} pending exports');
+        'SimpleSpanProcessor: Force flushing - waiting for ${_pendingExports.length} pending exports',
+      );
     }
 
     try {
@@ -198,7 +216,8 @@ class SimpleSpanProcessor implements SpanProcessor {
       } else {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'SimpleSpanProcessor: Waiting for ${_pendingExports.length} pending exports');
+            'SimpleSpanProcessor: Waiting for ${_pendingExports.length} pending exports',
+          );
         }
         await Future.wait(_pendingExports);
         if (OTelLog.isDebug()) {

--- a/lib/src/trace/export/test_file_exporter.dart
+++ b/lib/src/trace/export/test_file_exporter.dart
@@ -59,7 +59,8 @@ class TestFileExporter implements SpanExporter {
       print('TestFileExporter: Cannot export - exporter is shut down');
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TestFileExporter: Cannot export - exporter is shut down');
+          'TestFileExporter: Cannot export - exporter is shut down',
+        );
       }
       throw StateError('Exporter is shutdown');
     }
@@ -78,7 +79,8 @@ class TestFileExporter implements SpanExporter {
       print('TestFileExporter: Exporting ${spans.length} spans to $_filePath');
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TestFileExporter: Exporting ${spans.length} spans to $_filePath');
+          'TestFileExporter: Exporting ${spans.length} spans to $_filePath',
+        );
       }
 
       // Convert spans to simplified JSON - avoiding properties that might not be accessible
@@ -103,7 +105,8 @@ class TestFileExporter implements SpanExporter {
       print('TestFileExporter: Successfully exported ${spans.length} spans');
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TestFileExporter: Successfully exported ${spans.length} spans');
+          'TestFileExporter: Successfully exported ${spans.length} spans',
+        );
       }
     } catch (e, stackTrace) {
       print('TestFileExporter ERROR: Failed to export spans: $e');

--- a/lib/src/trace/sampling/composite_sampler.dart
+++ b/lib/src/trace/sampling/composite_sampler.dart
@@ -81,7 +81,4 @@ class CompositeSampler implements Sampler {
   }
 }
 
-enum _Operation {
-  and,
-  or,
-}
+enum _Operation { and, or }

--- a/lib/src/trace/sampling/counting_sampler.dart
+++ b/lib/src/trace/sampling/counting_sampler.dart
@@ -219,8 +219,13 @@ class AttributeSamplingCondition extends SamplingCondition {
   /// @param boolValue Optional boolean value to match
   /// @param intValue Optional integer value to match
   /// @param doubleValue Optional double value to match
-  AttributeSamplingCondition(this.key,
-      {this.stringValue, this.boolValue, this.intValue, this.doubleValue}) {
+  AttributeSamplingCondition(
+    this.key, {
+    this.stringValue,
+    this.boolValue,
+    this.intValue,
+    this.doubleValue,
+  }) {
     int nonNullCount = 0;
     if (stringValue != null) {
       nonNullCount++;
@@ -236,7 +241,8 @@ class AttributeSamplingCondition extends SamplingCondition {
     }
     if (nonNullCount != 1) {
       throw ArgumentError(
-          'One of the type values must be non-null. string: $stringValue, bool: $boolValue, int: $intValue, double: $doubleValue');
+        'One of the type values must be non-null. string: $stringValue, bool: $boolValue, int: $intValue, double: $doubleValue',
+      );
     }
   }
 

--- a/lib/src/trace/span.dart
+++ b/lib/src/trace/span.dart
@@ -51,7 +51,8 @@ class Span implements APISpan {
   void end({DateTime? endTime, SpanStatusCode? spanStatus}) {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SDKSpan: Starting to end span ${spanContext.spanId} with name $name');
+        'SDKSpan: Starting to end span ${spanContext.spanId} with name $name',
+      );
     }
 
     if (spanStatus != null) {
@@ -71,23 +72,27 @@ class Span implements APISpan {
       final provider = _sdkTracer.provider;
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'SDKSpan: Notifying ${provider.spanProcessors.length} span processors');
+          'SDKSpan: Notifying ${provider.spanProcessors.length} span processors',
+        );
       }
       for (final processor in provider.spanProcessors) {
         try {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'SDKSpan: Calling onEnd for processor ${processor.runtimeType}');
+              'SDKSpan: Calling onEnd for processor ${processor.runtimeType}',
+            );
           }
           processor.onEnd(this);
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'SDKSpan: Successfully called onEnd for processor ${processor.runtimeType}');
+              'SDKSpan: Successfully called onEnd for processor ${processor.runtimeType}',
+            );
           }
         } catch (e, stackTrace) {
           if (OTelLog.isError()) {
             OTelLog.error(
-                'SDKSpan: Error calling onEnd for processor ${processor.runtimeType}: $e');
+              'SDKSpan: Error calling onEnd for processor ${processor.runtimeType}: $e',
+            );
             OTelLog.error('Stack trace: $stackTrace');
           }
         }
@@ -144,10 +149,18 @@ class Span implements APISpan {
   APISpan? get parentSpan => _delegate.parentSpan;
 
   @override
-  void recordException(Object exception,
-          {StackTrace? stackTrace, Attributes? attributes, bool? escaped}) =>
-      _delegate.recordException(exception,
-          stackTrace: stackTrace, attributes: attributes, escaped: escaped);
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Attributes? attributes,
+    bool? escaped,
+  }) =>
+      _delegate.recordException(
+        exception,
+        stackTrace: stackTrace,
+        attributes: attributes,
+        escaped: escaped,
+      );
 
   @override
   void setBoolAttribute(String name, bool value) =>
@@ -178,7 +191,8 @@ class Span implements APISpan {
     _delegate.setStatus(statusCode, description);
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SDKSpan: Set status to $statusCode for span ${spanContext.spanId}');
+        'SDKSpan: Set status to $statusCode for span ${spanContext.spanId}',
+      );
     }
   }
 

--- a/lib/src/trace/span_create.dart
+++ b/lib/src/trace/span_create.dart
@@ -14,8 +14,10 @@ class SDKSpanCreate {
   /// @param delegateSpan The API Span implementation to delegate to
   /// @param sdkTracer The SDK Tracer that created this Span
   /// @return A new Span instance
-  static Span create(
-      {required APISpan delegateSpan, required Tracer sdkTracer}) {
+  static Span create({
+    required APISpan delegateSpan,
+    required Tracer sdkTracer,
+  }) {
     return Span._(delegateSpan, sdkTracer);
   }
 }

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -88,7 +88,8 @@ class Tracer implements APITracer {
   T withSpan<T>(APISpan span, T Function() fn) {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'Tracer: withSpan called with span ${span.name}, spanId: ${span.spanContext.spanId}');
+        'Tracer: withSpan called with span ${span.name}, spanId: ${span.spanContext.spanId}',
+      );
     }
     final originalContext = Context.current;
     try {
@@ -99,7 +100,8 @@ class Tracer implements APITracer {
       final result = fn();
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Tracer: Function completed in withSpan for ${span.name}');
+          'Tracer: Function completed in withSpan for ${span.name}',
+        );
       }
       return result;
     } catch (e, stackTrace) {
@@ -120,7 +122,8 @@ class Tracer implements APITracer {
       if (!span.isValid) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'Tracer: Warning - span ${span.name} is invalid after withSpan operation');
+            'Tracer: Warning - span ${span.name} is invalid after withSpan operation',
+          );
         }
       }
     }
@@ -130,20 +133,23 @@ class Tracer implements APITracer {
   Future<T> withSpanAsync<T>(APISpan span, Future<T> Function() fn) async {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'Tracer: withSpanAsync called with span ${span.name}, spanId: ${span.spanContext.spanId}');
+        'Tracer: withSpanAsync called with span ${span.name}, spanId: ${span.spanContext.spanId}',
+      );
     }
     final originalContext = Context.current;
     try {
       Context.current = originalContext.setCurrentSpan(span);
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Tracer: Context set with span ${span.name} for async operation');
+          'Tracer: Context set with span ${span.name} for async operation',
+        );
       }
       return await fn();
     } catch (e, stackTrace) {
       if (OTelLog.isError()) {
         OTelLog.error(
-            'Tracer: Exception in withSpanAsync for ${span.name}: $e');
+          'Tracer: Exception in withSpanAsync for ${span.name}: $e',
+        );
       }
       if (span is Span) {
         span.recordException(e, stackTrace: stackTrace);
@@ -159,7 +165,8 @@ class Tracer implements APITracer {
       if (!span.isValid) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'Tracer: Warning - span ${span.name} is invalid after withSpanAsync operation');
+            'Tracer: Warning - span ${span.name} is invalid after withSpanAsync operation',
+          );
         }
       }
     }
@@ -221,10 +228,7 @@ class Tracer implements APITracer {
       context: context,
     );
 
-    return SDKSpanCreate.create(
-      delegateSpan: delegateSpan,
-      sdkTracer: this,
-    );
+    return SDKSpanCreate.create(delegateSpan: delegateSpan, sdkTracer: this);
   }
 
   @override
@@ -272,9 +276,10 @@ class Tracer implements APITracer {
       if (parentContext != null && parentContext.isValid) {
         if (parentContext.traceId != traceId) {
           throw ArgumentError(
-              'Cannot create span with different trace ID than parent. '
-              'Parent trace ID: ${parentContext.traceId}, '
-              'Provided trace ID: $traceId');
+            'Cannot create span with different trace ID than parent. '
+            'Parent trace ID: ${parentContext.traceId}, '
+            'Provided trace ID: $traceId',
+          );
         }
       }
     } else if (parentContext != null && parentContext.isValid) {
@@ -305,7 +310,8 @@ class Tracer implements APITracer {
     if (OTelLog.isDebug()) {
       if (parentSpanId != null) {
         OTelLog.debug(
-            'Creating child span: traceId=$traceId, parentSpanId=$parentSpanId');
+          'Creating child span: traceId=$traceId, parentSpanId=$parentSpanId',
+        );
       } else {
         OTelLog.debug('Creating root span: traceId=$traceId');
       }
@@ -329,7 +335,8 @@ class Tracer implements APITracer {
       // Update trace flags based on sampling decision
       if (traceFlags == null) {
         traceFlags = OTel.traceFlags(
-            shouldRecord ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG);
+          shouldRecord ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
+        );
       } else if (shouldRecord && !traceFlags.isSampled) {
         // Upgrade to sampled if necessary
         traceFlags = OTel.traceFlags(TraceFlags.SAMPLED_FLAG);
@@ -343,14 +350,16 @@ class Tracer implements APITracer {
         if (attributes == null) {
           attributes = samplingResult.attributes;
         } else {
-          attributes =
-              attributes.copyWithAttributes(samplingResult.attributes!);
+          attributes = attributes.copyWithAttributes(
+            samplingResult.attributes!,
+          );
         }
       }
 
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Sampling decision for span $name: ${samplingResult.decision}');
+          'Sampling decision for span $name: ${samplingResult.decision}',
+        );
       }
     }
 
@@ -365,14 +374,16 @@ class Tracer implements APITracer {
     );
 
     // Create the delegate span with our newly created span context
-    final APISpan delegateSpan = _delegate.startSpan(name,
-        context: effectiveContext,
-        spanContext: newSpanContext,
-        parentSpan: effectiveParentSpan,
-        kind: kind,
-        attributes: attributes,
-        links: links,
-        isRecording: isRecording ?? shouldRecord);
+    final APISpan delegateSpan = _delegate.startSpan(
+      name,
+      context: effectiveContext,
+      spanContext: newSpanContext,
+      parentSpan: effectiveParentSpan,
+      kind: kind,
+      attributes: attributes,
+      links: links,
+      isRecording: isRecording ?? shouldRecord,
+    );
 
     // Wrap it in our SDK span which will handle processing
     final sdkSpan = SDKSpanCreate.create(

--- a/lib/src/trace/tracer_create.dart
+++ b/lib/src/trace/tracer_create.dart
@@ -15,10 +15,11 @@ class SDKTracerCreate {
   /// @param provider The TracerProvider that created this Tracer
   /// @param sampler Optional custom sampler for this Tracer
   /// @return A new APITracer instance (actually a Tracer implementation)
-  static APITracer create(
-      {required APITracer delegate,
-      required TracerProvider provider,
-      Sampler? sampler}) {
+  static APITracer create({
+    required APITracer delegate,
+    required TracerProvider provider,
+    Sampler? sampler,
+  }) {
     return Tracer._(delegate: delegate, provider: provider, sampler: sampler);
   }
 }

--- a/lib/src/trace/tracer_provider.dart
+++ b/lib/src/trace/tracer_provider.dart
@@ -60,7 +60,8 @@ class TracerProvider implements APITracerProvider {
   }) : _delegate = delegate {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'TracerProvider: Created with resource: $resource, sampler: $sampler');
+        'TracerProvider: Created with resource: $resource, sampler: $sampler',
+      );
       if (resource != null) {
         OTelLog.debug('Resource attributes:');
         resource!.attributes.toList().forEach((attr) {
@@ -74,11 +75,13 @@ class TracerProvider implements APITracerProvider {
   Future<bool> shutdown() async {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'TracerProvider: Shutting down with ${_spanProcessors.length} processors');
+        'TracerProvider: Shutting down with ${_spanProcessors.length} processors',
+      );
     }
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'TracerProvider: Shutting down with ${_spanProcessors.length} processors');
+        'TracerProvider: Shutting down with ${_spanProcessors.length} processors',
+      );
     }
 
     if (!isShutdown) {
@@ -86,22 +89,26 @@ class TracerProvider implements APITracerProvider {
       for (final processor in _spanProcessors) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'TracerProvider: Shutting down processor ${processor.runtimeType}');
+            'TracerProvider: Shutting down processor ${processor.runtimeType}',
+          );
         }
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'SDKTracerProvider: Shutting down processor ${processor.runtimeType}');
+            'SDKTracerProvider: Shutting down processor ${processor.runtimeType}',
+          );
         }
         try {
           await processor.shutdown();
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'TracerProvider: Successfully shut down processor ${processor.runtimeType}');
+              'TracerProvider: Successfully shut down processor ${processor.runtimeType}',
+            );
           }
         } catch (e) {
           if (OTelLog.isDebug()) {
             OTelLog.debug(
-                'TracerProvider: Error shutting down processor ${processor.runtimeType}: $e');
+              'TracerProvider: Error shutting down processor ${processor.runtimeType}: $e',
+            );
           }
         }
       }
@@ -141,7 +148,8 @@ class TracerProvider implements APITracerProvider {
   }) {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'TracerProvider: Getting tracer with name: $name, version: $version, schemaUrl: $schemaUrl');
+        'TracerProvider: Getting tracer with name: $name, version: $version, schemaUrl: $schemaUrl',
+      );
     }
     if (isShutdown) {
       throw StateError('TracerProvider has been shut down');
@@ -178,7 +186,8 @@ class TracerProvider implements APITracerProvider {
     }
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'SDKTracerProvider: Adding span processor of type ${processor.runtimeType}');
+        'SDKTracerProvider: Adding span processor of type ${processor.runtimeType}',
+      );
     }
     _spanProcessors.add(processor);
   }
@@ -250,13 +259,15 @@ class TracerProvider implements APITracerProvider {
   Future<void> forceFlush() async {
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'TracerProvider: Force flushing ${_spanProcessors.length} processors');
+        'TracerProvider: Force flushing ${_spanProcessors.length} processors',
+      );
     }
 
     if (isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TracerProvider: Cannot force flush - provider is shut down');
+          'TracerProvider: Cannot force flush - provider is shut down',
+        );
       }
       return;
     }
@@ -265,17 +276,20 @@ class TracerProvider implements APITracerProvider {
       try {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'TracerProvider: Flushing processor ${processor.runtimeType}');
+            'TracerProvider: Flushing processor ${processor.runtimeType}',
+          );
         }
         await processor.forceFlush();
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'TracerProvider: Successfully flushed processor ${processor.runtimeType}');
+            'TracerProvider: Successfully flushed processor ${processor.runtimeType}',
+          );
         }
       } catch (e) {
         if (OTelLog.isDebug()) {
           OTelLog.debug(
-              'TracerProvider: Error flushing processor ${processor.runtimeType}: $e');
+            'TracerProvider: Error flushing processor ${processor.runtimeType}: $e',
+          );
         }
       }
     }

--- a/lib/src/trace/tracer_provider_create.dart
+++ b/lib/src/trace/tracer_provider_create.dart
@@ -15,8 +15,10 @@ class SDKTracerProviderCreate {
   /// @param delegate The API TracerProvider implementation to delegate to
   /// @param resource Optional Resource describing the entity producing telemetry
   /// @return A new TracerProvider instance
-  static TracerProvider create(
-      {required APITracerProvider delegate, Resource? resource}) {
+  static TracerProvider create({
+    required APITracerProvider delegate,
+    Resource? resource,
+  }) {
     return TracerProvider._(delegate: delegate, resource: resource);
   }
 }

--- a/lib/src/trace/w3c_trace_context_propagator.dart
+++ b/lib/src/trace/w3c_trace_context_propagator.dart
@@ -35,8 +35,11 @@ class W3CTraceContextPropagator
   static const _traceparentLength = 55; // 00-{32}-{16}-{2}
 
   @override
-  Context extract(Context context, Map<String, String> carrier,
-      TextMapGetter<String> getter) {
+  Context extract(
+    Context context,
+    Map<String, String> carrier,
+    TextMapGetter<String> getter,
+  ) {
     final traceparent = getter.get(_traceparentHeader);
 
     if (OTelLog.isDebug()) {
@@ -63,8 +66,9 @@ class W3CTraceContextPropagator
     if (tracestate != null && tracestate.isNotEmpty) {
       final tracestateMap = _parseTracestate(tracestate);
       if (tracestateMap.isNotEmpty) {
-        finalSpanContext =
-            spanContext.withTraceState(OTel.traceState(tracestateMap));
+        finalSpanContext = spanContext.withTraceState(
+          OTel.traceState(tracestateMap),
+        );
       }
     }
 
@@ -76,8 +80,11 @@ class W3CTraceContextPropagator
   }
 
   @override
-  void inject(Context context, Map<String, String> carrier,
-      TextMapSetter<String> setter) {
+  void inject(
+    Context context,
+    Map<String, String> carrier,
+    TextMapSetter<String> setter,
+  ) {
     final spanContext = context.spanContext;
 
     if (OTelLog.isDebug()) {
@@ -129,7 +136,8 @@ class W3CTraceContextPropagator
     if (traceparent.length != _traceparentLength) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Invalid traceparent length: ${traceparent.length}, expected $_traceparentLength');
+          'Invalid traceparent length: ${traceparent.length}, expected $_traceparentLength',
+        );
       }
       return null;
     }
@@ -138,7 +146,8 @@ class W3CTraceContextPropagator
     if (parts.length != 4) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Invalid traceparent format: expected 4 parts, got ${parts.length}');
+          'Invalid traceparent format: expected 4 parts, got ${parts.length}',
+        );
       }
       return null;
     }
@@ -162,7 +171,8 @@ class W3CTraceContextPropagator
     if (traceIdHex.length != 32) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Invalid trace ID length: ${traceIdHex.length}, expected 32');
+          'Invalid trace ID length: ${traceIdHex.length}, expected 32',
+        );
       }
       return null;
     }
@@ -171,7 +181,8 @@ class W3CTraceContextPropagator
     if (spanIdHex.length != 16) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Invalid span ID length: ${spanIdHex.length}, expected 16');
+          'Invalid span ID length: ${spanIdHex.length}, expected 16',
+        );
       }
       return null;
     }
@@ -180,7 +191,8 @@ class W3CTraceContextPropagator
     if (traceFlagsHex.length != 2) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'Invalid trace flags length: ${traceFlagsHex.length}, expected 2');
+          'Invalid trace flags length: ${traceFlagsHex.length}, expected 2',
+        );
       }
       return null;
     }

--- a/lib/src/util/zip/gzip_mock.dart
+++ b/lib/src/util/zip/gzip_mock.dart
@@ -10,10 +10,12 @@ import 'dart:typed_data';
 class GZip {
   /// Compress the [data] using gzip compression.
   Future<List<int>> compress(Uint8List data) async => throw UnimplementedError(
-      'GZip.compress is not implemented on this platform');
+        'GZip.compress is not implemented on this platform',
+      );
 
   /// Decode the gzip-compressed [data].
   Future<List<int>> decompress(Uint8List data) async =>
       throw UnimplementedError(
-          'GZip.decompress is not implemented on this platform');
+        'GZip.decompress is not implemented on this platform',
+      );
 }

--- a/lib/src/util/zip/gzip_web.dart
+++ b/lib/src/util/zip/gzip_web.dart
@@ -15,10 +15,12 @@ class GZip {
     final compressionStream = CompressionStream('gzip');
     final reader = _blob(data)
         .stream()
-        .pipeThrough(ReadableWritablePair(
-          readable: compressionStream.readable,
-          writable: compressionStream.writable,
-        ))
+        .pipeThrough(
+          ReadableWritablePair(
+            readable: compressionStream.readable,
+            writable: compressionStream.writable,
+          ),
+        )
         .getReader() as ReadableStreamDefaultReader;
     return await _readUntilDone(reader);
   }
@@ -28,10 +30,12 @@ class GZip {
     final decompressionStream = DecompressionStream('gzip');
     final reader = _blob(data)
         .stream()
-        .pipeThrough(ReadableWritablePair(
-          readable: decompressionStream.readable,
-          writable: decompressionStream.writable,
-        ))
+        .pipeThrough(
+          ReadableWritablePair(
+            readable: decompressionStream.readable,
+            writable: decompressionStream.writable,
+          ),
+        )
         .getReader() as ReadableStreamDefaultReader;
     return await _readUntilDone(reader);
   }
@@ -53,8 +57,6 @@ class GZip {
     return values;
   }
 
-  Blob _blob(Uint8List data) => Blob(
-        [data.toJS].toJS,
-        BlobPropertyBag(type: 'application/octet-stream'),
-      );
+  Blob _blob(Uint8List data) =>
+      Blob([data.toJS].toJS, BlobPropertyBag(type: 'application/octet-stream'));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartastic_opentelemetry
 description: OpenTelemetry SDK for Dart and Flutter. Distributed tracing, metrics, OTLP exporters (gRPC/HTTP),
   and context propagation for observability backends.
-version: 1.0.1-alpha
+version: 1.0.2-alpha
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry
 homepage: https://dartastic.io
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartastic_opentelemetry
 description: OpenTelemetry SDK for Dart and Flutter. Distributed tracing, metrics, OTLP exporters (gRPC/HTTP),
   and context propagation for observability backends.
-version: 1.0.2-alpha
+version: 1.0.0-alpha
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry
 homepage: https://dartastic.io
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartastic_opentelemetry
 description: OpenTelemetry SDK for Dart and Flutter. Distributed tracing, metrics, OTLP exporters (gRPC/HTTP),
   and context propagation for observability backends.
-version: 1.0.0-alpha
+version: 1.0.1-alpha
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry
 homepage: https://dartastic.io
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -4,10 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('Basic initialization works', () async {
     // Simple test to see if basic initialization works
-    await OTel.initialize(
-      serviceName: 'test-service',
-      serviceVersion: '1.0.0',
-    );
+    await OTel.initialize(serviceName: 'test-service', serviceVersion: '1.0.0');
 
     expect(OTel.defaultResource, isNotNull);
 

--- a/test/integration/cert_test.dart
+++ b/test/integration/cert_test.dart
@@ -15,109 +15,158 @@ void main() {
       // persist for the duration of the test run
     });
 
-    test('TLS with CA cert', () async {
-      // This test expects the collector to be running with TLS
-      // The environment variables should be set by the cert_test.sh script
+    test(
+      'TLS with CA cert',
+      () async {
+        // This test expects the collector to be running with TLS
+        // The environment variables should be set by the cert_test.sh script
 
-      final endpoint = Platform.environment['OTEL_EXPORTER_OTLP_ENDPOINT'];
-      final caCert = Platform.environment['OTEL_EXPORTER_OTLP_CERTIFICATE'];
+        final endpoint = Platform.environment['OTEL_EXPORTER_OTLP_ENDPOINT'];
+        final caCert = Platform.environment['OTEL_EXPORTER_OTLP_CERTIFICATE'];
 
-      expect(endpoint, isNotNull,
-          reason: 'OTEL_EXPORTER_OTLP_ENDPOINT must be set');
-      expect(caCert, isNotNull,
-          reason: 'OTEL_EXPORTER_OTLP_CERTIFICATE must be set');
-      expect(endpoint, startsWith('https://'),
-          reason: 'Endpoint must use HTTPS for TLS');
+        expect(
+          endpoint,
+          isNotNull,
+          reason: 'OTEL_EXPORTER_OTLP_ENDPOINT must be set',
+        );
+        expect(
+          caCert,
+          isNotNull,
+          reason: 'OTEL_EXPORTER_OTLP_CERTIFICATE must be set',
+        );
+        expect(
+          endpoint,
+          startsWith('https://'),
+          reason: 'Endpoint must use HTTPS for TLS',
+        );
 
-      // Verify certificate file exists
-      final certFile = File(caCert!);
-      expect(certFile.existsSync(), isTrue,
-          reason: 'CA certificate file must exist');
+        // Verify certificate file exists
+        final certFile = File(caCert!);
+        expect(
+          certFile.existsSync(),
+          isTrue,
+          reason: 'CA certificate file must exist',
+        );
 
-      print('Testing TLS with CA certificate: $caCert');
-      print('Endpoint: $endpoint');
+        print('Testing TLS with CA certificate: $caCert');
+        print('Endpoint: $endpoint');
 
-      // Initialize OTel - it will read from environment variables
-      await OTel.initialize(
-        serviceName: 'cert-test-tls',
-      );
+        // Initialize OTel - it will read from environment variables
+        await OTel.initialize(serviceName: 'cert-test-tls');
 
-      // Create a span
-      final tracer =
-          OTel.tracerProvider().getTracer('cert-test', version: '1.0.0');
-      await tracer.startActiveSpanAsync(
+        // Create a span
+        final tracer = OTel.tracerProvider().getTracer(
+          'cert-test',
+          version: '1.0.0',
+        );
+        await tracer.startActiveSpanAsync(
           name: 'tls-test-span',
           fn: (span) async {
-            span.addAttributes(Attributes.of({
-              'test.type': 'tls',
-              'test.timestamp': DateTime.now().toIso8601String()
-            }));
+            span.addAttributes(
+              Attributes.of({
+                'test.type': 'tls',
+                'test.timestamp': DateTime.now().toIso8601String(),
+              }),
+            );
             await Future<void>.delayed(const Duration(milliseconds: 100));
             span.end();
-          });
+          },
+        );
 
-      // Shutdown and flush
-      await OTel.shutdown();
+        // Shutdown and flush
+        await OTel.shutdown();
 
-      print('✅ TLS test completed successfully');
-    }, timeout: const Timeout(Duration(seconds: 30)), skip: true);
+        print('✅ TLS test completed successfully');
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+      skip: true,
+    );
 
-    test('mTLS with client cert', () async {
-      // This test expects the collector to be running with mTLS enabled
-      // The environment variables should be set by the cert_test.sh script
+    test(
+      'mTLS with client cert',
+      () async {
+        // This test expects the collector to be running with mTLS enabled
+        // The environment variables should be set by the cert_test.sh script
 
-      final endpoint = Platform.environment['OTEL_EXPORTER_OTLP_ENDPOINT'];
-      final caCert = Platform.environment['OTEL_EXPORTER_OTLP_CERTIFICATE'];
-      final clientCert =
-          Platform.environment['OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE'];
-      final clientKey = Platform.environment['OTEL_EXPORTER_OTLP_CLIENT_KEY'];
+        final endpoint = Platform.environment['OTEL_EXPORTER_OTLP_ENDPOINT'];
+        final caCert = Platform.environment['OTEL_EXPORTER_OTLP_CERTIFICATE'];
+        final clientCert =
+            Platform.environment['OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE'];
+        final clientKey = Platform.environment['OTEL_EXPORTER_OTLP_CLIENT_KEY'];
 
-      expect(endpoint, isNotNull,
-          reason: 'OTEL_EXPORTER_OTLP_ENDPOINT must be set');
-      expect(caCert, isNotNull,
-          reason: 'OTEL_EXPORTER_OTLP_CERTIFICATE must be set');
-      expect(clientCert, isNotNull,
-          reason: 'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE must be set');
-      expect(clientKey, isNotNull,
-          reason: 'OTEL_EXPORTER_OTLP_CLIENT_KEY must be set');
+        expect(
+          endpoint,
+          isNotNull,
+          reason: 'OTEL_EXPORTER_OTLP_ENDPOINT must be set',
+        );
+        expect(
+          caCert,
+          isNotNull,
+          reason: 'OTEL_EXPORTER_OTLP_CERTIFICATE must be set',
+        );
+        expect(
+          clientCert,
+          isNotNull,
+          reason: 'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE must be set',
+        );
+        expect(
+          clientKey,
+          isNotNull,
+          reason: 'OTEL_EXPORTER_OTLP_CLIENT_KEY must be set',
+        );
 
-      // Verify certificate files exist
-      expect(File(caCert!).existsSync(), isTrue,
-          reason: 'CA certificate file must exist');
-      expect(File(clientCert!).existsSync(), isTrue,
-          reason: 'Client certificate file must exist');
-      expect(File(clientKey!).existsSync(), isTrue,
-          reason: 'Client key file must exist');
+        // Verify certificate files exist
+        expect(
+          File(caCert!).existsSync(),
+          isTrue,
+          reason: 'CA certificate file must exist',
+        );
+        expect(
+          File(clientCert!).existsSync(),
+          isTrue,
+          reason: 'Client certificate file must exist',
+        );
+        expect(
+          File(clientKey!).existsSync(),
+          isTrue,
+          reason: 'Client key file must exist',
+        );
 
-      print('Testing mTLS with client certificate');
-      print('Endpoint: $endpoint');
-      print('CA cert: $caCert');
-      print('Client cert: $clientCert');
-      print('Client key: $clientKey');
+        print('Testing mTLS with client certificate');
+        print('Endpoint: $endpoint');
+        print('CA cert: $caCert');
+        print('Client cert: $clientCert');
+        print('Client key: $clientKey');
 
-      // Initialize OTel - it will read from environment variables
-      await OTel.initialize(
-        serviceName: 'cert-test-mtls',
-      );
+        // Initialize OTel - it will read from environment variables
+        await OTel.initialize(serviceName: 'cert-test-mtls');
 
-      // Create a span
-      final tracer =
-          OTel.tracerProvider().getTracer('cert-test', version: '1.0.0');
-      await tracer.startActiveSpanAsync(
+        // Create a span
+        final tracer = OTel.tracerProvider().getTracer(
+          'cert-test',
+          version: '1.0.0',
+        );
+        await tracer.startActiveSpanAsync(
           name: 'mtls-test-span',
           fn: (span) async {
-            span.addAttributes(Attributes.of({
-              'test.type': 'mtls',
-              'test.timestamp': DateTime.now().toIso8601String()
-            }));
+            span.addAttributes(
+              Attributes.of({
+                'test.type': 'mtls',
+                'test.timestamp': DateTime.now().toIso8601String(),
+              }),
+            );
             await Future<void>.delayed(const Duration(milliseconds: 100));
             span.end();
-          });
+          },
+        );
 
-      // Shutdown and flush
-      await OTel.shutdown();
+        // Shutdown and flush
+        await OTel.shutdown();
 
-      print('✅ mTLS test completed successfully');
-    }, timeout: const Timeout(Duration(seconds: 30)), skip: true);
+        print('✅ mTLS test completed successfully');
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+      skip: true,
+    );
   });
 }

--- a/test/integration/environment_variables_test.dart
+++ b/test/integration/environment_variables_test.dart
@@ -26,17 +26,20 @@ void main() {
       }
     });
 
-    test('reads OTEL_EXPORTER_OTLP_ENDPOINT from environment or --dart-define',
-        () {
-      final endpoint =
-          EnvironmentService.instance.getValue(otelExporterOtlpEndpoint);
+    test(
+      'reads OTEL_EXPORTER_OTLP_ENDPOINT from environment or --dart-define',
+      () {
+        final endpoint = EnvironmentService.instance.getValue(
+          otelExporterOtlpEndpoint,
+        );
 
-      if (endpoint != null) {
-        expect(endpoint, isNotEmpty);
-        // Should be a valid URL format
-        expect(endpoint, contains('://'));
-      }
-    });
+        if (endpoint != null) {
+          expect(endpoint, isNotEmpty);
+          // Should be a valid URL format
+          expect(endpoint, contains('://'));
+        }
+      },
+    );
 
     test('--dart-define takes precedence over environment variables', () {
       // This test is meaningful when both are set
@@ -47,22 +50,28 @@ void main() {
       expect(serviceName, anyOf(isNull, isA<String>()));
     });
 
-    test('OTel.initialize uses environment variables when no params provided',
-        () async {
-      final serviceName = EnvironmentService.instance.getValue(otelServiceName);
+    test(
+      'OTel.initialize uses environment variables when no params provided',
+      () async {
+        final serviceName = EnvironmentService.instance.getValue(
+          otelServiceName,
+        );
 
-      await OTel.initialize();
+        await OTel.initialize();
 
-      final attrs = OTel.defaultResource!.attributes.toList();
-      final serviceNameAttr = attrs.firstWhere((a) => a.key == 'service.name');
+        final attrs = OTel.defaultResource!.attributes.toList();
+        final serviceNameAttr = attrs.firstWhere(
+          (a) => a.key == 'service.name',
+        );
 
-      if (serviceName != null && serviceName.isNotEmpty) {
-        expect(serviceNameAttr.value, equals(serviceName));
-      } else {
-        // Default service name should be set
-        expect(serviceNameAttr.value, isNotEmpty);
-      }
-    });
+        if (serviceName != null && serviceName.isNotEmpty) {
+          expect(serviceNameAttr.value, equals(serviceName));
+        } else {
+          // Default service name should be set
+          expect(serviceNameAttr.value, isNotEmpty);
+        }
+      },
+    );
 
     test('explicit parameters override environment variables', () async {
       // Even if OTEL_SERVICE_NAME is set, explicit parameter should win

--- a/test/integration/metrics/auto_collection_test.dart
+++ b/test/integration/metrics/auto_collection_test.dart
@@ -44,8 +44,10 @@ class MockSystemMetricsCollector {
     // Simulate memory usage fluctuations (±256MB)
     final memoryDeltaMB = _random.nextInt(512) - 256;
     final memoryDeltaBytes = memoryDeltaMB * 1024 * 1024;
-    _usedMemoryBytes =
-        max(0, min(_totalMemoryBytes, _usedMemoryBytes + memoryDeltaBytes));
+    _usedMemoryBytes = max(
+      0,
+      min(_totalMemoryBytes, _usedMemoryBytes + memoryDeltaBytes),
+    );
 
     // Simulate CPU usage fluctuations (±5%)
     final cpuDelta = (_random.nextDouble() * 10) - 5;
@@ -54,8 +56,10 @@ class MockSystemMetricsCollector {
     // Simulate disk usage fluctuations (±1GB)
     final diskDeltaMB = _random.nextInt(2048) - 1024;
     final diskDeltaBytes = diskDeltaMB * 1024 * 1024;
-    _diskUsedBytes =
-        max(0, min(_diskTotalBytes, _diskUsedBytes + diskDeltaBytes));
+    _diskUsedBytes = max(
+      0,
+      min(_diskTotalBytes, _diskUsedBytes + diskDeltaBytes),
+    );
   }
 }
 
@@ -140,10 +144,7 @@ class TestMetricReader extends MetricReader {
     _collectedMetrics.clear();
     _collectedMetrics.addAll(metrics);
 
-    return MetricData(
-      resource: meterProvider!.resource,
-      metrics: metrics,
-    );
+    return MetricData(resource: meterProvider!.resource, metrics: metrics);
   }
 
   @override
@@ -196,10 +197,8 @@ void main() {
       meterProvider.addMetricReader(metricReader);
 
       // Get a meter for our system metrics
-      meter = meterProvider.getMeter(
-        name: 'system-metrics',
-        version: '1.0.0',
-      ) as Meter;
+      meter = meterProvider.getMeter(name: 'system-metrics', version: '1.0.0')
+          as Meter;
 
       // Create the metrics collector
       metricsCollector = SystemMetricsCollector(systemCollector, meter);
@@ -338,14 +337,22 @@ void main() {
       );
 
       // Record measurements with different attributes
-      cpuGauge.record(systemCollector.cpuUsagePercent * 0.9,
-          {'core': '0', 'type': 'user'}.toAttributes());
-      cpuGauge.record(systemCollector.cpuUsagePercent * 0.1,
-          {'core': '0', 'type': 'system'}.toAttributes());
-      cpuGauge.record(systemCollector.cpuUsagePercent * 0.8,
-          {'core': '1', 'type': 'user'}.toAttributes());
-      cpuGauge.record(systemCollector.cpuUsagePercent * 0.2,
-          {'core': '1', 'type': 'system'}.toAttributes());
+      cpuGauge.record(
+        systemCollector.cpuUsagePercent * 0.9,
+        {'core': '0', 'type': 'user'}.toAttributes(),
+      );
+      cpuGauge.record(
+        systemCollector.cpuUsagePercent * 0.1,
+        {'core': '0', 'type': 'system'}.toAttributes(),
+      );
+      cpuGauge.record(
+        systemCollector.cpuUsagePercent * 0.8,
+        {'core': '1', 'type': 'user'}.toAttributes(),
+      );
+      cpuGauge.record(
+        systemCollector.cpuUsagePercent * 0.2,
+        {'core': '1', 'type': 'system'}.toAttributes(),
+      );
 
       // Update system metrics
       systemCollector.updateMetrics();
@@ -360,17 +367,20 @@ void main() {
 
       // Try to find our metric if it was collected
       try {
-        final cpuCoreMetric =
-            metrics.firstWhere((m) => m.name == 'system.cpu.core.usage');
+        final cpuCoreMetric = metrics.firstWhere(
+          (m) => m.name == 'system.cpu.core.usage',
+        );
         print(
-            'Found CPU core metric with ${cpuCoreMetric.points.length} data points');
+          'Found CPU core metric with ${cpuCoreMetric.points.length} data points',
+        );
 
         // Verify we have data points (implementation may vary)
         expect(cpuCoreMetric.points, isA<List>());
 
         if (cpuCoreMetric.points.isNotEmpty) {
           print(
-              'Sample data point value: ${cpuCoreMetric.points.first.valueAsString}');
+            'Sample data point value: ${cpuCoreMetric.points.first.valueAsString}',
+          );
         }
       } catch (e) {
         print('Metric not found or not fully implemented yet: $e');
@@ -403,8 +413,9 @@ void main() {
 
       // Try to find and test the histogram metric if implemented
       try {
-        final histogramMetric =
-            metrics.firstWhere((m) => m.name == 'app.request.duration');
+        final histogramMetric = metrics.firstWhere(
+          (m) => m.name == 'app.request.duration',
+        );
         print('Found histogram metric: ${histogramMetric.name}');
         expect(histogramMetric.type, equals(MetricType.histogram));
 
@@ -447,10 +458,12 @@ void main() {
 
       // Try to find our counter metric
       try {
-        final requestCountMetric =
-            resourceMetrics.firstWhere((m) => m.name == 'app.request.count');
+        final requestCountMetric = resourceMetrics.firstWhere(
+          (m) => m.name == 'app.request.count',
+        );
         print(
-            'Found request count metric with ${requestCountMetric.points.length} points');
+          'Found request count metric with ${requestCountMetric.points.length} points',
+        );
 
         // Verify basic structure
         expect(requestCountMetric.points, isA<List>());

--- a/test/integration/resource_attributes_test.dart
+++ b/test/integration/resource_attributes_test.dart
@@ -14,21 +14,23 @@ void main() {
       await OTel.reset();
     });
 
-    test('EnvVarResourceDetector reads OTEL_RESOURCE_ATTRIBUTES from env',
-        () async {
-      final envService = EnvironmentService.instance;
-      final resourceAttrs = envService.getValue(otelResourceAttributes);
+    test(
+      'EnvVarResourceDetector reads OTEL_RESOURCE_ATTRIBUTES from env',
+      () async {
+        final envService = EnvironmentService.instance;
+        final resourceAttrs = envService.getValue(otelResourceAttributes);
 
-      // Test only runs if OTEL_RESOURCE_ATTRIBUTES is set
-      if (resourceAttrs != null && resourceAttrs.isNotEmpty) {
-        final detector = EnvVarResourceDetector(envService);
-        final resource = await detector.detect();
-        final attrs = resource.attributes.toMap();
+        // Test only runs if OTEL_RESOURCE_ATTRIBUTES is set
+        if (resourceAttrs != null && resourceAttrs.isNotEmpty) {
+          final detector = EnvVarResourceDetector(envService);
+          final resource = await detector.detect();
+          final attrs = resource.attributes.toMap();
 
-        // Verify at least one attribute was parsed
-        expect(attrs.isNotEmpty, isTrue);
-      }
-    });
+          // Verify at least one attribute was parsed
+          expect(attrs.isNotEmpty, isTrue);
+        }
+      },
+    );
 
     test('handles URL-encoded spaces in resource attributes', () async {
       final envService = EnvironmentService.instance;

--- a/test/performance/baggage/baggage_benchmarks.dart
+++ b/test/performance/baggage/baggage_benchmarks.dart
@@ -20,11 +20,7 @@ class BaggageOperationsBenchmark extends DartasticBenchmark {
   void setup() {
     _testBaggage = OTel.baggage();
     for (var i = 0; i < numEntries; i++) {
-      _testBaggage = _testBaggage.copyWith(
-        'key.$i',
-        'value.$i',
-        'metadata.$i',
-      );
+      _testBaggage = _testBaggage.copyWith('key.$i', 'value.$i', 'metadata.$i');
     }
   }
 
@@ -57,11 +53,7 @@ class BaggageIsolateBenchmark extends DartasticBenchmark {
   void setup() {
     Baggage baggage = OTel.baggage();
     for (var i = 0; i < numEntries; i++) {
-      baggage = baggage.copyWith(
-        'key.$i',
-        'value.$i',
-        'metadata.$i',
-      );
+      baggage = baggage.copyWith('key.$i', 'value.$i', 'metadata.$i');
     }
   }
 
@@ -125,7 +117,8 @@ class BaggageMemoryBenchmark extends DartasticBenchmark {
     print('    RSS: ${snapshot.rss ~/ 1024} KB');
     print('    Heap: ${snapshot.heap ~/ 1024} KB');
     print(
-        '  Average memory per entry: ${(snapshot.heap / (numUniqueKeys * numValuesPerKey)).toStringAsFixed(2)} bytes');
+      '  Average memory per entry: ${(snapshot.heap / (numUniqueKeys * numValuesPerKey)).toStringAsFixed(2)} bytes',
+    );
   }
 }
 
@@ -141,10 +134,7 @@ void main() {
   BaggageIsolateBenchmark(numEntries: 50).runAndPrint();
 
   // Memory impact benchmarks
-  BaggageMemoryBenchmark(
-    numUniqueKeys: 10,
-    numValuesPerKey: 100,
-  ).runAndPrint();
+  BaggageMemoryBenchmark(numUniqueKeys: 10, numValuesPerKey: 100).runAndPrint();
   BaggageMemoryBenchmark(
     numUniqueKeys: 100,
     numValuesPerKey: 1000,

--- a/test/performance/benchmark_runner.dart
+++ b/test/performance/benchmark_runner.dart
@@ -76,8 +76,12 @@ class MemorySnapshot {
   static int _getCurrentRss() {
     if (Platform.isLinux || Platform.isMacOS) {
       try {
-        final result =
-            Process.runSync('ps', ['-o', 'rss=', '-p', pid.toString()]);
+        final result = Process.runSync('ps', [
+          '-o',
+          'rss=',
+          '-p',
+          pid.toString(),
+        ]);
         if (result.exitCode == 0 && result.stdout != null) {
           return int.parse((result.stdout as String).trim()) *
               1024; // Convert KB to bytes
@@ -87,8 +91,13 @@ class MemorySnapshot {
       }
     } else if (Platform.isWindows) {
       try {
-        final result = Process.runSync('wmic',
-            ['process', 'where', 'ProcessId=$pid', 'get', 'WorkingSetSize']);
+        final result = Process.runSync('wmic', [
+          'process',
+          'where',
+          'ProcessId=$pid',
+          'get',
+          'WorkingSetSize',
+        ]);
         if (result.exitCode == 0 && result.stdout != null) {
           final lines = (result.stdout as String).trim().split('\n');
           if (lines.length > 1) {

--- a/test/performance/core/api_benchmarks.dart
+++ b/test/performance/core/api_benchmarks.dart
@@ -21,8 +21,11 @@ class AttributesBenchmark extends BenchmarkBase {
 
   @override
   void run() {
-    final attributes = OTel.attributesFromMap(
-        {stringKey: 'value1', intKey: 42, boolKey: true});
+    final attributes = OTel.attributesFromMap({
+      stringKey: 'value1',
+      intKey: 42,
+      boolKey: true,
+    });
     attributes.getString(stringKey);
     attributes.getInt(intKey);
     attributes.getBool(boolKey);

--- a/test/performance/transformer_performance_test.dart
+++ b/test/performance/transformer_performance_test.dart
@@ -23,11 +23,11 @@ void main() {
     // The default tracer is set up with an instrumentation scope, for example "http".
     httpTracer = tracerProvider!.getTracer('http');
     // To simulate a different instrumentation scope, we create a separate tracer.
-    dbTracer = tracerProvider!.getTracer('database',
-        version: '1.0.0',
-        attributes: OTel.attributesFromMap(
-          {'db_type': 'postgres'},
-        ));
+    dbTracer = tracerProvider!.getTracer(
+      'database',
+      version: '1.0.0',
+      attributes: OTel.attributesFromMap({'db_type': 'postgres'}),
+    );
   });
 
   tearDown(() async {
@@ -54,10 +54,13 @@ void main() {
       stopwatch.stop();
 
       print(
-          'Transformation time for 10000 spans: ${stopwatch.elapsedMilliseconds}ms');
+        'Transformation time for 10000 spans: ${stopwatch.elapsedMilliseconds}ms',
+      );
       expect(stopwatch.elapsedMilliseconds, lessThan(5000));
-      expect(request.resourceSpans.first.scopeSpans.first.spans.length,
-          equals(10000));
+      expect(
+        request.resourceSpans.first.scopeSpans.first.spans.length,
+        equals(10000),
+      );
     });
 
     test('measures parallel transformation performance', () async {
@@ -127,9 +130,7 @@ void main() {
         ),
       );
 
-      final span = tracer!.startSpan(
-        'event-test',
-      );
+      final span = tracer!.startSpan('event-test');
 
       for (final event in events) {
         span.addEvent(event);
@@ -140,7 +141,8 @@ void main() {
       stopwatch.stop();
 
       print(
-          'Complex event transformation time: ${stopwatch.elapsedMilliseconds}ms');
+        'Complex event transformation time: ${stopwatch.elapsedMilliseconds}ms',
+      );
       expect(stopwatch.elapsedMilliseconds, lessThan(2000));
 
       final transformedSpan =

--- a/test/performance/utils/attributes.dart
+++ b/test/performance/utils/attributes.dart
@@ -15,7 +15,7 @@ class TestAttributes {
                 ? i
                 : i % 4 == 2
                     ? i.toDouble()
-                    : i % 2 == 0
+                    : i % 2 == 0,
     };
   }
 

--- a/test/testing_utils/memory_log_record_exporter.dart
+++ b/test/testing_utils/memory_log_record_exporter.dart
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+/// A memory-based log record exporter for testing purposes.
+/// This exporter stores log records in memory instead of sending them to an endpoint.
+class MemoryLogRecordExporter implements LogRecordExporter {
+  final List<ReadableLogRecord> _exportedLogRecords = [];
+  bool _isShutdown = false;
+
+  /// Get all exported log records.
+  List<ReadableLogRecord> get exportedLogRecords =>
+      List.unmodifiable(_exportedLogRecords);
+
+  /// Clear all exported log records.
+  void clear() {
+    _exportedLogRecords.clear();
+  }
+
+  /// Get the count of exported log records.
+  int get count => _exportedLogRecords.length;
+
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    if (_isShutdown) {
+      return ExportResult.failure;
+    }
+
+    _exportedLogRecords.addAll(logRecords);
+    return ExportResult.success;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    // No buffering, nothing to flush
+  }
+
+  @override
+  Future<void> shutdown() async {
+    _isShutdown = true;
+  }
+
+  /// Whether the exporter has been shut down.
+  bool get isShutdown => _isShutdown;
+}

--- a/test/testing_utils/memory_metric_exporter.dart
+++ b/test/testing_utils/memory_metric_exporter.dart
@@ -71,10 +71,7 @@ class MemoryMetricReader implements MetricReader {
     // Collect metrics from all instruments in the meter provider
     final metrics = await _meterProvider!.collectAllMetrics();
 
-    return MetricData(
-      resource: _meterProvider!.resource,
-      metrics: metrics,
-    );
+    return MetricData(resource: _meterProvider!.resource, metrics: metrics);
   }
 
   @override

--- a/test/testing_utils/network_proxy.dart
+++ b/test/testing_utils/network_proxy.dart
@@ -54,8 +54,10 @@ class NetworkProxyService extends proto.TraceServiceBase {
     return await _targetClient.export(request);
   }
 
-  void failNextRequests(int count,
-      {int errorCode = grpc.StatusCode.unavailable}) {
+  void failNextRequests(
+    int count, {
+    int errorCode = grpc.StatusCode.unavailable,
+  }) {
     _shouldFail = true;
     _failureCount = count;
     _curFailureCode = errorCode;
@@ -111,7 +113,8 @@ class NetworkProxy {
     _server = grpc.Server.create(services: [_service]);
     await _server!.serve(port: listenPort);
     print(
-        'Network proxy listening on port $listenPort -> $targetHost:$targetPort');
+      'Network proxy listening on port $listenPort -> $targetHost:$targetPort',
+    );
   }
 
   Future<void> stop() async {
@@ -134,8 +137,10 @@ class NetworkProxy {
     }
   }
 
-  void failNextRequests(int count,
-      {int errorCode = grpc.StatusCode.unavailable}) {
+  void failNextRequests(
+    int count, {
+    int errorCode = grpc.StatusCode.unavailable,
+  }) {
     _service.failNextRequests(count, errorCode: errorCode);
   }
 

--- a/test/testing_utils/real_collector.dart
+++ b/test/testing_utils/real_collector.dart
@@ -60,17 +60,16 @@ class RealCollector {
     final tempConfigPath =
         '${Directory.current.path}/test/testing_utils/otelcol-config-$port.yaml';
     final configContent = await File(_configPath).readAsString();
-    final updatedConfig =
-        configContent.replaceAll('127.0.0.1:4316', '127.0.0.1:$port');
+    final updatedConfig = configContent.replaceAll(
+      '127.0.0.1:4316',
+      '127.0.0.1:$port',
+    );
     await File(tempConfigPath).writeAsString(updatedConfig);
 
     // Start collector with our config
     try {
       print('Starting collector with config: $tempConfigPath');
-      _process = await Process.start(
-        execPath,
-        ['--config', tempConfigPath],
-      );
+      _process = await Process.start(execPath, ['--config', tempConfigPath]);
       print('Collector started with process ID: ${_process!.pid}');
     } catch (e) {
       print('Error starting collector: $e');
@@ -86,8 +85,9 @@ class RealCollector {
     _process!.stdout.transform(utf8.decoder).listen((line) {
       print('Collector stdout: $line');
       if (line.contains('invalid configuration')) {
-        readyCompleter
-            .completeError(Exception('Collector config error: $line'));
+        readyCompleter.completeError(
+          Exception('Collector config error: $line'),
+        );
       }
       if (line.contains('Everything is ready') && !hasServiceStarted) {
         hasServiceStarted = true;
@@ -150,8 +150,9 @@ class RealCollector {
         bool isRunning = true;
         try {
           // Check if process has already exited
-          final exitCode = await _process!.exitCode
-              .timeout(const Duration(milliseconds: 100));
+          final exitCode = await _process!.exitCode.timeout(
+            const Duration(milliseconds: 100),
+          );
           print('Collector exited with code: $exitCode');
           isRunning = false;
         } catch (e) {
@@ -269,8 +270,9 @@ class RealCollector {
             for (final resourceSpan in data['resourceSpans'] as List) {
               final resource =
                   resourceSpan['resource'] as Map<String, dynamic>?;
-              final resourceAttrs =
-                  _parseAttributes(resource?['attributes'] as List?);
+              final resourceAttrs = _parseAttributes(
+                resource?['attributes'] as List?,
+              );
 
               for (final scopeSpans in resourceSpan['scopeSpans'] as List) {
                 for (final span in scopeSpans['spans'] as List) {
@@ -345,7 +347,8 @@ class RealCollector {
         print('  Parsed as bool: ${result[key]}');
       } else {
         print(
-            '  No value found for attribute $key, keys: ${valueMap.keys.join(', ')}');
+          '  No value found for attribute $key, keys: ${valueMap.keys.join(', ')}',
+        );
       }
     }
 
@@ -399,14 +402,16 @@ class RealCollector {
             print('Output file content: $content');
           } else {
             print(
-                'Output file content is too large to print (${content.length} bytes)');
+              'Output file content is too large to print (${content.length} bytes)',
+            );
           }
         }
 
         // If file exists but is empty after multiple attempts, it might be an issue with collector
         if (size == 0 && attempts > 3) {
           print(
-              'Output file is empty after multiple attempts, checking collector status...');
+            'Output file is empty after multiple attempts, checking collector status...',
+          );
           // Check if collector is still running
           bool isRunning = _process != null;
           if (isRunning) {
@@ -450,8 +455,9 @@ class RealCollector {
             print('Collector process is not running, restarting...');
             try {
               await stop(); // Ensure clean stop first
-              await Future<void>.delayed(const Duration(
-                  milliseconds: 500)); // Wait for resources to be freed
+              await Future<void>.delayed(
+                const Duration(milliseconds: 500),
+              ); // Wait for resources to be freed
               await start();
               // Make sure the file is cleared after restart
               // ignore: avoid_slow_async_io
@@ -473,8 +479,10 @@ class RealCollector {
 
     // Final attempt to read spans
     final spans = await getSpans();
-    throw TimeoutException('Timed out waiting for $count spans. '
-        'Found ${spans.length} spans: ${spans.map((s) => s['name']).toList()}');
+    throw TimeoutException(
+      'Timed out waiting for $count spans. '
+      'Found ${spans.length} spans: ${spans.map((s) => s['name']).toList()}',
+    );
   }
 
   /// Assert that a span matching the given criteria exists
@@ -492,7 +500,8 @@ class RealCollector {
       final resourceAttrs = span['resourceAttributes'] as Map<String, dynamic>?;
       final allAttrs = {...?resourceAttrs, ...spanAttrs};
       print(
-          'Found span: ${span['name']}, spanId: ${span['spanId']}, traceId: ${span['traceId']}');
+        'Found span: ${span['name']}, spanId: ${span['spanId']}, traceId: ${span['traceId']}',
+      );
       print('  Attributes: $allAttrs');
 
       // Log the raw attribute structure for debugging
@@ -515,13 +524,15 @@ class RealCollector {
     // For more reliable span matching, try to find the first span when expecting a name
     if (name != null && spans.isNotEmpty && spans.length == 1) {
       print(
-          'Single span found with name: ${spans[0]['name']}, expected: $name');
+        'Single span found with name: ${spans[0]['name']}, expected: $name',
+      );
     }
 
     final matching = spans.where((span) {
       if (name != null && span['name'] != name) {
         print(
-            'Span ${span['spanId']} has name "${span['name']}" which doesn\'t match expected "$name"');
+          'Span ${span['spanId']} has name "${span['name']}" which doesn\'t match expected "$name"',
+        );
         return false;
       }
       if (traceId != null && span['traceId'] != traceId) return false;
@@ -540,13 +551,15 @@ class RealCollector {
 
           if (actualValue == null) {
             print(
-                'Attribute ${entry.key} is missing. Expected: $expectedValue');
+              'Attribute ${entry.key} is missing. Expected: $expectedValue',
+            );
             return false;
           }
 
           // Log types for debugging
           print(
-              'Comparing ${entry.key}: expected=$expectedValue (${expectedValue.runtimeType}), actual=$actualValue (${actualValue.runtimeType})');
+            'Comparing ${entry.key}: expected=$expectedValue (${expectedValue.runtimeType}), actual=$actualValue (${actualValue.runtimeType})',
+          );
 
           // Perform appropriate comparison based on types
           bool match = false;
@@ -566,7 +579,8 @@ class RealCollector {
 
           if (!match) {
             print(
-                'Attribute mismatch for ${entry.key}: expected $expectedValue (${expectedValue.runtimeType}), got $actualValue (${actualValue.runtimeType})');
+              'Attribute mismatch for ${entry.key}: expected $expectedValue (${expectedValue.runtimeType}), got $actualValue (${actualValue.runtimeType})',
+            );
             return false;
           }
         }
@@ -580,9 +594,10 @@ class RealCollector {
       if (spans.length == 1 && name != null) {
         final actualName = spans.first['name'];
         throw StateError(
-            // ignore: prefer_adjacent_string_concatenation
-            'No matching span found with name "$name". Found span named "$actualName" instead. ' +
-                'Consider updating the test to use the correct span name.');
+          // ignore: prefer_adjacent_string_concatenation
+          'No matching span found with name "$name". Found span named "$actualName" instead. ' +
+              'Consider updating the test to use the correct span name.',
+        );
       }
 
       final criteria = <String, dynamic>{
@@ -592,7 +607,8 @@ class RealCollector {
         if (spanId != null) 'spanId': spanId,
       };
       throw StateError(
-          'No matching span found.\nCriteria: ${json.encode(criteria)}\nAll spans: ${json.encode(spans)}');
+        'No matching span found.\nCriteria: ${json.encode(criteria)}\nAll spans: ${json.encode(spans)}',
+      );
     }
   }
 }

--- a/test/testing_utils/test_file_exporter.dart
+++ b/test/testing_utils/test_file_exporter.dart
@@ -39,7 +39,8 @@ class TestFileExporter implements SpanExporter {
     if (_isShutdown) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TestFileExporter: Cannot export - exporter is shut down');
+          'TestFileExporter: Cannot export - exporter is shut down',
+        );
       }
       print('TestFileExporter: Cannot export - exporter is shut down');
       throw StateError('Exporter is shutdown');
@@ -56,7 +57,8 @@ class TestFileExporter implements SpanExporter {
     // Debug information about the spans
     for (var span in spans) {
       print(
-          'TestFileExporter: Exporting span ${span.name} with ID ${span.spanContext.spanId} and traceID ${span.spanContext.traceId}');
+        'TestFileExporter: Exporting span ${span.name} with ID ${span.spanContext.spanId} and traceID ${span.spanContext.traceId}',
+      );
       print('TestFileExporter:   isRecording: ${span.isRecording}');
       print('TestFileExporter:   isEnded: ${span.isEnded}');
       print('TestFileExporter:   status: ${span.status}');
@@ -65,7 +67,8 @@ class TestFileExporter implements SpanExporter {
       // Check if the span is properly ended
       if (!span.isEnded) {
         print(
-            'TestFileExporter: WARNING - Span ${span.name} is not properly ended, which may cause export issues');
+          'TestFileExporter: WARNING - Span ${span.name} is not properly ended, which may cause export issues',
+        );
       }
     }
 
@@ -74,7 +77,8 @@ class TestFileExporter implements SpanExporter {
 
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TestFileExporter: Exporting ${spans.length} spans to $_filePath');
+          'TestFileExporter: Exporting ${spans.length} spans to $_filePath',
+        );
       }
 
       // Convert spans to simplified JSON format - handle attributes safely
@@ -85,7 +89,8 @@ class TestFileExporter implements SpanExporter {
           attributesJson = span.attributes.toJson();
         } catch (e) {
           print(
-              'TestFileExporter: Warning - could not serialize attributes for span ${span.name}: $e');
+            'TestFileExporter: Warning - could not serialize attributes for span ${span.name}: $e',
+          );
           // Fallback to empty attributes
           attributesJson = {};
         }
@@ -115,22 +120,26 @@ class TestFileExporter implements SpanExporter {
       // Verify file was written
       final fileSize = file.lengthSync();
       print(
-          'TestFileExporter: Wrote ${newContent.length} characters to file. File size is now $fileSize bytes');
+        'TestFileExporter: Wrote ${newContent.length} characters to file. File size is now $fileSize bytes',
+      );
       print('TestFileExporter: File absolute path: ${file.absolute.path}');
 
       // Read back to verify it was written correctly
       final readBack = file.readAsStringSync();
       if (readBack.isNotEmpty && readBack.contains(spans.first.name)) {
         print(
-            'TestFileExporter: Verified file write was successful - found span name in file');
+          'TestFileExporter: Verified file write was successful - found span name in file',
+        );
       } else {
         print(
-            'TestFileExporter: WARNING - File write verification failed. Content: $readBack');
+          'TestFileExporter: WARNING - File write verification failed. Content: $readBack',
+        );
       }
 
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'TestFileExporter: Successfully exported ${spans.length} spans');
+          'TestFileExporter: Successfully exported ${spans.length} spans',
+        );
       }
     } catch (e, stackTrace) {
       if (OTelLog.isError()) {

--- a/test/unit/baggage/w3c_baggage_propagator_test.dart
+++ b/test/unit/baggage/w3c_baggage_propagator_test.dart
@@ -100,10 +100,14 @@ void main() {
       final extractedContext = propagator.extract(context, carrier, getter);
       final extractedBaggage = extractedContext.baggage;
 
-      expect(extractedBaggage!.getEntry('key with spaces')?.value,
-          equals('value with spaces'));
-      expect(extractedBaggage.getEntry('key,with,commas')?.value,
-          equals('value,with,commas'));
+      expect(
+        extractedBaggage!.getEntry('key with spaces')?.value,
+        equals('value with spaces'),
+      );
+      expect(
+        extractedBaggage.getEntry('key,with,commas')?.value,
+        equals('value,with,commas'),
+      );
     });
 
     test('handles empty baggage', () {

--- a/test/unit/common/attributes_test.dart
+++ b/test/unit/common/attributes_test.dart
@@ -45,12 +45,18 @@ void main() {
 
       // Verify map lookups work as expected
       expect(map.containsKey(attrs1), isTrue);
-      expect(map.containsKey(attrs2), isTrue,
-          reason: 'Same content but different instances should be equal');
+      expect(
+        map.containsKey(attrs2),
+        isTrue,
+        reason: 'Same content but different instances should be equal',
+      );
       expect(map.containsKey(attrs3), isFalse);
       expect(map[attrs1], equals('value1'));
-      expect(map[attrs2], equals('value1'),
-          reason: 'Should retrieve value with equivalent key');
+      expect(
+        map[attrs2],
+        equals('value1'),
+        reason: 'Should retrieve value with equivalent key',
+      );
     });
 
     test('Empty attributes equality', () {

--- a/test/unit/common/resource_tenant_id_test.dart
+++ b/test/unit/common/resource_tenant_id_test.dart
@@ -38,10 +38,7 @@ void main() {
       File(outputPath).writeAsStringSync('');
 
       // Start collector
-      collector = RealCollector(
-        configPath: configPath,
-        outputPath: outputPath,
-      );
+      collector = RealCollector(configPath: configPath, outputPath: outputPath);
       await collector.start();
 
       // Create exporter
@@ -67,10 +64,11 @@ void main() {
       // Initialize OTel with service name
       final serviceName = 'example-service';
       await OTel.initialize(
-          endpoint: 'http://localhost:${collector.port}',
-          serviceName: serviceName,
-          tenantId: '123456789',
-          spanProcessor: null);
+        endpoint: 'http://localhost:${collector.port}',
+        serviceName: serviceName,
+        tenantId: '123456789',
+        spanProcessor: null,
+      );
 
       // Create exporter
       final exporter = OtlpGrpcSpanExporter(
@@ -100,12 +98,16 @@ void main() {
       print(json.encode(spans[0]['resourceAttributes']));
 
       // Verify both service.name and tenant_id are present
-      expect(spans[0]['resourceAttributes'],
-          containsPair('service.name', serviceName),
-          reason: 'service.name should be present in resource attributes');
-      expect(spans[0]['resourceAttributes'],
-          containsPair('tenant_id', '123456789'),
-          reason: 'tenant_id should be present in resource attributes');
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('service.name', serviceName),
+        reason: 'service.name should be present in resource attributes',
+      );
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('tenant_id', '123456789'),
+        reason: 'tenant_id should be present in resource attributes',
+      );
 
       await tracerProvider.shutdown();
     });
@@ -135,10 +137,7 @@ void main() {
 
       // Create a tracer with different name
       final tracerName = 'my-instrumentation-library';
-      final tracer = tracerProvider.getTracer(
-        tracerName,
-        version: '1.0.0',
-      );
+      final tracer = tracerProvider.getTracer(tracerName, version: '1.0.0');
 
       // Create a span
       final span = tracer.startSpan('test-operation');
@@ -156,9 +155,11 @@ void main() {
       print(json.encode(spans[0]['resourceAttributes']));
 
       // Verify service.name is from initialize
-      expect(spans[0]['resourceAttributes'],
-          containsPair('service.name', serviceName),
-          reason: 'service.name should come from OTel.initialize');
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('service.name', serviceName),
+        reason: 'service.name should come from OTel.initialize',
+      );
 
       // Shutdown
       await tracerProvider.shutdown();
@@ -167,10 +168,12 @@ void main() {
     test('tenant_id is properly included in resource attributes', () async {
       // 1. Create resources similar to the example
       final tenantId = '123456789';
-      final Resource tenantIdResource = OTel.resource(OTel.attributesFromMap({
-        'tenant_id': tenantId,
-        'service.name': 'test-service' // Explicitly set service.name
-      }));
+      final Resource tenantIdResource = OTel.resource(
+        OTel.attributesFromMap({
+          'tenant_id': tenantId,
+          'service.name': 'test-service', // Explicitly set service.name
+        }),
+      );
 
       // Get platform resource
       final resourceDetector = PlatformResourceDetector.create();
@@ -208,9 +211,7 @@ void main() {
       // Create a span
       final span = tracer.startSpan(
         'test-operation',
-        attributes: OTel.attributesFromMap({
-          'test.key': 'test-value',
-        }),
+        attributes: OTel.attributesFromMap({'test.key': 'test-value'}),
       );
       span.end();
 
@@ -225,23 +226,31 @@ void main() {
 
       // Verify the tenant_id is included in resource attributes
       final spans = await collector.getSpans();
-      expect(spans, isNotEmpty,
-          reason: 'At least one span should have been exported');
+      expect(
+        spans,
+        isNotEmpty,
+        reason: 'At least one span should have been exported',
+      );
 
       // Print all resource attributes for debugging
       print(
-          'Resource attributes: ${json.encode(spans[0]['resourceAttributes'])}');
+        'Resource attributes: ${json.encode(spans[0]['resourceAttributes'])}',
+      );
 
       // Verify tenant_id is present and has correct value
       expect(
-          spans[0]['resourceAttributes'], containsPair('tenant_id', tenantId),
-          reason: 'tenant_id should be present in resource attributes');
+        spans[0]['resourceAttributes'],
+        containsPair('tenant_id', tenantId),
+        reason: 'tenant_id should be present in resource attributes',
+      );
 
       // Verify service.name is explicitly present
-      expect(spans[0]['resourceAttributes'],
-          containsPair('service.name', 'test-service'),
-          reason:
-              'service.name should be present in resource attributes with correct value');
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('service.name', 'test-service'),
+        reason:
+            'service.name should be present in resource attributes with correct value',
+      );
 
       // Shutdown
       await tracerProvider.shutdown();
@@ -249,15 +258,17 @@ void main() {
 
     test('tenant_id merges correctly with existing resource', () async {
       // Create a resource with service info
-      final serviceResource = OTel.resource(OTel.attributesFromMap({
-        'service.name': 'test-service',
-        'service.version': '1.0.0',
-      }));
+      final serviceResource = OTel.resource(
+        OTel.attributesFromMap({
+          'service.name': 'test-service',
+          'service.version': '1.0.0',
+        }),
+      );
 
       // Create tenant resource
-      final tenantResource = OTel.resource(OTel.attributesFromMap({
-        'tenant_id': '987654321',
-      }));
+      final tenantResource = OTel.resource(
+        OTel.attributesFromMap({'tenant_id': '987654321'}),
+      );
 
       // Get platform resources
       final resourceDetector = PlatformResourceDetector.create();
@@ -286,60 +297,70 @@ void main() {
 
       // Verify both attributes are present
       final spans = await collector.getSpans();
-      expect(spans[0]['resourceAttributes'],
-          containsPair('service.name', 'test-service'));
-      expect(spans[0]['resourceAttributes'],
-          containsPair('tenant_id', '987654321'));
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('service.name', 'test-service'),
+      );
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('tenant_id', '987654321'),
+      );
 
       await tracerProvider.shutdown();
     });
 
-    test('tenant_id is overridden when merged with higher priority resource',
-        () async {
-      // First set a default resource with tenant_id
-      final originalTenantResource = OTel.resource(OTel.attributesFromMap({
-        'tenant_id': 'original-tenant',
-      }));
+    test(
+      'tenant_id is overridden when merged with higher priority resource',
+      () async {
+        // First set a default resource with tenant_id
+        final originalTenantResource = OTel.resource(
+          OTel.attributesFromMap({'tenant_id': 'original-tenant'}),
+        );
 
-      // Get platform resource
-      final resourceDetector = PlatformResourceDetector.create();
-      final platformResource = await resourceDetector.detect();
+        // Get platform resource
+        final resourceDetector = PlatformResourceDetector.create();
+        final platformResource = await resourceDetector.detect();
 
-      // Merge platform and original tenant
-      OTel.defaultResource = platformResource.merge(originalTenantResource);
+        // Merge platform and original tenant
+        OTel.defaultResource = platformResource.merge(originalTenantResource);
 
-      // Then create a new resource with a different tenant_id
-      final newResource = OTel.resource(OTel.attributesFromMap({
-        'tenant_id': 'override-tenant',
-      }));
+        // Then create a new resource with a different tenant_id
+        final newResource = OTel.resource(
+          OTel.attributesFromMap({'tenant_id': 'override-tenant'}),
+        );
 
-      // Override the default resource
-      OTel.defaultResource = OTel.defaultResource!.merge(newResource);
+        // Override the default resource
+        OTel.defaultResource = OTel.defaultResource!.merge(newResource);
 
-      // Create exporter and processor
-      final spanProcessor = BatchSpanProcessor(exporter);
-      final tracerProvider = OTel.tracerProvider();
-      // Ensure the TracerProvider uses our updated resource
-      tracerProvider.resource = OTel.defaultResource!;
-      tracerProvider.addSpanProcessor(spanProcessor);
+        // Create exporter and processor
+        final spanProcessor = BatchSpanProcessor(exporter);
+        final tracerProvider = OTel.tracerProvider();
+        // Ensure the TracerProvider uses our updated resource
+        tracerProvider.resource = OTel.defaultResource!;
+        tracerProvider.addSpanProcessor(spanProcessor);
 
-      // Create and export a span
-      final tracer = tracerProvider.getTracer('override-test');
-      final span = tracer.startSpan('override-test-span');
-      span.end();
+        // Create and export a span
+        final tracer = tracerProvider.getTracer('override-test');
+        final span = tracer.startSpan('override-test-span');
+        span.end();
 
-      await spanProcessor.forceFlush();
-      await collector.waitForSpans(1);
+        await spanProcessor.forceFlush();
+        await collector.waitForSpans(1);
 
-      // Verify the overridden tenant_id is used
-      final spans = await collector.getSpans();
-      expect(spans[0]['resourceAttributes'],
-          containsPair('tenant_id', 'override-tenant'));
-      expect(spans[0]['resourceAttributes'],
-          isNot(containsPair('tenant_id', 'original-tenant')));
+        // Verify the overridden tenant_id is used
+        final spans = await collector.getSpans();
+        expect(
+          spans[0]['resourceAttributes'],
+          containsPair('tenant_id', 'override-tenant'),
+        );
+        expect(
+          spans[0]['resourceAttributes'],
+          isNot(containsPair('tenant_id', 'original-tenant')),
+        );
 
-      await tracerProvider.shutdown();
-    });
+        await tracerProvider.shutdown();
+      },
+    );
 
     test('tenant_id follows example pattern exactly', () async {
       // This test follows the exact pattern used in the example file
@@ -368,14 +389,14 @@ void main() {
       final resourceDetector = PlatformResourceDetector.create();
 
       // Create service resource first
-      final serviceResource = OTel.resource(OTel.attributesFromMap({
-        'service.name': serviceName,
-      }));
+      final serviceResource = OTel.resource(
+        OTel.attributesFromMap({'service.name': serviceName}),
+      );
 
       // Create tenant resource
-      final Resource tenantIdResource = OTel.resource(OTel.attributesFromMap({
-        'tenant_id': '123456789',
-      }));
+      final Resource tenantIdResource = OTel.resource(
+        OTel.attributesFromMap({'tenant_id': '123456789'}),
+      );
 
       // Detect platform resources
       final platformResource = await resourceDetector.detect();
@@ -419,9 +440,7 @@ void main() {
       // Create a span
       final span = tracer.startSpan(
         'example-operation',
-        attributes: OTel.attributesFromMap({
-          'example.key': 'example-value',
-        }),
+        attributes: OTel.attributesFromMap({'example.key': 'example-value'}),
       );
       span.end();
 
@@ -434,17 +453,22 @@ void main() {
       // Verify both service.name and tenant_id are present
       final spans = await collector.getSpans();
       print(
-          'Resource attributes for example pattern: ${json.encode(spans[0]["resourceAttributes"])}');
+        'Resource attributes for example pattern: ${json.encode(spans[0]["resourceAttributes"])}',
+      );
 
       // The key verification: tenant_id must be present
-      expect(spans[0]['resourceAttributes'],
-          containsPair('tenant_id', '123456789'),
-          reason: 'tenant_id should be present in resource attributes');
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('tenant_id', '123456789'),
+        reason: 'tenant_id should be present in resource attributes',
+      );
 
       // service.name should come from OTel.initialize
-      expect(spans[0]['resourceAttributes'],
-          containsPair('service.name', 'example-service'),
-          reason: 'service.name should be present from OTel.initialize');
+      expect(
+        spans[0]['resourceAttributes'],
+        containsPair('service.name', 'example-service'),
+        reason: 'service.name should be present from OTel.initialize',
+      );
 
       // Wait for any pending exports
       await Future<void>.delayed(const Duration(seconds: 1));

--- a/test/unit/context/context_propagation_test.dart
+++ b/test/unit/context/context_propagation_test.dart
@@ -59,7 +59,8 @@ void main() {
 
     setUp(() async {
       print(
-          'Setting up context_propagation_test in ${isIsolatedRun ? "ISOLATED" : "NORMAL"} mode');
+        'Setting up context_propagation_test in ${isIsolatedRun ? "ISOLATED" : "NORMAL"} mode',
+      );
       print('Using port $testPort and output file $outputPath');
 
       // Ensure OTel is reset
@@ -143,9 +144,11 @@ void main() {
       tracer = tracerProvider.getTracer('test-tracer-$uniqueId');
 
       // Stabilization time (longer when in isolation mode)
-      await Future<void>.delayed(isIsolatedRun
-          ? const Duration(milliseconds: 500)
-          : const Duration(milliseconds: 100));
+      await Future<void>.delayed(
+        isIsolatedRun
+            ? const Duration(milliseconds: 500)
+            : const Duration(milliseconds: 100),
+      );
     });
 
     tearDown(() async {
@@ -163,10 +166,10 @@ void main() {
               'attributes': [
                 {
                   'key': 'test.key',
-                  'value': {'stringValue': 'test-value'}
+                  'value': {'stringValue': 'test-value'},
                 },
-              ]
-            }
+              ],
+            },
           ];
           await File(fallbackPath).writeAsString(json.encode(fallbackData));
         }
@@ -212,9 +215,11 @@ void main() {
       _PortManager.releasePort(collector.getPort);
 
       // Very short delay for cleanup
-      await Future<void>.delayed(isIsolatedRun
-          ? const Duration(seconds: 1)
-          : const Duration(milliseconds: 50));
+      await Future<void>.delayed(
+        isIsolatedRun
+            ? const Duration(seconds: 1)
+            : const Duration(milliseconds: 50),
+      );
 
       print('TearDown complete');
     });
@@ -239,15 +244,15 @@ void main() {
 
       print('Waiting for span to be exported...');
       try {
-        await collector.waitForSpans(1,
-            timeout: const Duration(seconds: 3)); // Reduced timeout
+        await collector.waitForSpans(
+          1,
+          timeout: const Duration(seconds: 3),
+        ); // Reduced timeout
 
         print('Verifying span attributes...');
         await collector.assertSpanExists(
           name: 'attributed-span-test-$uniqueId',
-          attributes: {
-            'test.key': 'test-value',
-          },
+          attributes: {'test.key': 'test-value'},
         );
         print('Context attributes test completed');
       } catch (e) {
@@ -260,79 +265,97 @@ void main() {
       }
     }, timeout: testTimeout);
 
-    test('propagates context between spans correctly using withSpan', () async {
-      print('Starting context propagation test with withSpan');
+    test(
+      'propagates context between spans correctly using withSpan',
+      () async {
+        print('Starting context propagation test with withSpan');
 
-      final parentSpan = tracer.startSpan('parent-span-test-$uniqueId');
-      parentSpan.spanContext.spanId.toString();
+        final parentSpan = tracer.startSpan('parent-span-test-$uniqueId');
+        parentSpan.spanContext.spanId.toString();
 
-      final parentContext = OTel.context().withSpan(parentSpan);
+        final parentContext = OTel.context().withSpan(parentSpan);
 
-      final childSpan = tracer.startSpan(
-        'child-span-test-$uniqueId',
-        context: parentContext,
-      );
+        final childSpan = tracer.startSpan(
+          'child-span-test-$uniqueId',
+          context: parentContext,
+        );
 
-      // Verify parent-child relationship at the span level
-      expect(
-          childSpan.spanContext.traceId, equals(parentSpan.spanContext.traceId),
-          reason: 'Child span should inherit trace ID from parent');
-      expect(childSpan.parentSpanContext, equals(parentSpan.spanContext),
-          reason: 'Child span should have parent span context');
-
-      print('Ending spans...');
-      childSpan.end();
-      parentSpan.end();
-
-      // Force flush to ensure immediate export
-      await tracerProvider.forceFlush();
-
-      print('Waiting for spans to be exported...');
-      try {
-        await collector.waitForSpans(2,
-            timeout: const Duration(seconds: 3)); // Reduced timeout
-
-        final spans = await collector.getSpans();
-        print('Got ${spans.length} spans');
-
-        print('Available spans:');
-        for (var span in spans) {
-          print('  Span: ${span['name']}, ID: ${span['spanId']}');
-        }
-
+        // Verify parent-child relationship at the span level
         expect(
-            spans.any((s) => s['name'] == 'parent-span-test-$uniqueId'), isTrue,
-            reason: 'Parent span should be exported');
+          childSpan.spanContext.traceId,
+          equals(parentSpan.spanContext.traceId),
+          reason: 'Child span should inherit trace ID from parent',
+        );
         expect(
-            spans.any((s) => s['name'] == 'child-span-test-$uniqueId'), isTrue,
-            reason: 'Child span should be exported');
+          childSpan.parentSpanContext,
+          equals(parentSpan.spanContext),
+          reason: 'Child span should have parent span context',
+        );
 
-        final parentExportedSpan = spans.firstWhere(
-            (s) => s['name'] == 'parent-span-test-$uniqueId',
-            orElse: () => <String, dynamic>{});
+        print('Ending spans...');
+        childSpan.end();
+        parentSpan.end();
 
-        final childExportedSpan = spans.firstWhere(
-            (s) => s['name'] == 'child-span-test-$uniqueId',
-            orElse: () => <String, dynamic>{});
+        // Force flush to ensure immediate export
+        await tracerProvider.forceFlush();
 
-        if (parentExportedSpan.isNotEmpty && childExportedSpan.isNotEmpty) {
-          if (childExportedSpan['parentSpanId'] != null) {
-            expect(childExportedSpan['parentSpanId'], isNotNull);
+        print('Waiting for spans to be exported...');
+        try {
+          await collector.waitForSpans(
+            2,
+            timeout: const Duration(seconds: 3),
+          ); // Reduced timeout
 
-            expect(
-              childExportedSpan['traceId'],
-              equals(parentExportedSpan['traceId']),
-              reason: 'Child span should inherit trace ID from parent',
-            );
+          final spans = await collector.getSpans();
+          print('Got ${spans.length} spans');
+
+          print('Available spans:');
+          for (var span in spans) {
+            print('  Span: ${span['name']}, ID: ${span['spanId']}');
           }
+
+          expect(
+            spans.any((s) => s['name'] == 'parent-span-test-$uniqueId'),
+            isTrue,
+            reason: 'Parent span should be exported',
+          );
+          expect(
+            spans.any((s) => s['name'] == 'child-span-test-$uniqueId'),
+            isTrue,
+            reason: 'Child span should be exported',
+          );
+
+          final parentExportedSpan = spans.firstWhere(
+            (s) => s['name'] == 'parent-span-test-$uniqueId',
+            orElse: () => <String, dynamic>{},
+          );
+
+          final childExportedSpan = spans.firstWhere(
+            (s) => s['name'] == 'child-span-test-$uniqueId',
+            orElse: () => <String, dynamic>{},
+          );
+
+          if (parentExportedSpan.isNotEmpty && childExportedSpan.isNotEmpty) {
+            if (childExportedSpan['parentSpanId'] != null) {
+              expect(childExportedSpan['parentSpanId'], isNotNull);
+
+              expect(
+                childExportedSpan['traceId'],
+                equals(parentExportedSpan['traceId']),
+                reason: 'Child span should inherit trace ID from parent',
+              );
+            }
+          }
+        } catch (e) {
+          print(
+            'Export verification failed, but spans were created correctly: $e',
+          );
+          // We already verified the relationship at span level above
+          print('Context propagation verified at span level');
         }
-      } catch (e) {
-        print(
-            'Export verification failed, but spans were created correctly: $e');
-        // We already verified the relationship at span level above
-        print('Context propagation verified at span level');
-      }
-    }, timeout: testTimeout);
+      },
+      timeout: testTimeout,
+    );
 
     test('withSpanContext prevents trace ID changes', () async {
       final uniqueSpanName1 = 'span1-$uniqueId';
@@ -366,10 +389,7 @@ void main() {
       final context = OTel.context().withSpanContext(remoteContext);
 
       final uniqueChildName = 'remote-child-$uniqueId';
-      final childSpan = tracer.startSpan(
-        uniqueChildName,
-        context: context,
-      );
+      final childSpan = tracer.startSpan(uniqueChildName, context: context);
 
       expect(
         childSpan.spanContext.traceId,

--- a/test/unit/context/context_propagation_tests.dart
+++ b/test/unit/context/context_propagation_tests.dart
@@ -16,10 +16,7 @@ void main() {
     // Initialize a fresh tracer provider and tracer for each test
     tracerProvider = OTel.tracerProvider();
 
-    tracer = tracerProvider.getTracer(
-      'test-tracer',
-      version: '1.0.0',
-    );
+    tracer = tracerProvider.getTracer('test-tracer', version: '1.0.0');
 
     rootContext = OTel.context();
   });
@@ -27,20 +24,25 @@ void main() {
   group('Context Propagation', () {
     test('should maintain same trace ID between parent and child spans', () {
       final parentSpan = tracer.startSpan('parent', context: rootContext);
-      final parentContext =
-          Context.current.copyWithSpanContext(parentSpan.spanContext);
+      final parentContext = Context.current.copyWithSpanContext(
+        parentSpan.spanContext,
+      );
 
       final childSpan = tracer.startSpan('child', context: parentContext);
       (parentContext).copyWithSpanContext(childSpan.spanContext);
 
       expect(
-          childSpan.spanContext.traceId, equals(parentSpan.spanContext.traceId),
-          reason: 'Child span should inherit trace ID from parent');
+        childSpan.spanContext.traceId,
+        equals(parentSpan.spanContext.traceId),
+        reason: 'Child span should inherit trace ID from parent',
+      );
 
       // Get the parent span ID from the  implementation
-      expect((childSpan.spanContext).parentSpanId,
-          equals(parentSpan.spanContext.spanId),
-          reason: 'Child span should reference parent span ID');
+      expect(
+        (childSpan.spanContext).parentSpanId,
+        equals(parentSpan.spanContext.spanId),
+        reason: 'Child span should reference parent span ID',
+      );
     });
 
     test('should properly propagate span context through multiple levels', () {
@@ -55,32 +57,43 @@ void main() {
       expect(span2.spanContext.traceId, equals(span1.spanContext.traceId));
       expect(span3.spanContext.traceId, equals(span1.spanContext.traceId));
       expect(
-          (span2.spanContext).parentSpanId, equals(span1.spanContext.spanId));
+        (span2.spanContext).parentSpanId,
+        equals(span1.spanContext.spanId),
+      );
       expect(
-          (span3.spanContext).parentSpanId, equals(span2.spanContext.spanId));
+        (span3.spanContext).parentSpanId,
+        equals(span2.spanContext.spanId),
+      );
     });
 
     test('should maintain context when using current context', () {
       final parentSpan = tracer.startSpan('parent', context: rootContext);
-      final parentContext =
-          (rootContext).copyWithSpanContext(parentSpan.spanContext);
+      final parentContext = (rootContext).copyWithSpanContext(
+        parentSpan.spanContext,
+      );
 
       parentContext.run<void>(() async {
         final currentContext = Context.current;
         final currentSpanContext = currentContext.spanContext;
 
         expect(
-            currentSpanContext?.spanId, equals(parentSpan.spanContext.spanId),
-            reason: 'Current span should match parent span');
+          currentSpanContext?.spanId,
+          equals(parentSpan.spanContext.spanId),
+          reason: 'Current span should match parent span',
+        );
 
         final childSpan = tracer.startSpan('child', context: currentContext);
 
-        expect(childSpan.spanContext.traceId,
-            equals(parentSpan.spanContext.traceId),
-            reason: 'Child span should inherit trace ID from current context');
-        expect((childSpan.spanContext).parentSpanId,
-            equals(parentSpan.spanContext.spanId),
-            reason: 'Child span should reference current span as parent');
+        expect(
+          childSpan.spanContext.traceId,
+          equals(parentSpan.spanContext.traceId),
+          reason: 'Child span should inherit trace ID from current context',
+        );
+        expect(
+          (childSpan.spanContext).parentSpanId,
+          equals(parentSpan.spanContext.spanId),
+          reason: 'Child span should reference current span as parent',
+        );
       });
     });
   });

--- a/test/unit/context/context_propagator_test.dart
+++ b/test/unit/context/context_propagator_test.dart
@@ -38,8 +38,11 @@ class TestPropagator implements TextMapPropagator<Map<String, String>, String> {
   List<String> fields() => ['test-field'];
 
   @override
-  void inject(Context context, Map<String, String> carrier,
-      TextMapSetter<String> setter) {
+  void inject(
+    Context context,
+    Map<String, String> carrier,
+    TextMapSetter<String> setter,
+  ) {
     final span = context.span;
     if (span != null) {
       setter.set('test-field', span.spanContext.traceId.toString());
@@ -47,8 +50,11 @@ class TestPropagator implements TextMapPropagator<Map<String, String>, String> {
   }
 
   @override
-  Context extract(Context context, Map<String, String> carrier,
-      TextMapGetter<String> getter) {
+  Context extract(
+    Context context,
+    Map<String, String> carrier,
+    TextMapGetter<String> getter,
+  ) {
     final value = getter.get('test-field');
     if (value != null) {
       // In a real implementation, you would parse the value and create a span
@@ -94,8 +100,11 @@ void main() {
       expect(carrier.headers['test-field'], isNotNull);
 
       // Extract and verify context
-      final extractedContext =
-          propagator.extract(Context.root, carrier.headers, getter);
+      final extractedContext = propagator.extract(
+        Context.root,
+        carrier.headers,
+        getter,
+      );
       expect(extractedContext, isNotNull);
     });
 
@@ -107,8 +116,11 @@ void main() {
       ]);
 
       propagator.inject(context, carrier.headers, setter);
-      final extractedContext =
-          propagator.extract(Context.root, carrier.headers, getter);
+      final extractedContext = propagator.extract(
+        Context.root,
+        carrier.headers,
+        getter,
+      );
 
       expect(extractedContext, isNotNull);
     });

--- a/test/unit/context/context_test.dart
+++ b/test/unit/context/context_test.dart
@@ -72,8 +72,11 @@ void main() {
       test('prevents changing trace ID via withSpanContext', () {
         final context = OTel.context().withSpanContext(spanContext1);
 
-        expect(() => context.withSpanContext(spanContext2), throwsArgumentError,
-            reason: 'Should not allow changing trace ID via withSpanContext');
+        expect(
+          () => context.withSpanContext(spanContext2),
+          throwsArgumentError,
+          reason: 'Should not allow changing trace ID via withSpanContext',
+        );
       });
 
       test('maintains context immutability when adding span contexts', () {
@@ -93,17 +96,25 @@ void main() {
         final context2 = context1.withSpanContext(spanContext1b);
 
         // Verify original context is unchanged
-        expect(context1.spanContext, equals(spanContext1),
-            reason: 'Original context should be unchanged');
+        expect(
+          context1.spanContext,
+          equals(spanContext1),
+          reason: 'Original context should be unchanged',
+        );
 
         // Verify new context has the new span context
-        expect(context2.spanContext, equals(spanContext1b),
-            reason: 'New context should have new span context');
+        expect(
+          context2.spanContext,
+          equals(spanContext1b),
+          reason: 'New context should have new span context',
+        );
 
         // Verify both contexts have same trace ID
-        expect(context1.spanContext?.traceId,
-            equals(context2.spanContext?.traceId),
-            reason: 'Both contexts should have same trace ID');
+        expect(
+          context1.spanContext?.traceId,
+          equals(context2.spanContext?.traceId),
+          reason: 'Both contexts should have same trace ID',
+        );
       });
     });
 
@@ -129,21 +140,23 @@ void main() {
         final entries = baggage.getAllEntries();
         entries.forEach((key, value) {
           final retrievedValue = retrievedBaggage!.getEntry(key);
-          expect(retrievedValue, isNotNull,
-              reason: 'Missing entry for key: $key');
-          expect(retrievedValue?.value, equals(value.value),
-              reason: 'Value mismatch for key: $key');
+          expect(
+            retrievedValue,
+            isNotNull,
+            reason: 'Missing entry for key: $key',
+          );
+          expect(
+            retrievedValue?.value,
+            equals(value.value),
+            reason: 'Value mismatch for key: $key',
+          );
         });
       });
 
       test('maintains baggage immutability', () {
-        final baggage1 = OTel.baggage({
-          'key1': OTel.baggageEntry('value1'),
-        });
+        final baggage1 = OTel.baggage({'key1': OTel.baggageEntry('value1')});
 
-        final baggage2 = OTel.baggage({
-          'key2': OTel.baggageEntry('value2'),
-        });
+        final baggage2 = OTel.baggage({'key2': OTel.baggageEntry('value2')});
 
         final context1 = OTel.context(baggage: baggage1);
 
@@ -156,12 +169,18 @@ void main() {
         print('Original baggage2: ${baggage2.getAllEntries()}');
 
         final retrievedBaggage1 = context1.baggage;
-        expect(retrievedBaggage1!.getEntry('key1')?.value, equals('value1'),
-            reason: 'Context1 lost its baggage value');
+        expect(
+          retrievedBaggage1!.getEntry('key1')?.value,
+          equals('value1'),
+          reason: 'Context1 lost its baggage value',
+        );
 
         final retrievedBaggage2 = context2.baggage;
-        expect(retrievedBaggage2!.getEntry('key2')?.value, equals('value2'),
-            reason: 'Context2 lost its baggage value');
+        expect(
+          retrievedBaggage2!.getEntry('key2')?.value,
+          equals('value2'),
+          reason: 'Context2 lost its baggage value',
+        );
       });
     });
 
@@ -184,29 +203,37 @@ void main() {
         );
       });
 
-      test('maintains separate contexts in parallel async operations',
-          () async {
-        final key = OTel.contextKey<String>('key');
-        final context1 = OTel.context().copyWith(key, 'value1');
-        final context2 = OTel.context().copyWith(key, 'value2');
+      test(
+        'maintains separate contexts in parallel async operations',
+        () async {
+          final key = OTel.contextKey<String>('key');
+          final context1 = OTel.context().copyWith(key, 'value1');
+          final context2 = OTel.context().copyWith(key, 'value2');
 
-        final future1 = context1.run(() async {
-          await Future<void>.delayed(Duration.zero);
-          return Context.current;
-        });
+          final future1 = context1.run(() async {
+            await Future<void>.delayed(Duration.zero);
+            return Context.current;
+          });
 
-        final future2 = context2.run(() async {
-          await Future<void>.delayed(Duration.zero);
-          return Context.current;
-        });
+          final future2 = context2.run(() async {
+            await Future<void>.delayed(Duration.zero);
+            return Context.current;
+          });
 
-        final results = await Future.wait([future1, future2]);
+          final results = await Future.wait([future1, future2]);
 
-        expect(results[0].get(key), equals('value1'),
-            reason: 'Context1 value was lost or modified');
-        expect(results[1].get(key), equals('value2'),
-            reason: 'Context2 value was lost or modified');
-      });
+          expect(
+            results[0].get(key),
+            equals('value1'),
+            reason: 'Context1 value was lost or modified',
+          );
+          expect(
+            results[1].get(key),
+            equals('value2'),
+            reason: 'Context2 value was lost or modified',
+          );
+        },
+      );
     });
 
     group('Context serialization', () {
@@ -238,8 +265,10 @@ void main() {
         expect(deserializedSpanContext, isNotNull);
         expect(deserializedSpanContext?.traceId, equals(spanContext.traceId));
         expect(deserializedSpanContext?.spanId, equals(spanContext.spanId));
-        expect(deserializedSpanContext?.traceFlags,
-            equals(spanContext.traceFlags));
+        expect(
+          deserializedSpanContext?.traceFlags,
+          equals(spanContext.traceFlags),
+        );
         expect(
           deserializedSpanContext?.traceState.toString(),
           equals(spanContext.traceState.toString()),
@@ -261,15 +290,22 @@ void main() {
         final deserializedBaggage = deserializedContext.baggage;
         for (final entry in baggage.getAllEntries().entries) {
           final retrievedValue = deserializedBaggage!.getEntry(entry.key);
-          expect(retrievedValue, isNotNull,
-              reason:
-                  'Missing baggage entry after deserialization: ${entry.key}');
-          expect(retrievedValue?.value, equals(entry.value.value),
-              reason:
-                  'Wrong value after deserialization for key: ${entry.key}');
-          expect(retrievedValue?.metadata, equals(entry.value.metadata),
-              reason:
-                  'Wrong metadata after deserialization for key: ${entry.key}');
+          expect(
+            retrievedValue,
+            isNotNull,
+            reason: 'Missing baggage entry after deserialization: ${entry.key}',
+          );
+          expect(
+            retrievedValue?.value,
+            equals(entry.value.value),
+            reason: 'Wrong value after deserialization for key: ${entry.key}',
+          );
+          expect(
+            retrievedValue?.metadata,
+            equals(entry.value.metadata),
+            reason:
+                'Wrong metadata after deserialization for key: ${entry.key}',
+          );
         }
       });
 
@@ -290,9 +326,12 @@ void main() {
         final key2 = OTel.contextKey<String>('same-name');
 
         // Verify they are different keys despite same name
-        expect(key1 == key2, isFalse,
-            reason:
-                'Keys with same name should be different objects due to different uniqueIds');
+        expect(
+          key1 == key2,
+          isFalse,
+          reason:
+              'Keys with same name should be different objects due to different uniqueIds',
+        );
 
         // Create context with both keys
         final originalContext =
@@ -319,8 +358,9 @@ void main() {
           'baggage-key': OTel.baggageEntry('baggage-value'),
         });
 
-        final originalContext =
-            OTel.context(baggage: baggage).copyWith(key, 'test-value');
+        final originalContext = OTel.context(
+          baggage: baggage,
+        ).copyWith(key, 'test-value');
 
         await originalContext.run(() async {
           final result = await originalContext.runIsolate(() async {
@@ -332,10 +372,16 @@ void main() {
             };
           });
 
-          expect(result['test-key'], equals('test-value'),
-              reason: 'Context key not propagated to isolate');
-          expect(result['baggage-value'], equals('baggage-value'),
-              reason: 'Baggage not propagated to isolate');
+          expect(
+            result['test-key'],
+            equals('test-value'),
+            reason: 'Context key not propagated to isolate',
+          );
+          expect(
+            result['baggage-value'],
+            equals('baggage-value'),
+            reason: 'Baggage not propagated to isolate',
+          );
         });
       });
 

--- a/test/unit/context/context_utils_test.dart
+++ b/test/unit/context/context_utils_test.dart
@@ -77,14 +77,22 @@ void main() {
           expect(serialized['spanContext'], isA<Map<String, dynamic>>());
           final serializedSpanContext =
               serialized['spanContext'] as Map<String, dynamic>;
-          expect(serializedSpanContext['traceId'],
-              equals(spanContext.traceId.hexString));
-          expect(serializedSpanContext['spanId'],
-              equals(spanContext.spanId.hexString));
-          expect(serializedSpanContext['traceFlags'],
-              equals(spanContext.traceFlags.asByte));
           expect(
-              serializedSpanContext['isRemote'], equals(spanContext.isRemote));
+            serializedSpanContext['traceId'],
+            equals(spanContext.traceId.hexString),
+          );
+          expect(
+            serializedSpanContext['spanId'],
+            equals(spanContext.spanId.hexString),
+          );
+          expect(
+            serializedSpanContext['traceFlags'],
+            equals(spanContext.traceFlags.asByte),
+          );
+          expect(
+            serializedSpanContext['isRemote'],
+            equals(spanContext.isRemote),
+          );
           expect(serializedSpanContext['traceState'], equals({'key': 'value'}));
         });
 
@@ -97,8 +105,9 @@ void main() {
             isRemote: false,
           );
 
-          final originalContext =
-              OTel.context().withSpanContext(originalSpanContext);
+          final originalContext = OTel.context().withSpanContext(
+            originalSpanContext,
+          );
 
           final serializedData = originalContext.serialize();
           final reconstructedContext = Context.deserialize(serializedData);

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -20,6 +20,8 @@ import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../testing_utils/memory_log_record_exporter.dart';
+
 /// Runs a Dart script in a subprocess with specific environment variables set.
 /// Returns the stdout output as a string.
 Future<String> runWithEnv(
@@ -826,6 +828,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
       );
       expect(OTel.isLogPrintEnabled, isTrue);
@@ -857,6 +860,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
       );
 
@@ -872,6 +876,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
       );
 
@@ -910,6 +915,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
       );
 
@@ -926,6 +932,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
       );
 
@@ -954,6 +961,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
       );
 
@@ -969,6 +977,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
         logPrint: true,
         logPrintLoggerName: 'my.custom.logger',
       );
@@ -1219,6 +1228,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
 
       final lp = OTel.loggerProvider();
@@ -1244,6 +1254,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: true,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
 
       expect(OTel.loggerProvider(), isA<LoggerProvider>());
@@ -1256,6 +1267,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
 
       final logger = OTel.logger('test-logger');
@@ -1268,6 +1280,7 @@ void main() {
         detectPlatformResources: false,
         enableMetrics: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
 
       final logger = OTel.logger();

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -1,0 +1,1331 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Tests for environment configuration, resource detection, and OTel
+// initialization exercising error paths and edge cases.
+//
+// Areas tested:
+//   1. lib/src/environment/otel_env.dart  - getBlrpConfig, getLogRecordLimits,
+//      _parseHeaders edge cases, _getEnvBoolNullable, getExporter for metrics/logs
+//   2. lib/src/resource/resource_detector.dart - ProcessResourceDetector,
+//      HostResourceDetector, CompositeResourceDetector error handling,
+//      EnvVarResourceDetector with encoded values
+//   3. lib/src/otel.dart - print interception, tenantId, addTracerProvider,
+//      addMeterProvider, addLoggerProvider
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+/// Runs a Dart script in a subprocess with specific environment variables set.
+/// Returns the stdout output as a string.
+Future<String> runWithEnv(
+  String scriptPath,
+  Map<String, String> envVars,
+) async {
+  final env = Map<String, String>.from(Platform.environment);
+  // Clear any existing OTEL env vars that might interfere
+  env.removeWhere((key, _) => key.startsWith('OTEL_'));
+  env.addAll(envVars);
+  final result = await Process.run(
+    Platform.executable,
+    ['run', scriptPath],
+    environment: env,
+    workingDirectory: Directory.current.path,
+  );
+  if (result.exitCode != 0) {
+    throw Exception(
+      'Script failed with exit code ${result.exitCode}:\n'
+      'stdout: ${result.stdout}\n'
+      'stderr: ${result.stderr}',
+    );
+  }
+  return result.stdout as String;
+}
+
+/// A detector that throws a non-Exception type to exercise
+/// the catch block in CompositeResourceDetector.
+class _StringThrowingDetector implements ResourceDetector {
+  @override
+  Future<Resource> detect() async {
+    throw 'non-exception error string';
+  }
+}
+
+/// A detector that returns a known resource for merge testing.
+class _FixedDetector implements ResourceDetector {
+  final Map<String, Object> attrs;
+  _FixedDetector(this.attrs);
+
+  @override
+  Future<Resource> detect() async {
+    return ResourceCreate.create(
+      OTelFactory.otelFactory!.attributesFromMap(attrs),
+    );
+  }
+}
+
+void main() {
+  // =========================================================================
+  // OTelEnv - subprocess tests for getBlrpConfig
+  // =========================================================================
+  group('OTelEnv.getBlrpConfig (subprocess)', () {
+    test('reads scheduleDelay', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_SCHEDULE_DELAY': '2000'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['scheduleDelay_ms'], equals(2000));
+    });
+
+    test('reads exportTimeout', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_EXPORT_TIMEOUT': '30000'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['exportTimeout_ms'], equals(30000));
+    });
+
+    test('reads maxQueueSize', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_MAX_QUEUE_SIZE': '4096'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['maxQueueSize'], equals(4096));
+    });
+
+    test('reads maxExportBatchSize', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '1024'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['maxExportBatchSize'], equals(1024));
+    });
+
+    test('reads all BLRP config values together', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {
+          'OTEL_BLRP_SCHEDULE_DELAY': '1000',
+          'OTEL_BLRP_EXPORT_TIMEOUT': '5000',
+          'OTEL_BLRP_MAX_QUEUE_SIZE': '2048',
+          'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '512',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['scheduleDelay_ms'], equals(1000));
+      expect(result['exportTimeout_ms'], equals(5000));
+      expect(result['maxQueueSize'], equals(2048));
+      expect(result['maxExportBatchSize'], equals(512));
+    });
+
+    test('ignores non-numeric scheduleDelay', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_SCHEDULE_DELAY': 'not-a-number'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('scheduleDelay_ms'), isFalse);
+    });
+
+    test('ignores non-numeric exportTimeout', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_EXPORT_TIMEOUT': 'abc'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('exportTimeout_ms'), isFalse);
+    });
+
+    test('ignores non-numeric maxQueueSize', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_MAX_QUEUE_SIZE': 'xyz'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('maxQueueSize'), isFalse);
+    });
+
+    test('ignores non-numeric maxExportBatchSize', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': 'foo'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('maxExportBatchSize'), isFalse);
+    });
+
+    test('returns empty map when no BLRP env vars set', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_blrp_config.dart',
+        {},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result, isEmpty);
+    });
+  });
+
+  // =========================================================================
+  // OTelEnv - subprocess tests for getLogRecordLimits
+  // =========================================================================
+  group('OTelEnv.getLogRecordLimits (subprocess)', () {
+    test('reads attributeValueLengthLimit', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_logrecord_limits.dart',
+        {'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': '256'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['attributeValueLengthLimit'], equals(256));
+    });
+
+    test('reads attributeCountLimit', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_logrecord_limits.dart',
+        {'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '64'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['attributeCountLimit'], equals(64));
+    });
+
+    test('reads both limits together', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_logrecord_limits.dart',
+        {
+          'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': '512',
+          'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '128',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['attributeValueLengthLimit'], equals(512));
+      expect(result['attributeCountLimit'], equals(128));
+    });
+
+    test('ignores non-numeric attributeValueLengthLimit', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_logrecord_limits.dart',
+        {'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': 'not-a-number'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('attributeValueLengthLimit'), isFalse);
+    });
+
+    test('ignores non-numeric attributeCountLimit', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_logrecord_limits.dart',
+        {'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': 'bad'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('attributeCountLimit'), isFalse);
+    });
+
+    test('returns empty map when no limits env vars set', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_logrecord_limits.dart',
+        {},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result, isEmpty);
+    });
+  });
+
+  // =========================================================================
+  // OTelEnv - subprocess tests for _parseHeaders edge cases
+  // =========================================================================
+  group('OTelEnv._parseHeaders edge cases (subprocess)', () {
+    test('handles empty header value', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {'OTEL_EXPORTER_OTLP_HEADERS': 'key='},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      // "key=" has equalIndex at position 3, but equalIndex < pair.length - 1
+      // is false (3 < 3 is false), so it should be skipped
+      expect(result.containsKey('key'), isFalse);
+    });
+
+    test('handles header with no equals sign', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {'OTEL_EXPORTER_OTLP_HEADERS': 'noequalssign'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result, isEmpty);
+    });
+
+    test('handles header starting with equals sign', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {'OTEL_EXPORTER_OTLP_HEADERS': '=value'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      // equalIndex is 0, which is not > 0, so it should be skipped
+      expect(result, isEmpty);
+    });
+
+    test('handles multiple equals signs in value (base64)', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS':
+              'authorization=Basic dXNlcjpwYXNz==,x-api=val',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['authorization'], equals('Basic dXNlcjpwYXNz=='));
+      expect(result['x-api'], equals('val'));
+    });
+
+    test('handles whitespace around keys and values', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {'OTEL_EXPORTER_OTLP_HEADERS': ' key1 = value1 , key2 = value2 '},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['key1'], equals('value1'));
+      expect(result['key2'], equals('value2'));
+    });
+
+    test('handles single header', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {'OTEL_EXPORTER_OTLP_HEADERS': 'single=header'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['single'], equals('header'));
+    });
+
+    test('handles mix of valid and invalid headers', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_parse_headers.dart',
+        {'OTEL_EXPORTER_OTLP_HEADERS': 'good=val,bad,=nokey,also-good=yes'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['good'], equals('val'));
+      expect(result['also-good'], equals('yes'));
+      expect(result.containsKey('bad'), isFalse);
+      expect(result.containsKey(''), isFalse);
+    });
+  });
+
+  // =========================================================================
+  // OTelEnv - subprocess tests for getOtlpConfig with metrics and logs signals
+  // (covers the 'metrics' and 'logs' cases in the switch blocks)
+  // =========================================================================
+  group('OTelEnv.getOtlpConfig metrics/logs signals (subprocess)', () {
+    test('reads metrics-specific insecure setting', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_INSECURE': 'false',
+          'OTEL_EXPORTER_OTLP_METRICS_INSECURE': 'true',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isTrue);
+    });
+
+    test('reads logs-specific insecure setting', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_INSECURE': 'true',
+          'OTEL_EXPORTER_OTLP_LOGS_INSECURE': 'false',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
+    });
+
+    test('reads metrics-specific protocol', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_METRICS_PROTOCOL': 'http/protobuf',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['protocol'], equals('http/protobuf'));
+    });
+
+    test('reads logs-specific protocol', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_LOGS_PROTOCOL': 'http/json',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['protocol'], equals('http/json'));
+    });
+
+    test('reads metrics-specific timeout', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_TIMEOUT': '10000',
+          'OTEL_EXPORTER_OTLP_METRICS_TIMEOUT': '5000',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['timeout_ms'], equals(5000));
+    });
+
+    test('reads logs-specific timeout', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_TIMEOUT': '10000',
+          'OTEL_EXPORTER_OTLP_LOGS_TIMEOUT': '8000',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['timeout_ms'], equals(8000));
+    });
+
+    test('reads metrics-specific compression', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_COMPRESSION': 'none',
+          'OTEL_EXPORTER_OTLP_METRICS_COMPRESSION': 'gzip',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['compression'], equals('gzip'));
+    });
+
+    test('reads metrics-specific certificate', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_CERTIFICATE': '/general/cert.pem',
+          'OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE': '/metrics/cert.pem',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['certificate'], equals('/metrics/cert.pem'));
+    });
+
+    test('reads logs-specific certificate', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_CERTIFICATE': '/general/cert.pem',
+          'OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE': '/logs/cert.pem',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['certificate'], equals('/logs/cert.pem'));
+    });
+
+    test('reads metrics-specific client key', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_CLIENT_KEY': '/general/key.pem',
+          'OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY': '/metrics/key.pem',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['clientKey'], equals('/metrics/key.pem'));
+    });
+
+    test('reads logs-specific client key', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_CLIENT_KEY': '/general/key.pem',
+          'OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY': '/logs/key.pem',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['clientKey'], equals('/logs/key.pem'));
+    });
+
+    test('reads metrics-specific client certificate', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE': '/general/client.pem',
+          'OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE':
+              '/metrics/client.pem',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['clientCertificate'], equals('/metrics/client.pem'));
+    });
+
+    test('reads full metrics config with all fields', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT': 'http://metrics:4318',
+          'OTEL_EXPORTER_OTLP_METRICS_PROTOCOL': 'http/protobuf',
+          'OTEL_EXPORTER_OTLP_METRICS_HEADERS': 'metric-key=mval',
+          'OTEL_EXPORTER_OTLP_METRICS_INSECURE': 'true',
+          'OTEL_EXPORTER_OTLP_METRICS_TIMEOUT': '7000',
+          'OTEL_EXPORTER_OTLP_METRICS_COMPRESSION': 'gzip',
+          'OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE': '/m/cert.pem',
+          'OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY': '/m/key.pem',
+          'OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE': '/m/client.pem',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['endpoint'], equals('http://metrics:4318'));
+      expect(result['protocol'], equals('http/protobuf'));
+      expect(result['insecure'], isTrue);
+      expect(result['timeout_ms'], equals(7000));
+      expect(result['compression'], equals('gzip'));
+      expect(result['certificate'], equals('/m/cert.pem'));
+      expect(result['clientKey'], equals('/m/key.pem'));
+      expect(result['clientCertificate'], equals('/m/client.pem'));
+      final headers = result['headers'] as Map<String, dynamic>;
+      expect(headers['metric-key'], equals('mval'));
+    });
+
+    test('reads full logs config with all fields', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {
+          'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT': 'http://logs:4318',
+          'OTEL_EXPORTER_OTLP_LOGS_PROTOCOL': 'http/json',
+          'OTEL_EXPORTER_OTLP_LOGS_HEADERS': 'log-key=lval',
+          'OTEL_EXPORTER_OTLP_LOGS_INSECURE': 'false',
+          'OTEL_EXPORTER_OTLP_LOGS_TIMEOUT': '3000',
+          'OTEL_EXPORTER_OTLP_LOGS_COMPRESSION': 'none',
+          'OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE': '/l/cert.pem',
+          'OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY': '/l/key.pem',
+          'OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE': '/l/client.pem',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['endpoint'], equals('http://logs:4318'));
+      expect(result['protocol'], equals('http/json'));
+      expect(result['insecure'], isFalse);
+      expect(result['timeout_ms'], equals(3000));
+      expect(result['compression'], equals('none'));
+      expect(result['certificate'], equals('/l/cert.pem'));
+      expect(result['clientKey'], equals('/l/key.pem'));
+      expect(result['clientCertificate'], equals('/l/client.pem'));
+      final headers = result['headers'] as Map<String, dynamic>;
+      expect(headers['log-key'], equals('lval'));
+    });
+  });
+
+  // =========================================================================
+  // OTelEnv - subprocess tests for _getEnvBoolNullable edge cases
+  // (tested indirectly through insecure settings)
+  // =========================================================================
+  group('OTelEnv._getEnvBoolNullable edge cases (subprocess)', () {
+    test('insecure "1" is true', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': '1'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isTrue);
+    });
+
+    test('insecure "yes" is true', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'yes'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isTrue);
+    });
+
+    test('insecure "on" is true', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'on'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isTrue);
+    });
+
+    test('insecure "0" is false', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': '0'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
+    });
+
+    test('insecure "no" is false', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'no'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
+    });
+
+    test('insecure "off" is false', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'off'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
+    });
+
+    test('insecure "FALSE" (uppercase) is false', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'FALSE'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
+    });
+
+    test('insecure "TRUE" (uppercase) is true', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'TRUE'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isTrue);
+    });
+
+    test('insecure with unrecognized value returns null (no insecure key)',
+        () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_otlp_config.dart',
+        {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result.containsKey('insecure'), isFalse);
+    });
+  });
+
+  // =========================================================================
+  // OTelEnv - subprocess tests for getExporter with metrics/logs
+  // =========================================================================
+  group('OTelEnv.getExporter for metrics and logs (subprocess)', () {
+    test('reads OTEL_METRICS_EXPORTER', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_exporter.dart',
+        {
+          'OTEL_METRICS_EXPORTER': 'prometheus',
+          'CHECK_SIGNAL': 'metrics',
+        },
+      );
+      expect(output.trim(), equals('prometheus'));
+    });
+
+    test('reads OTEL_LOGS_EXPORTER', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_exporter.dart',
+        {
+          'OTEL_LOGS_EXPORTER': 'none',
+          'CHECK_SIGNAL': 'logs',
+        },
+      );
+      expect(output.trim(), equals('none'));
+    });
+
+    test('returns null for unknown signal', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_exporter.dart',
+        {'CHECK_SIGNAL': 'unknown'},
+      );
+      expect(output.trim(), equals('null'));
+    });
+  });
+
+  // =========================================================================
+  // OTelEnv - in-process tests for getBlrpConfig and getLogRecordLimits
+  // (these read from actual env, but test the method call and return type)
+  // =========================================================================
+  group('OTelEnv in-process', () {
+    test('getBlrpConfig returns a Map<String, dynamic>', () {
+      final config = OTelEnv.getBlrpConfig();
+      expect(config, isA<Map<String, dynamic>>());
+    });
+
+    test('getLogRecordLimits returns a Map<String, dynamic>', () {
+      final config = OTelEnv.getLogRecordLimits();
+      expect(config, isA<Map<String, dynamic>>());
+    });
+
+    test('getExporter for metrics returns nullable result', () {
+      final result = OTelEnv.getExporter(signal: 'metrics');
+      // Result is null when env var is not set, or a String when set
+      expect(result, anyOf(isNull, isA<String>()));
+    });
+
+    test('getExporter for logs returns nullable result', () {
+      final result = OTelEnv.getExporter(signal: 'logs');
+      expect(result, anyOf(isNull, isA<String>()));
+    });
+  });
+
+  // =========================================================================
+  // EnvVarResourceDetector - subprocess tests for encoded values
+  // =========================================================================
+  group('EnvVarResourceDetector with encoded values (subprocess)', () {
+    test('parses simple key=value pairs', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_envvar_resource_detector.dart',
+        {'OTEL_RESOURCE_ATTRIBUTES': 'key1=value1,key2=value2'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['key1'], equals('value1'));
+      expect(result['key2'], equals('value2'));
+    });
+
+    test('handles percent-encoded values', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_envvar_resource_detector.dart',
+        {'OTEL_RESOURCE_ATTRIBUTES': 'path=/usr%2Flocal%2Fbin'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['path'], equals('/usr/local/bin'));
+    });
+
+    test('handles empty OTEL_RESOURCE_ATTRIBUTES', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_envvar_resource_detector.dart',
+        {'OTEL_RESOURCE_ATTRIBUTES': ''},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result, isEmpty);
+    });
+
+    test('handles single attribute', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_envvar_resource_detector.dart',
+        {'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-app'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['service.name'], equals('my-app'));
+    });
+
+    test('skips malformed entries (no equals)', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_envvar_resource_detector.dart',
+        {'OTEL_RESOURCE_ATTRIBUTES': 'good=val,badentry,also-good=yes'},
+      );
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['good'], equals('val'));
+      expect(result['also-good'], equals('yes'));
+      expect(result.containsKey('badentry'), isFalse);
+    });
+  });
+
+  // =========================================================================
+  // ResourceDetector - additional in-process edge case tests
+  // =========================================================================
+  group('ResourceDetector additional tests', () {
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'detector-edge-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+    });
+
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+    });
+
+    test(
+        'CompositeResourceDetector continues when detector throws non-Exception',
+        () async {
+      final stringThrower = _StringThrowingDetector();
+      final working = _FixedDetector({'survived': 'yes'});
+      final composite = CompositeResourceDetector([stringThrower, working]);
+      final resource = await composite.detect();
+      final attrs = resource.attributes.toMap();
+      expect(attrs['survived']?.value, equals('yes'));
+    });
+
+    test('CompositeResourceDetector with all string-throwing detectors',
+        () async {
+      final composite = CompositeResourceDetector([
+        _StringThrowingDetector(),
+        _StringThrowingDetector(),
+      ]);
+      final resource = await composite.detect();
+      expect(resource.attributes.isEmpty, isTrue);
+    });
+
+    test('EnvVarResourceDetector returns empty resource when no env var set',
+        () async {
+      // The default env in tests typically has no OTEL_RESOURCE_ATTRIBUTES
+      final detector = EnvVarResourceDetector();
+      final resource = await detector.detect();
+      expect(resource.attributes.isEmpty, isTrue);
+    });
+
+    test('PlatformResourceDetector.create returns CompositeResourceDetector',
+        () {
+      final detector = PlatformResourceDetector.create();
+      expect(detector, isA<CompositeResourceDetector>());
+    });
+  });
+
+  // =========================================================================
+  // OTel - print interception methods
+  // =========================================================================
+  group('OTel print interception', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+    });
+
+    test('isLogPrintEnabled defaults to false', () async {
+      await OTel.initialize(
+        serviceName: 'print-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      expect(OTel.isLogPrintEnabled, isFalse);
+    });
+
+    test('isLogPrintEnabled is true when logPrint=true', () async {
+      await OTel.initialize(
+        serviceName: 'print-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+      );
+      expect(OTel.isLogPrintEnabled, isTrue);
+    });
+
+    test('runWithPrintInterception runs callback directly when not enabled',
+        () async {
+      await OTel.initialize(
+        serviceName: 'print-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+        logPrint: false,
+      );
+
+      var callbackRan = false;
+      final result = OTel.runWithPrintInterception(() {
+        callbackRan = true;
+        return 42;
+      });
+      expect(callbackRan, isTrue);
+      expect(result, equals(42));
+    });
+
+    test('runWithPrintInterception returns callback result when enabled',
+        () async {
+      await OTel.initialize(
+        serviceName: 'print-enabled-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+      );
+
+      final result = OTel.runWithPrintInterception(() {
+        return 'hello';
+      });
+      expect(result, equals('hello'));
+    });
+
+    test('runWithPrintInterception intercepts print when enabled', () async {
+      await OTel.initialize(
+        serviceName: 'print-intercept-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+      );
+
+      // This should not throw - print is intercepted and logged
+      OTel.runWithPrintInterception(() {
+        print('test message from print interception');
+      });
+      // If we got here without error, the interception is working
+      expect(true, isTrue);
+    });
+
+    test(
+        'runWithPrintInterceptionAsync runs callback directly when not enabled',
+        () async {
+      await OTel.initialize(
+        serviceName: 'async-print-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+        logPrint: false,
+      );
+
+      var callbackRan = false;
+      final result = await OTel.runWithPrintInterceptionAsync(() async {
+        callbackRan = true;
+        return 99;
+      });
+      expect(callbackRan, isTrue);
+      expect(result, equals(99));
+    });
+
+    test('runWithPrintInterceptionAsync returns callback result when enabled',
+        () async {
+      await OTel.initialize(
+        serviceName: 'async-print-enabled-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+      );
+
+      final result = await OTel.runWithPrintInterceptionAsync(() async {
+        return 'async hello';
+      });
+      expect(result, equals('async hello'));
+    });
+
+    test('runWithPrintInterceptionAsync intercepts print when enabled',
+        () async {
+      await OTel.initialize(
+        serviceName: 'async-print-intercept-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+      );
+
+      await OTel.runWithPrintInterceptionAsync(() async {
+        print('async test message from print interception');
+      });
+      // If we got here without error, the interception is working
+      expect(true, isTrue);
+    });
+
+    test('logBridge is null when logPrint is false', () async {
+      await OTel.initialize(
+        serviceName: 'no-bridge-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+        logPrint: false,
+      );
+      expect(OTel.logBridge, isNull);
+    });
+
+    test('logBridge is initialized after first runWithPrintInterception',
+        () async {
+      await OTel.initialize(
+        serviceName: 'bridge-init-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+      );
+
+      // Before first call, bridge may or may not be initialized
+      // After call, it should be
+      OTel.runWithPrintInterception(() {});
+      expect(OTel.logBridge, isNotNull);
+    });
+
+    test('custom logPrintLoggerName is used', () async {
+      await OTel.initialize(
+        serviceName: 'custom-logger-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+        logPrint: true,
+        logPrintLoggerName: 'my.custom.logger',
+      );
+
+      // Trigger initialization of the bridge
+      OTel.runWithPrintInterception(() {});
+      expect(OTel.logBridge, isNotNull);
+    });
+  });
+
+  // =========================================================================
+  // OTel - addTracerProvider, addMeterProvider, addLoggerProvider
+  // =========================================================================
+  group('OTel provider creation methods', () {
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'provider-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+    });
+
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+    });
+
+    test('addTracerProvider creates a named TracerProvider', () {
+      final tp = OTel.addTracerProvider('custom-traces');
+      expect(tp, isA<TracerProvider>());
+      expect(tp.resource, isNotNull);
+    });
+
+    test('addTracerProvider uses default resource when none specified', () {
+      final tp = OTel.addTracerProvider('default-resource-tp');
+      expect(tp.resource, equals(OTel.defaultResource));
+    });
+
+    test('addTracerProvider uses custom resource when specified', () {
+      final customResource = OTel.resource(
+        OTel.attributesFromMap({'custom': 'value'}),
+      );
+      final tp = OTel.addTracerProvider(
+        'custom-resource-tp',
+        resource: customResource,
+      );
+      expect(tp.resource, equals(customResource));
+    });
+
+    test('addTracerProvider with custom sampler', () {
+      final tp = OTel.addTracerProvider(
+        'sampled-tp',
+        sampler: const AlwaysOffSampler(),
+      );
+      expect(tp, isA<TracerProvider>());
+      expect(tp.sampler, isA<AlwaysOffSampler>());
+    });
+
+    test('addMeterProvider creates a named MeterProvider', () {
+      final mp = OTel.addMeterProvider('custom-metrics');
+      expect(mp, isA<MeterProvider>());
+      expect(mp.resource, isNotNull);
+    });
+
+    test('addMeterProvider uses default resource when none specified', () {
+      final mp = OTel.addMeterProvider('default-resource-mp');
+      expect(mp.resource, equals(OTel.defaultResource));
+    });
+
+    test('addMeterProvider uses custom resource when specified', () {
+      final customResource = OTel.resource(
+        OTel.attributesFromMap({'meter.custom': 'val'}),
+      );
+      final mp = OTel.addMeterProvider(
+        'custom-resource-mp',
+        resource: customResource,
+      );
+      expect(mp.resource, equals(customResource));
+    });
+
+    test('addLoggerProvider creates a named LoggerProvider', () {
+      final lp = OTel.addLoggerProvider('custom-logs');
+      expect(lp, isA<LoggerProvider>());
+      expect(lp.resource, isNotNull);
+    });
+
+    test('addLoggerProvider uses default resource when none specified', () {
+      final lp = OTel.addLoggerProvider('default-resource-lp');
+      expect(lp.resource, equals(OTel.defaultResource));
+    });
+
+    test('addLoggerProvider uses custom resource when specified', () {
+      final customResource = OTel.resource(
+        OTel.attributesFromMap({'logger.custom': 'val'}),
+      );
+      final lp = OTel.addLoggerProvider(
+        'custom-resource-lp',
+        resource: customResource,
+      );
+      expect(lp.resource, equals(customResource));
+    });
+
+    test('can retrieve named TracerProvider after adding', () {
+      OTel.addTracerProvider('retrievable');
+      final tp = OTel.tracerProvider(name: 'retrievable');
+      expect(tp, isA<TracerProvider>());
+    });
+
+    test('can retrieve named MeterProvider after adding', () {
+      OTel.addMeterProvider('retrievable-meter');
+      final mp = OTel.meterProvider(name: 'retrievable-meter');
+      expect(mp, isA<MeterProvider>());
+    });
+
+    test('can retrieve named LoggerProvider after adding', () {
+      OTel.addLoggerProvider('retrievable-logger');
+      final lp = OTel.loggerProvider(name: 'retrievable-logger');
+      expect(lp, isA<LoggerProvider>());
+    });
+
+    test('tracerProviders returns list including default and named', () {
+      OTel.addTracerProvider('extra-tp');
+      final providers = OTel.tracerProviders();
+      expect(providers.length, greaterThanOrEqualTo(2));
+    });
+
+    test('meterProviders returns list including named provider', () {
+      OTel.addMeterProvider('extra-mp');
+      final providers = OTel.meterProviders();
+      expect(providers.length, greaterThanOrEqualTo(1));
+    });
+  });
+
+  // =========================================================================
+  // OTel - tenantId handling in initialize
+  // =========================================================================
+  group('OTel tenantId handling', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+    });
+
+    test('initialize without tenantId has no tenant_id attribute', () async {
+      await OTel.initialize(
+        serviceName: 'no-tenant-service',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+
+      expect(OTel.defaultResource, isNotNull);
+      final attrs = OTel.defaultResource!.attributes.toList();
+      final hasTenantId = attrs.any((a) => a.key == 'tenant_id');
+      expect(hasTenantId, isFalse);
+    });
+
+    test('initialize with tenantId preserves it through platform detection',
+        () async {
+      await OTel.initialize(
+        serviceName: 'tenant-with-platform',
+        tenantId: 'my-tenant',
+        detectPlatformResources: true,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+
+      expect(OTel.defaultResource, isNotNull);
+      final attrs = OTel.defaultResource!.attributes.toList();
+      final tenantAttr = attrs.firstWhere(
+        (a) => a.key == 'tenant_id',
+        orElse: () => throw StateError('tenant_id not found'),
+      );
+      expect(tenantAttr.value, equals('my-tenant'));
+    });
+
+    test('tenantId coexists with custom resource attributes', () async {
+      final customAttrs = OTel.attributesFromMap({
+        'custom.key': 'custom-value',
+        'deployment.environment': 'staging',
+      });
+
+      await OTel.initialize(
+        serviceName: 'tenant-with-custom',
+        tenantId: 'multi-tenant',
+        resourceAttributes: customAttrs,
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+
+      expect(OTel.defaultResource, isNotNull);
+      final attrs = OTel.defaultResource!.attributes.toList();
+
+      final tenantAttr = attrs.firstWhere(
+        (a) => a.key == 'tenant_id',
+        orElse: () => throw StateError('tenant_id not found'),
+      );
+      expect(tenantAttr.value, equals('multi-tenant'));
+
+      final customAttr = attrs.firstWhere(
+        (a) => a.key == 'custom.key',
+        orElse: () => throw StateError('custom.key not found'),
+      );
+      expect(customAttr.value, equals('custom-value'));
+    });
+
+    test('initialize with dartasticApiKey stores it', () async {
+      await OTel.initialize(
+        serviceName: 'api-key-test',
+        dartasticApiKey: 'test-api-key-123',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+
+      expect(OTel.dartasticApiKey, equals('test-api-key-123'));
+    });
+  });
+
+  // =========================================================================
+  // OTel - enableLogs and enableMetrics configuration
+  // =========================================================================
+  group('OTel initialization with logs/metrics options', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+    });
+
+    test('initialize with enableLogs=true configures LoggerProvider', () async {
+      await OTel.initialize(
+        serviceName: 'logs-enabled',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+      );
+
+      final lp = OTel.loggerProvider();
+      expect(lp, isA<LoggerProvider>());
+    });
+
+    test('initialize with enableMetrics=true configures MeterProvider',
+        () async {
+      await OTel.initialize(
+        serviceName: 'metrics-enabled',
+        detectPlatformResources: false,
+        enableMetrics: true,
+        enableLogs: false,
+      );
+
+      final mp = OTel.meterProvider();
+      expect(mp, isA<MeterProvider>());
+    });
+
+    test('initialize with both logs and metrics', () async {
+      await OTel.initialize(
+        serviceName: 'both-enabled',
+        detectPlatformResources: false,
+        enableMetrics: true,
+        enableLogs: true,
+      );
+
+      expect(OTel.loggerProvider(), isA<LoggerProvider>());
+      expect(OTel.meterProvider(), isA<MeterProvider>());
+    });
+
+    test('logger() returns a Logger from default LoggerProvider', () async {
+      await OTel.initialize(
+        serviceName: 'logger-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+      );
+
+      final logger = OTel.logger('test-logger');
+      expect(logger, isA<Logger>());
+    });
+
+    test('logger() with default name uses defaultTracerName', () async {
+      await OTel.initialize(
+        serviceName: 'default-logger-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: true,
+      );
+
+      final logger = OTel.logger();
+      expect(logger, isA<Logger>());
+    });
+  });
+
+  // =========================================================================
+  // OTel - validation in initialize
+  // =========================================================================
+  group('OTel.initialize validation', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+    });
+
+    test('throws ArgumentError for empty endpoint', () async {
+      expect(
+        () => OTel.initialize(
+          serviceName: 'test',
+          endpoint: '',
+          detectPlatformResources: false,
+          enableMetrics: false,
+          enableLogs: false,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for empty serviceName', () async {
+      expect(
+        () => OTel.initialize(
+          serviceName: '',
+          detectPlatformResources: false,
+          enableMetrics: false,
+          enableLogs: false,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for empty serviceVersion', () async {
+      expect(
+        () => OTel.initialize(
+          serviceName: 'test',
+          serviceVersion: '',
+          detectPlatformResources: false,
+          enableMetrics: false,
+          enableLogs: false,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/unit/environment/helpers/check_blrp_config.dart
+++ b/test/unit/environment/helpers/check_blrp_config.dart
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Helper script: prints JSON of OTelEnv.getBlrpConfig() result.
+// Run via subprocess with OTEL_BLRP_* env vars set.
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() {
+  OTelLog.logFunction = null;
+  final config = OTelEnv.getBlrpConfig();
+
+  // Convert Duration to milliseconds for JSON serialization
+  final jsonConfig = <String, dynamic>{};
+  config.forEach((key, value) {
+    if (value is Duration) {
+      jsonConfig['${key}_ms'] = value.inMilliseconds;
+    } else {
+      jsonConfig[key] = value;
+    }
+  });
+
+  print(jsonEncode(jsonConfig));
+}

--- a/test/unit/environment/helpers/check_envvar_resource_detector.dart
+++ b/test/unit/environment/helpers/check_envvar_resource_detector.dart
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Helper script: initializes OTel and runs EnvVarResourceDetector, prints
+// the detected attributes as JSON.
+// Run via subprocess with OTEL_RESOURCE_ATTRIBUTES env var set.
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() async {
+  // Suppress all logging so only our JSON goes to stdout.
+  // Use a no-op function (not null, not print) so initializeLogging() won't
+  // override it from the OTEL_LOG_LEVEL env var.
+  OTelLog.logFunction = (_) {};
+
+  await OTel.initialize(
+    serviceName: 'test',
+    detectPlatformResources: false,
+    enableMetrics: false,
+    enableLogs: false,
+  );
+
+  final detector = EnvVarResourceDetector();
+  final resource = await detector.detect();
+
+  final attrs = <String, dynamic>{};
+  resource.attributes.toList().forEach((attr) {
+    attrs[attr.key] = attr.value;
+  });
+
+  print(jsonEncode(attrs));
+
+  await OTel.shutdown();
+  await OTel.reset();
+}

--- a/test/unit/environment/helpers/check_log_bools.dart
+++ b/test/unit/environment/helpers/check_log_bools.dart
@@ -19,9 +19,11 @@ void main() {
 
   OTelEnv.initializeLogging();
 
-  print(jsonEncode({
-    'metricLogFunction': OTelLog.metricLogFunction != null,
-    'spanLogFunction': OTelLog.spanLogFunction != null,
-    'exportLogFunction': OTelLog.exportLogFunction != null,
-  }));
+  print(
+    jsonEncode({
+      'metricLogFunction': OTelLog.metricLogFunction != null,
+      'spanLogFunction': OTelLog.spanLogFunction != null,
+      'exportLogFunction': OTelLog.exportLogFunction != null,
+    }),
+  );
 }

--- a/test/unit/environment/helpers/check_logrecord_limits.dart
+++ b/test/unit/environment/helpers/check_logrecord_limits.dart
@@ -1,0 +1,15 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Helper script: prints JSON of OTelEnv.getLogRecordLimits() result.
+// Run via subprocess with OTEL_LOGRECORD_* env vars set.
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() {
+  OTelLog.logFunction = null;
+  final config = OTelEnv.getLogRecordLimits();
+  print(jsonEncode(config));
+}

--- a/test/unit/environment/helpers/check_parse_headers.dart
+++ b/test/unit/environment/helpers/check_parse_headers.dart
@@ -1,0 +1,17 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Helper script: prints JSON of parsed headers from OTEL_EXPORTER_OTLP_HEADERS.
+// Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS env var set.
+// This exercises the _parseHeaders() method via getOtlpConfig().
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() {
+  OTelLog.logFunction = null;
+  final config = OTelEnv.getOtlpConfig(signal: 'traces');
+  final headers = config['headers'] as Map<String, String>?;
+  print(jsonEncode(headers ?? {}));
+}

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -24,9 +24,7 @@ Future<String> runWithEnv(
     Platform.executable,
     ['run', scriptPath],
     environment: env,
-    workingDirectory: Directory.current.path.endsWith('dartastic_opentelemetry')
-        ? Directory.current.path
-        : '${Directory.current.path}/dartastic_opentelemetry',
+    workingDirectory: Directory.current.path,
   );
   if (result.exitCode != 0) {
     throw Exception(
@@ -103,8 +101,9 @@ void main() {
         // remain null since hasCustomLogFunction is false but logFunction is
         // null (not a custom function), so it gets set to print.
         // If not set, logFunction stays null.
-        final envLogLevel =
-            EnvironmentService.instance.getValue('OTEL_LOG_LEVEL');
+        final envLogLevel = EnvironmentService.instance.getValue(
+          'OTEL_LOG_LEVEL',
+        );
         if (envLogLevel == null) {
           expect(OTelLog.logFunction, isNull);
         } else {
@@ -114,21 +113,23 @@ void main() {
       });
 
       test(
-          'sets logFunction to print when OTEL_LOG_LEVEL is set and no custom function',
-          () {
-        // Start with the default print function
-        OTelLog.logFunction = print;
+        'sets logFunction to print when OTEL_LOG_LEVEL is set and no custom function',
+        () {
+          // Start with the default print function
+          OTelLog.logFunction = print;
 
-        OTelEnv.initializeLogging();
+          OTelEnv.initializeLogging();
 
-        // If OTEL_LOG_LEVEL is set, logFunction stays print (not custom)
-        // If not set, logFunction stays as-is
-        final envLogLevel =
-            EnvironmentService.instance.getValue('OTEL_LOG_LEVEL');
-        if (envLogLevel != null) {
-          expect(OTelLog.logFunction, equals(print));
-        }
-      });
+          // If OTEL_LOG_LEVEL is set, logFunction stays print (not custom)
+          // If not set, logFunction stays as-is
+          final envLogLevel = EnvironmentService.instance.getValue(
+            'OTEL_LOG_LEVEL',
+          );
+          if (envLogLevel != null) {
+            expect(OTelLog.logFunction, equals(print));
+          }
+        },
+      );
 
       test('does not overwrite existing metric log function', () {
         final metricLogs = <String>[];
@@ -162,8 +163,9 @@ void main() {
 
       test('handles log level set during coverage run', () {
         // During coverage run, OTEL_LOG_LEVEL=trace is set
-        final envLogLevel =
-            EnvironmentService.instance.getValue('OTEL_LOG_LEVEL');
+        final envLogLevel = EnvironmentService.instance.getValue(
+          'OTEL_LOG_LEVEL',
+        );
 
         // Reset to known state
         OTelLog.logFunction = null;
@@ -212,11 +214,13 @@ void main() {
 
         OTelEnv.initializeLogging();
 
-        final logMetrics =
-            EnvironmentService.instance.getValue('OTEL_LOG_METRICS');
+        final logMetrics = EnvironmentService.instance.getValue(
+          'OTEL_LOG_METRICS',
+        );
         final logSpans = EnvironmentService.instance.getValue('OTEL_LOG_SPANS');
-        final logExport =
-            EnvironmentService.instance.getValue('OTEL_LOG_EXPORT');
+        final logExport = EnvironmentService.instance.getValue(
+          'OTEL_LOG_EXPORT',
+        );
 
         if (logMetrics?.toLowerCase() == 'true') {
           expect(OTelLog.metricLogFunction, equals(print));
@@ -275,22 +279,25 @@ void main() {
       });
 
       test(
-          'returns empty map when no OTEL_RESOURCE_ATTRIBUTES or OTEL_SERVICE_NAME set',
-          () {
-        final resourceAttrs =
-            EnvironmentService.instance.getValue('OTEL_RESOURCE_ATTRIBUTES');
-        final serviceName =
-            EnvironmentService.instance.getValue('OTEL_SERVICE_NAME');
+        'returns empty map when no OTEL_RESOURCE_ATTRIBUTES or OTEL_SERVICE_NAME set',
+        () {
+          final resourceAttrs = EnvironmentService.instance.getValue(
+            'OTEL_RESOURCE_ATTRIBUTES',
+          );
+          final serviceName = EnvironmentService.instance.getValue(
+            'OTEL_SERVICE_NAME',
+          );
 
-        final config = OTelEnv.getServiceConfig();
+          final config = OTelEnv.getServiceConfig();
 
-        if (resourceAttrs == null && serviceName == null) {
-          expect(config, isEmpty);
-        } else {
-          // If env vars are set, config should have entries
-          expect(config, isA<Map<String, dynamic>>());
-        }
-      });
+          if (resourceAttrs == null && serviceName == null) {
+            expect(config, isEmpty);
+          } else {
+            // If env vars are set, config should have entries
+            expect(config, isA<Map<String, dynamic>>());
+          }
+        },
+      );
     });
 
     // =========================================================================
@@ -303,8 +310,9 @@ void main() {
       });
 
       test('returns empty map when OTEL_RESOURCE_ATTRIBUTES not set', () {
-        final resourceStr =
-            EnvironmentService.instance.getValue('OTEL_RESOURCE_ATTRIBUTES');
+        final resourceStr = EnvironmentService.instance.getValue(
+          'OTEL_RESOURCE_ATTRIBUTES',
+        );
 
         final attrs = OTelEnv.getResourceAttributes();
 
@@ -321,8 +329,9 @@ void main() {
     // =========================================================================
     group('getExporter', () {
       test('returns null for traces when OTEL_TRACES_EXPORTER not set', () {
-        final envValue =
-            EnvironmentService.instance.getValue('OTEL_TRACES_EXPORTER');
+        final envValue = EnvironmentService.instance.getValue(
+          'OTEL_TRACES_EXPORTER',
+        );
         final result = OTelEnv.getExporter(signal: 'traces');
         if (envValue == null) {
           expect(result, isNull);
@@ -332,8 +341,9 @@ void main() {
       });
 
       test('returns null for metrics when OTEL_METRICS_EXPORTER not set', () {
-        final envValue =
-            EnvironmentService.instance.getValue('OTEL_METRICS_EXPORTER');
+        final envValue = EnvironmentService.instance.getValue(
+          'OTEL_METRICS_EXPORTER',
+        );
         final result = OTelEnv.getExporter(signal: 'metrics');
         if (envValue == null) {
           expect(result, isNull);
@@ -343,8 +353,9 @@ void main() {
       });
 
       test('returns null for logs when OTEL_LOGS_EXPORTER not set', () {
-        final envValue =
-            EnvironmentService.instance.getValue('OTEL_LOGS_EXPORTER');
+        final envValue = EnvironmentService.instance.getValue(
+          'OTEL_LOGS_EXPORTER',
+        );
         final result = OTelEnv.getExporter(signal: 'logs');
         if (envValue == null) {
           expect(result, isNull);
@@ -379,7 +390,7 @@ void main() {
         'info',
         'warn',
         'error',
-        'fatal'
+        'fatal',
       ]) {
         test('sets log level to $level from OTEL_LOG_LEVEL', () async {
           final output = await runWithEnv(
@@ -566,20 +577,22 @@ void main() {
         expect(headers['tenant'], equals('acme'));
       });
 
-      test('parses headers with base64 values containing equals signs',
-          () async {
-        final output = await runWithEnv(
-          'test/unit/environment/helpers/check_otlp_config.dart',
-          {
-            'OTEL_EXPORTER_OTLP_HEADERS':
-                'authorization=Bearer dG9rZW4=,x-custom=val',
-          },
-        );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-        final headers = result['headers'] as Map<String, dynamic>;
-        expect(headers['authorization'], equals('Bearer dG9rZW4='));
-        expect(headers['x-custom'], equals('val'));
-      });
+      test(
+        'parses headers with base64 values containing equals signs',
+        () async {
+          final output = await runWithEnv(
+            'test/unit/environment/helpers/check_otlp_config.dart',
+            {
+              'OTEL_EXPORTER_OTLP_HEADERS':
+                  'authorization=Bearer dG9rZW4=,x-custom=val',
+            },
+          );
+          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          final headers = result['headers'] as Map<String, dynamic>;
+          expect(headers['authorization'], equals('Bearer dG9rZW4='));
+          expect(headers['x-custom'], equals('val'));
+        },
+      );
 
       test('reads signal-specific headers for metrics', () async {
         final output = await runWithEnv(
@@ -812,18 +825,20 @@ void main() {
         expect(result['serviceVersion'], equals('1.2.3'));
       });
 
-      test('OTEL_SERVICE_NAME overrides service.name from resource attributes',
-          () async {
-        final output = await runWithEnv(
-          'test/unit/environment/helpers/check_service_config.dart',
-          {
-            'OTEL_RESOURCE_ATTRIBUTES': 'service.name=from-attrs',
-            'OTEL_SERVICE_NAME': 'from-env-var',
-          },
-        );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-        expect(result['serviceName'], equals('from-env-var'));
-      });
+      test(
+        'OTEL_SERVICE_NAME overrides service.name from resource attributes',
+        () async {
+          final output = await runWithEnv(
+            'test/unit/environment/helpers/check_service_config.dart',
+            {
+              'OTEL_RESOURCE_ATTRIBUTES': 'service.name=from-attrs',
+              'OTEL_SERVICE_NAME': 'from-env-var',
+            },
+          );
+          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          expect(result['serviceName'], equals('from-env-var'));
+        },
+      );
 
       test('OTEL_SERVICE_NAME alone without resource attributes', () async {
         final output = await runWithEnv(
@@ -904,9 +919,7 @@ void main() {
       test('parses mixed types', () async {
         final output = await runWithEnv(
           'test/unit/environment/helpers/check_resource_attrs.dart',
-          {
-            'OTEL_RESOURCE_ATTRIBUTES': 'name=test,count=5,ratio=1.5,flag=true',
-          },
+          {'OTEL_RESOURCE_ATTRIBUTES': 'name=test,count=5,ratio=1.5,flag=true'},
         );
         final result = jsonDecode(output.trim()) as Map<String, dynamic>;
         expect(result['name'], equals('test'));
@@ -1012,15 +1025,17 @@ void main() {
         });
       }
 
-      test('OTEL_EXPORTER_OTLP_INSECURE with unrecognized value is absent',
-          () async {
-        final output = await runWithEnv(
-          'test/unit/environment/helpers/check_otlp_config.dart',
-          {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
-        );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-        expect(result.containsKey('insecure'), isFalse);
-      });
+      test(
+        'OTEL_EXPORTER_OTLP_INSECURE with unrecognized value is absent',
+        () async {
+          final output = await runWithEnv(
+            'test/unit/environment/helpers/check_otlp_config.dart',
+            {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
+          );
+          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          expect(result.containsKey('insecure'), isFalse);
+        },
+      );
     });
   });
 }

--- a/test/unit/export/console_exporter_test.dart
+++ b/test/unit/export/console_exporter_test.dart
@@ -85,7 +85,8 @@ class TestableConsoleExporter extends SpanExporter {
       buffer.writeln('End Time: ${span.endTime!.toIso8601String()}');
       final duration = span.endTime!.difference(span.startTime);
       buffer.writeln(
-          'Duration: ${duration.inMicroseconds}μs (${duration.inMilliseconds}ms)');
+        'Duration: ${duration.inMicroseconds}μs (${duration.inMilliseconds}ms)',
+      );
     } else {
       buffer.writeln('End Time: (not ended)');
     }
@@ -206,8 +207,10 @@ void main() {
 
       // Verify onNameUpdate was called
       expect(testProcessor.nameUpdatedSpans, hasLength(1));
-      expect(testProcessor.nameUpdatedSpans.first.name,
-          equals('updated-test-span'));
+      expect(
+        testProcessor.nameUpdatedSpans.first.name,
+        equals('updated-test-span'),
+      );
 
       // End span
       span.end();
@@ -319,32 +322,34 @@ void main() {
       expect(output, contains('ms)'));
     });
 
-    test('ConsoleExporter handles spans with no attributes or events',
-        () async {
-      await OTel.initialize(
-        spanProcessor: SimpleSpanProcessor(testableExporter),
-        sampler: const AlwaysOnSampler(),
-      );
+    test(
+      'ConsoleExporter handles spans with no attributes or events',
+      () async {
+        await OTel.initialize(
+          spanProcessor: SimpleSpanProcessor(testableExporter),
+          sampler: const AlwaysOnSampler(),
+        );
 
-      final tracer = OTel.tracer();
+        final tracer = OTel.tracer();
 
-      // Create minimal span
-      final span = tracer.startSpan('minimal-span');
-      span.end();
+        // Create minimal span
+        final span = tracer.startSpan('minimal-span');
+        span.end();
 
-      await testableExporter.forceFlush();
+        await testableExporter.forceFlush();
 
-      final output = testableExporter.allOutput;
+        final output = testableExporter.allOutput;
 
-      // Should have basic span info
-      expect(output, contains('Name: minimal-span'));
-      expect(output, contains('=== OpenTelemetry Span ==='));
-      expect(output, contains('=========================='));
+        // Should have basic span info
+        expect(output, contains('Name: minimal-span'));
+        expect(output, contains('=== OpenTelemetry Span ==='));
+        expect(output, contains('=========================='));
 
-      // Should not have attributes or events sections if empty
-      expect(output, isNot(contains('Attributes:')));
-      expect(output, isNot(contains('Events:')));
-    });
+        // Should not have attributes or events sections if empty
+        expect(output, isNot(contains('Attributes:')));
+        expect(output, isNot(contains('Events:')));
+      },
+    );
 
     test('ConsoleExporter handles nested spans correctly', () async {
       await OTel.initialize(
@@ -386,8 +391,10 @@ void main() {
         (line) => line.contains('Parent Span ID:'),
         orElse: () => '',
       );
-      expect(parentIdLine,
-          isNot(contains('(root span)'))); // Should have actual parent ID
+      expect(
+        parentIdLine,
+        isNot(contains('(root span)')),
+      ); // Should have actual parent ID
     });
 
     test('ConsoleExporter handles error spans correctly', () async {
@@ -448,7 +455,9 @@ void main() {
 
       // Should have 3 span headers
       expect(
-          '=== OpenTelemetry Span ==='.allMatches(allOutput).length, equals(3));
+        '=== OpenTelemetry Span ==='.allMatches(allOutput).length,
+        equals(3),
+      );
     });
 
     test('Debug logging shows processor notifications', () async {
@@ -479,30 +488,33 @@ void main() {
       // Capture regular print statements (ConsoleExporter uses print())
       final printOutputCapture = <String>[];
 
-      await runZoned(() async {
-        await OTel.initialize(
-          spanProcessor: SimpleSpanProcessor(realConsoleExporter),
-          sampler: const AlwaysOnSampler(),
-        );
+      await runZoned(
+        () async {
+          await OTel.initialize(
+            spanProcessor: SimpleSpanProcessor(realConsoleExporter),
+            sampler: const AlwaysOnSampler(),
+          );
 
-        final tracer = OTel.tracer();
-        final span = tracer.startSpan(
-          'real-console-test',
-          attributes: OTel.attributesFromMap({
-            'test.attribute': 'test-value',
-          }),
-        );
+          final tracer = OTel.tracer();
+          final span = tracer.startSpan(
+            'real-console-test',
+            attributes: OTel.attributesFromMap({
+              'test.attribute': 'test-value',
+            }),
+          );
 
-        span.addEventNow('test-event');
-        span.end();
+          span.addEventNow('test-event');
+          span.end();
 
-        await realConsoleExporter.forceFlush();
-      }, zoneSpecification: ZoneSpecification(
-        print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-          printOutputCapture.add(line);
-          // Don't actually print during tests
+          await realConsoleExporter.forceFlush();
         },
-      ));
+        zoneSpecification: ZoneSpecification(
+          print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
+            printOutputCapture.add(line);
+            // Don't actually print during tests
+          },
+        ),
+      );
 
       final output = printOutputCapture.join('\n');
 

--- a/test/unit/export/otlp_config_test.dart
+++ b/test/unit/export/otlp_config_test.dart
@@ -70,10 +70,8 @@ void main() {
 
     test('validates retry parameters', () {
       expect(
-        () => OtlpGrpcExporterConfig(
-          endpoint: 'localhost:4317',
-          maxRetries: -1,
-        ),
+        () =>
+            OtlpGrpcExporterConfig(endpoint: 'localhost:4317', maxRetries: -1),
         throwsA(isA<ArgumentError>()),
       );
 
@@ -131,20 +129,15 @@ void main() {
         headers: validHeaders,
       );
       expect(
-          config.headers,
-          equals({
-            'authorization': 'Bearer token',
-            'custom-header': 'value',
-          }));
+        config.headers,
+        equals({'authorization': 'Bearer token', 'custom-header': 'value'}),
+      );
     });
 
     test('supports header case insensitivity', () {
       final config = OtlpGrpcExporterConfig(
         endpoint: 'localhost:4317',
-        headers: {
-          'Authorization': 'Bearer token',
-          'custom-HEADER': 'value',
-        },
+        headers: {'Authorization': 'Bearer token', 'custom-HEADER': 'value'},
       );
 
       expect(config.headers['authorization'], equals('Bearer token'));

--- a/test/unit/export/otlp_http_metric_exporter_config_test.dart
+++ b/test/unit/export/otlp_http_metric_exporter_config_test.dart
@@ -50,16 +50,12 @@ void main() {
     });
 
     test('http://localhost without port gets :4318 appended', () {
-      final config = OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost',
-      );
+      final config = OtlpHttpMetricExporterConfig(endpoint: 'http://localhost');
       expect(config.endpoint, equals('http://localhost:4318'));
     });
 
     test('http://127.0.0.1 without port gets :4318 appended', () {
-      final config = OtlpHttpMetricExporterConfig(
-        endpoint: 'http://127.0.0.1',
-      );
+      final config = OtlpHttpMetricExporterConfig(endpoint: 'http://127.0.0.1');
       expect(config.endpoint, equals('http://127.0.0.1:4318'));
     });
 
@@ -87,18 +83,14 @@ void main() {
 
     test('empty header key throws ArgumentError', () {
       expect(
-        () => OtlpHttpMetricExporterConfig(
-          headers: {'': 'some-value'},
-        ),
+        () => OtlpHttpMetricExporterConfig(headers: {'': 'some-value'}),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('empty header value throws ArgumentError', () {
       expect(
-        () => OtlpHttpMetricExporterConfig(
-          headers: {'valid-key': ''},
-        ),
+        () => OtlpHttpMetricExporterConfig(headers: {'valid-key': ''}),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -114,9 +106,8 @@ void main() {
 
     test('timeout above 10 minutes throws ArgumentError', () {
       expect(
-        () => OtlpHttpMetricExporterConfig(
-          timeout: const Duration(minutes: 11),
-        ),
+        () =>
+            OtlpHttpMetricExporterConfig(timeout: const Duration(minutes: 11)),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -151,9 +142,8 @@ void main() {
 
     test('maxDelay above 5 minutes throws ArgumentError', () {
       expect(
-        () => OtlpHttpMetricExporterConfig(
-          maxDelay: const Duration(minutes: 6),
-        ),
+        () =>
+            OtlpHttpMetricExporterConfig(maxDelay: const Duration(minutes: 6)),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -172,8 +162,9 @@ void main() {
       final compressedConfig = OtlpHttpMetricExporterConfig(compression: true);
       expect(compressedConfig.compression, isTrue);
 
-      final uncompressedConfig =
-          OtlpHttpMetricExporterConfig(compression: false);
+      final uncompressedConfig = OtlpHttpMetricExporterConfig(
+        compression: false,
+      );
       expect(uncompressedConfig.compression, isFalse);
     });
 

--- a/test/unit/export/otlp_http_span_exporter_config_test.dart
+++ b/test/unit/export/otlp_http_span_exporter_config_test.dart
@@ -50,23 +50,17 @@ void main() {
     });
 
     test('http://localhost without port gets :4318 appended', () {
-      final config = OtlpHttpExporterConfig(
-        endpoint: 'http://localhost',
-      );
+      final config = OtlpHttpExporterConfig(endpoint: 'http://localhost');
       expect(config.endpoint, equals('http://localhost:4318'));
     });
 
     test('http://127.0.0.1 without port gets :4318 appended', () {
-      final config = OtlpHttpExporterConfig(
-        endpoint: 'http://127.0.0.1',
-      );
+      final config = OtlpHttpExporterConfig(endpoint: 'http://127.0.0.1');
       expect(config.endpoint, equals('http://127.0.0.1:4318'));
     });
 
     test('https://localhost without port gets :4318 appended', () {
-      final config = OtlpHttpExporterConfig(
-        endpoint: 'https://localhost',
-      );
+      final config = OtlpHttpExporterConfig(endpoint: 'https://localhost');
       expect(config.endpoint, equals('https://localhost:4318'));
     });
 
@@ -87,36 +81,29 @@ void main() {
 
     test('empty header key throws ArgumentError', () {
       expect(
-        () => OtlpHttpExporterConfig(
-          headers: {'': 'some-value'},
-        ),
+        () => OtlpHttpExporterConfig(headers: {'': 'some-value'}),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('empty header value throws ArgumentError', () {
       expect(
-        () => OtlpHttpExporterConfig(
-          headers: {'valid-key': ''},
-        ),
+        () => OtlpHttpExporterConfig(headers: {'valid-key': ''}),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('timeout below 1ms throws ArgumentError', () {
       expect(
-        () => OtlpHttpExporterConfig(
-          timeout: const Duration(microseconds: 500),
-        ),
+        () =>
+            OtlpHttpExporterConfig(timeout: const Duration(microseconds: 500)),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('timeout above 10 minutes throws ArgumentError', () {
       expect(
-        () => OtlpHttpExporterConfig(
-          timeout: const Duration(minutes: 11),
-        ),
+        () => OtlpHttpExporterConfig(timeout: const Duration(minutes: 11)),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -151,9 +138,7 @@ void main() {
 
     test('maxDelay above 5 minutes throws ArgumentError', () {
       expect(
-        () => OtlpHttpExporterConfig(
-          maxDelay: const Duration(minutes: 6),
-        ),
+        () => OtlpHttpExporterConfig(maxDelay: const Duration(minutes: 6)),
         throwsA(isA<ArgumentError>()),
       );
     });

--- a/test/unit/export/span_transformer_test.dart
+++ b/test/unit/export/span_transformer_test.dart
@@ -81,14 +81,13 @@ void main() {
   group('OtlpSpanTransformer', () {
     test('transforms basic span correctly', () {
       final timestamp = DateTime.fromMillisecondsSinceEpoch(
-          1640995200000); // 2022-01-01 00:00:00 UTC
+        1640995200000,
+      ); // 2022-01-01 00:00:00 UTC
       final span = createTestSpan(
         name: 'test-span',
         startTime: timestamp,
         endTime: timestamp.add(const Duration(seconds: 1)),
-        attributes: {
-          'key': 'value',
-        },
+        attributes: {'key': 'value'},
         traceId: '00112233445566778899aabbccddeeff',
         spanId: '0011223344556677',
       );
@@ -105,8 +104,9 @@ void main() {
       expect(
         protoSpan.endTimeUnixNano.toInt(),
         equals(
-            timestamp.add(const Duration(seconds: 1)).microsecondsSinceEpoch *
-                1000),
+          timestamp.add(const Duration(seconds: 1)).microsecondsSinceEpoch *
+              1000,
+        ),
       );
 
       final attribute = protoSpan.attributes.first;
@@ -138,7 +138,8 @@ void main() {
 
     test('transforms span events correctly', () {
       final startTime = DateTime.fromMillisecondsSinceEpoch(
-          1640995200000); // 2022-01-01 00:00:00 UTC
+        1640995200000,
+      ); // 2022-01-01 00:00:00 UTC
       final eventTime = startTime.add(const Duration(milliseconds: 100));
 
       final span = createTestSpan(
@@ -162,8 +163,10 @@ void main() {
       expect(events, hasLength(1));
       final event = events.first;
       expect(event.name, equals('test-event'));
-      expect(event.timeUnixNano.toInt(),
-          equals(eventTime.microsecondsSinceEpoch * 1000));
+      expect(
+        event.timeUnixNano.toInt(),
+        equals(eventTime.microsecondsSinceEpoch * 1000),
+      );
       expect(event.attributes.first.key, equals('event_key'));
       expect(event.attributes.first.value.stringValue, equals('event_value'));
     });
@@ -172,14 +175,17 @@ void main() {
       final linkedContext = OTel.spanContext(
         traceId: OTel.traceIdFrom('ea2a896d85d8fd9373e092ece8cff414'),
         spanId: OTel.spanIdFrom(
-            '85d8fd937373e092'), // Must be 16 hex characters (8 bytes)
+          '85d8fd937373e092',
+        ), // Must be 16 hex characters (8 bytes)
       );
 
       final span = createTestSpan(
         name: 'link-test',
         links: [
-          OTel.spanLink(linkedContext,
-              attributes: OTel.attributesFromMap({'link.key': 'link.value'})),
+          OTel.spanLink(
+            linkedContext,
+            attributes: OTel.attributesFromMap({'link.key': 'link.value'}),
+          ),
         ],
         traceId: '00112233445566778899aabbccddeeff',
         spanId: '0011223344556677',
@@ -192,7 +198,9 @@ void main() {
       expect(links, hasLength(1));
       final link = links.first;
       expect(
-          bytesToHex(link.traceId), equals('ea2a896d85d8fd9373e092ece8cff414'));
+        bytesToHex(link.traceId),
+        equals('ea2a896d85d8fd9373e092ece8cff414'),
+      );
       expect(bytesToHex(link.spanId), equals('85d8fd937373e092'));
       expect(link.attributes, hasLength(1));
       expect(link.attributes.first.key, equals('link.key'));

--- a/test/unit/exporters_coverage_test.dart
+++ b/test/unit/exporters_coverage_test.dart
@@ -122,13 +122,17 @@ void main() {
       await metricExporter.shutdown();
 
       expect(
-        () => metricExporter.export(MetricData(metrics: [
-          Metric.sum(
-            name: 'test',
-            points: [],
-            temporality: AggregationTemporality.cumulative,
+        () => metricExporter.export(
+          MetricData(
+            metrics: [
+              Metric.sum(
+                name: 'test',
+                points: [],
+                temporality: AggregationTemporality.cumulative,
+              ),
+            ],
           ),
-        ])),
+        ),
         throwsStateError,
       );
     });
@@ -136,9 +140,7 @@ void main() {
     test('export with empty metrics returns true', () async {
       await initForMetrics();
       final metricExporter = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: 'http://localhost:4318',
-        ),
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:4318'),
       );
 
       // Empty metrics should return true and log debug
@@ -153,41 +155,45 @@ void main() {
       await metricExporter.shutdown();
     });
 
-    test('export to unreachable endpoint returns false (tryExport catches)',
-        () async {
-      await initForMetrics();
-      final metricExporter = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: 'http://127.0.0.1:1', // unreachable port
-          maxRetries: 0,
-          timeout: const Duration(milliseconds: 500),
-        ),
-      );
-
-      final metric = Metric.sum(
-        name: 'test.counter',
-        description: 'test metric',
-        unit: 'count',
-        points: [
-          MetricPoint<int>(
-            value: 42,
-            startTime: DateTime.now().subtract(const Duration(seconds: 1)),
-            endTime: DateTime.now(),
-            attributes: OTel.attributesFromMap({'env': 'test'}),
+    test(
+      'export to unreachable endpoint returns false (tryExport catches)',
+      () async {
+        await initForMetrics();
+        final metricExporter = OtlpHttpMetricExporter(
+          OtlpHttpMetricExporterConfig(
+            endpoint: 'http://127.0.0.1:1', // unreachable port
+            maxRetries: 0,
+            timeout: const Duration(milliseconds: 500),
           ),
-        ],
-        temporality: AggregationTemporality.cumulative,
-        isMonotonic: true,
-      );
+        );
 
-      // Connection refused: _tryExport's generic catch returns false,
-      // or ClientException is rethrown and _export handles it.
-      // Either way, result is false.
-      final result = await metricExporter.export(MetricData(metrics: [metric]));
-      expect(result, isFalse);
+        final metric = Metric.sum(
+          name: 'test.counter',
+          description: 'test metric',
+          unit: 'count',
+          points: [
+            MetricPoint<int>(
+              value: 42,
+              startTime: DateTime.now().subtract(const Duration(seconds: 1)),
+              endTime: DateTime.now(),
+              attributes: OTel.attributesFromMap({'env': 'test'}),
+            ),
+          ],
+          temporality: AggregationTemporality.cumulative,
+          isMonotonic: true,
+        );
 
-      await metricExporter.shutdown();
-    });
+        // Connection refused: _tryExport's generic catch returns false,
+        // or ClientException is rethrown and _export handles it.
+        // Either way, result is false.
+        final result = await metricExporter.export(
+          MetricData(metrics: [metric]),
+        );
+        expect(result, isFalse);
+
+        await metricExporter.shutdown();
+      },
+    );
 
     test('createHttpClient with certificate error falls back to default',
         () async {
@@ -196,7 +202,7 @@ void main() {
       // The 'invalid-cert-path' triggers an ArgumentError from CertificateUtils
       // which propagates to the constructor. We must use test:// to avoid that.
       // Instead, test createSecurityContext returning null when all args are null
-      // For the error path (lines 71-76), we need a real file that fails:
+      // For the certificate error path, we need a real file that fails:
       final metricExporter = OtlpHttpMetricExporter(
         OtlpHttpMetricExporterConfig(
           endpoint: 'http://localhost:4318',
@@ -215,27 +221,20 @@ void main() {
     test('forceFlush on already-shutdown exporter returns true', () async {
       await initForMetrics();
       final metricExporter = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: 'http://localhost:4318',
-        ),
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:4318'),
       );
 
       await metricExporter.shutdown();
       // Line: _isShutdown path in forceFlush
       final result = await metricExporter.forceFlush();
       expect(result, isTrue);
-      expect(
-        logOutput.any((m) => m.contains('already shut down')),
-        isTrue,
-      );
+      expect(logOutput.any((m) => m.contains('already shut down')), isTrue);
     });
 
     test('forceFlush with no pending exports returns true', () async {
       await initForMetrics();
       final metricExporter = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: 'http://localhost:4318',
-        ),
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:4318'),
       );
 
       final result = await metricExporter.forceFlush();
@@ -251,9 +250,7 @@ void main() {
     test('shutdown on already-shutdown exporter returns true', () async {
       await initForMetrics();
       final metricExporter = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: 'http://localhost:4318',
-        ),
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:4318'),
       );
 
       // First shutdown
@@ -303,9 +300,7 @@ void main() {
       await initForMetrics();
       // Test with trailing slash
       final metricExporter1 = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: 'http://localhost:4318/',
-        ),
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:4318/'),
       );
 
       // Test with endpoint already having path
@@ -330,7 +325,7 @@ void main() {
   group('OTel.initialize exporter type paths', () {
     test('initialize with console exporter type (no spanProcessor)', () async {
       // We need to test the code path where spanProcessor == null
-      // and exporterType == 'console' (line 307-308).
+      // and exporterType == 'console'.
       // Since we can't easily set env vars for OTEL_TRACES_EXPORTER,
       // we test other code paths.
 
@@ -348,8 +343,8 @@ void main() {
     });
 
     test('initialize with enableMetrics true and no metricExporter', () async {
-      // Covers lines 387-394 (MetricsConfiguration.configureMeterProvider
-      // with default exporter)
+      // Exercises MetricsConfiguration.configureMeterProvider
+      // with default exporter
       await OTel.initialize(
         serviceName: 'metrics-default-test',
         serviceVersion: '1.0.0',
@@ -362,7 +357,7 @@ void main() {
     });
 
     test('initialize with custom metricExporter and metricReader', () async {
-      // Covers lines 396-404 (MetricsConfiguration with custom exporter/reader)
+      // Exercises MetricsConfiguration with custom exporter/reader
       final memExporter = MemoryMetricExporter();
       final memReader = MemoryMetricReader(exporter: memExporter);
 
@@ -398,9 +393,9 @@ void main() {
     });
 
     test('initialize logs environment variable usage with debug', () async {
-      // With trace logging enabled, lines 149-162 should be hit if env vars
-      // are null (they are in test environment, so the 'if' blocks don't enter,
-      // but the outer isDebug check is still evaluated, covering the guard).
+      // With trace logging enabled, the env var debug guards are evaluated.
+      // Env vars are null in the test environment, so the inner blocks don't
+      // enter, but the outer isDebug check is still evaluated.
       await OTel.initialize(
         serviceName: 'env-log-test',
         serviceVersion: '1.0.0',
@@ -418,7 +413,7 @@ void main() {
 
   group('OTel.shutdown error handling paths', () {
     test('shutdown with failing tracer provider flush logs error', () async {
-      // Lines 999-1000: error during tracer provider flush
+      // Exercises the error path during tracer provider flush
       final exporter = _ErrorShutdownExporter();
       final processor = SimpleSpanProcessor(exporter);
 
@@ -450,7 +445,7 @@ void main() {
     });
 
     test('shutdown with failing meter provider logs error', () async {
-      // Lines 1033-1034: error during meter provider shutdown
+      // Exercises the error path during meter provider shutdown
       await OTel.initialize(
         serviceName: 'meter-shutdown-test',
         serviceVersion: '1.0.0',
@@ -497,7 +492,7 @@ void main() {
 
       final attrs = resource.attributes.toList();
       final osType = attrs.where((a) => a.key == 'os.type').toList();
-      // Running on macOS, so os.type should be 'macos' (covers lines 75-76)
+      // Running on macOS, so os.type should be 'macos'
       if (Platform.isMacOS) {
         expect(osType, isNotEmpty);
         expect(osType.first.value.toString(), contains('macos'));
@@ -598,10 +593,7 @@ void main() {
       final span = tracer.startSpan('test-span');
       span.end();
 
-      expect(
-        () => spanExporter.export([span]),
-        throwsStateError,
-      );
+      expect(() => spanExporter.export([span]), throwsStateError);
     });
 
     test('export with empty spans returns immediately', () async {
@@ -618,34 +610,30 @@ void main() {
       // Empty spans should return immediately
       await spanExporter.export([]);
 
-      expect(
-        logOutput.any((m) => m.contains('No spans to export')),
-        isTrue,
-      );
+      expect(logOutput.any((m) => m.contains('No spans to export')), isTrue);
 
       await spanExporter.shutdown();
     });
 
-    test('forceFlush on already-shutdown exporter returns immediately',
-        () async {
-      await OTel.initialize(
-        serviceName: 'span-exporter-flush-test',
-        detectPlatformResources: false,
-        enableMetrics: false,
-      );
+    test(
+      'forceFlush on already-shutdown exporter returns immediately',
+      () async {
+        await OTel.initialize(
+          serviceName: 'span-exporter-flush-test',
+          detectPlatformResources: false,
+          enableMetrics: false,
+        );
 
-      final spanExporter = OtlpHttpSpanExporter(
-        OtlpHttpExporterConfig(endpoint: 'http://localhost:4318'),
-      );
+        final spanExporter = OtlpHttpSpanExporter(
+          OtlpHttpExporterConfig(endpoint: 'http://localhost:4318'),
+        );
 
-      await spanExporter.shutdown();
-      await spanExporter.forceFlush();
+        await spanExporter.shutdown();
+        await spanExporter.forceFlush();
 
-      expect(
-        logOutput.any((m) => m.contains('already shut down')),
-        isTrue,
-      );
-    });
+        expect(logOutput.any((m) => m.contains('already shut down')), isTrue);
+      },
+    );
 
     test('forceFlush with no pending exports completes', () async {
       await OTel.initialize(
@@ -703,7 +691,7 @@ void main() {
         10.0,
         20.0,
         5.0,
-        5.0
+        5.0,
       ]; // increase, increase, reset, zero-delta
 
       final counter = meter.createObservableCounter<double>(
@@ -718,7 +706,7 @@ void main() {
         },
       );
 
-      // First collect: 10.0 > 0.0 -> positive delta (covers line 162: double record)
+      // First collect: 10.0 > 0.0 -> positive delta (exercises double record path)
       var measurements = counter.collect();
       expect(measurements, isNotEmpty);
 
@@ -726,11 +714,11 @@ void main() {
       measurements = counter.collect();
       expect(measurements, isNotEmpty);
 
-      // Third collect: 5.0 < 20.0 -> counter reset (covers lines 150-151: double reset)
+      // Third collect: 5.0 < 20.0 -> counter reset (exercises double reset path)
       measurements = counter.collect();
       expect(measurements, isNotEmpty);
 
-      // Fourth collect: 5.0 == 5.0 -> zero delta (covers lines 173-174: double zero-delta)
+      // Fourth collect: 5.0 == 5.0 -> zero delta (exercises double zero-delta path)
       measurements = counter.collect();
       // Zero-delta should NOT produce a measurement in the result
       expect(measurements, isEmpty);
@@ -752,7 +740,7 @@ void main() {
         },
       );
 
-      // Collect should not throw - error is caught (lines 190-192)
+      // Collect should not throw - callback error is caught
       final measurements = counter.collect();
       expect(measurements, isEmpty);
     });
@@ -763,7 +751,7 @@ void main() {
   // =========================================================================
   group('OtlpGrpcExporterConfig endpoint validation', () {
     test('HTTP URL without port gets default port appended', () {
-      // Covers line 128: URL format without port
+      // Exercises URL format without port
       // http://myhost -> already has port 80 implicitly, but the logic
       // checks for explicit port.
       // We need an endpoint that starts with http:// but has no port.
@@ -778,7 +766,7 @@ void main() {
     });
 
     test('HTTP URL with valid format passes through', () {
-      // Covers line 140: return endpoint for valid URL
+      // Exercises the valid URL pass-through path
       final config = OtlpGrpcExporterConfig(
         endpoint: 'http://collector.example.com:4317',
       );
@@ -786,13 +774,13 @@ void main() {
     });
 
     test('host:port format with valid port passes through', () {
-      // Covers line 162: valid host:port
+      // Exercises the valid host:port path
       final config = OtlpGrpcExporterConfig(endpoint: 'collector:4317');
       expect(config.endpoint, equals('collector:4317'));
     });
 
     test('endpoint with non-numeric port throws ArgumentError', () {
-      // Covers lines 158-159: int.tryParse fails
+      // Exercises the int.tryParse failure path for non-numeric port
       expect(
         () => OtlpGrpcExporterConfig(endpoint: 'host:abc'),
         throwsArgumentError,
@@ -800,7 +788,7 @@ void main() {
     });
 
     test('endpoint with empty port throws ArgumentError', () {
-      // Covers lines 155-156: empty port string
+      // Exercises the empty port string validation
       expect(
         () => OtlpGrpcExporterConfig(endpoint: 'host:'),
         throwsArgumentError,
@@ -835,10 +823,7 @@ void main() {
     });
 
     test('negative maxRetries throws ArgumentError', () {
-      expect(
-        () => OtlpGrpcExporterConfig(maxRetries: -1),
-        throwsArgumentError,
-      );
+      expect(() => OtlpGrpcExporterConfig(maxRetries: -1), throwsArgumentError);
     });
 
     test('empty header key throws ArgumentError', () {
@@ -850,9 +835,7 @@ void main() {
 
     test('timeout too large throws ArgumentError', () {
       expect(
-        () => OtlpGrpcExporterConfig(
-          timeout: const Duration(minutes: 11),
-        ),
+        () => OtlpGrpcExporterConfig(timeout: const Duration(minutes: 11)),
         throwsArgumentError,
       );
     });
@@ -892,7 +875,7 @@ void main() {
       // "00-abcdef1234567890abcdef1234567-890-00f067aa0ba902b7-01" is 56 chars.
       // This is hard because the format is fixed at 55 chars.
       // Instead let's test a traceparent with invalid hex chars that causes
-      // a parse error (lines 216-221: catch in _parseTraceparent).
+      // a parse error in _parseTraceparent.
       final badHexCarrier = {
         'traceparent':
             '00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-00f067aa0ba902b7-01',
@@ -900,16 +883,21 @@ void main() {
 
       logOutput.clear();
       propagator.extract(
-          OTel.context(), badHexCarrier, _MapGetter(badHexCarrier));
+        OTel.context(),
+        badHexCarrier,
+        _MapGetter(badHexCarrier),
+      );
 
       // The 'Z' chars are valid hex? No, Z is not valid hex.
       // Actually TraceId.fromString may accept it or throw.
-      // If it throws, we cover lines 217-218 (Error parsing traceparent).
+      // If it throws, we exercise the "Error parsing traceparent" path.
       expect(
-        logOutput.any((m) =>
-            m.contains('Error parsing traceparent') ||
-            m.contains('Invalid trace ID') ||
-            m.contains('Extracting traceparent')),
+        logOutput.any(
+          (m) =>
+              m.contains('Error parsing traceparent') ||
+              m.contains('Invalid trace ID') ||
+              m.contains('Extracting traceparent'),
+        ),
         isTrue,
       );
     });
@@ -922,8 +910,11 @@ void main() {
       };
 
       logOutput.clear();
-      final ctx =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final ctx = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       // Empty tracestate should not add traceState to the context
       expect(ctx.spanContext, isNotNull);
@@ -949,15 +940,19 @@ void main() {
       final promExporter = PrometheusExporter();
       await promExporter.shutdown();
 
-      final result = await promExporter.export(MetricData(metrics: [
-        Metric.sum(
-          name: 'test',
-          points: [],
-          temporality: AggregationTemporality.cumulative,
+      final result = await promExporter.export(
+        MetricData(
+          metrics: [
+            Metric.sum(
+              name: 'test',
+              points: [],
+              temporality: AggregationTemporality.cumulative,
+            ),
+          ],
         ),
-      ]));
+      );
 
-      // After shutdown, export returns false (lines 58-62)
+      // After shutdown, export returns false
       expect(result, isFalse);
     });
 
@@ -974,7 +969,7 @@ void main() {
       final promExporter = PrometheusExporter();
       final result = await promExporter.export(MetricData(metrics: []));
 
-      // Empty metrics returns true (lines 65-69)
+      // Empty metrics returns true
       expect(result, isTrue);
 
       await promExporter.shutdown();
@@ -1096,9 +1091,11 @@ void main() {
 
       // Debug logs should mention test certificates
       expect(
-        logOutput.any((m) =>
-            m.contains('test certificate') ||
-            m.contains('test client certificate')),
+        logOutput.any(
+          (m) =>
+              m.contains('test certificate') ||
+              m.contains('test client certificate'),
+        ),
         isTrue,
       );
     });
@@ -1112,8 +1109,10 @@ void main() {
       );
     });
 
-    test('validateCertificates accepts null paths',
-        CertificateUtils.validateCertificates);
+    test(
+      'validateCertificates accepts null paths',
+      CertificateUtils.validateCertificates,
+    );
 
     test('validateCertificates throws for invalid-cert-path', () {
       expect(
@@ -1130,7 +1129,7 @@ void main() {
   // =========================================================================
   group('SimpleSpanProcessor shutdown error paths', () {
     test('shutdown with failing exporter shutdown logs error', () async {
-      // Covers lines 159-161: error during exporter shutdown
+      // Exercises error path during exporter shutdown
       await OTel.initialize(
         serviceName: 'ssp-shutdown-err-test',
         detectPlatformResources: false,
@@ -1148,16 +1147,18 @@ void main() {
       await processor.shutdown();
 
       expect(
-        logOutput.any((m) =>
-            m.contains('Error shutting down exporter') ||
-            m.contains('shutdown fail')),
+        logOutput.any(
+          (m) =>
+              m.contains('Error shutting down exporter') ||
+              m.contains('shutdown fail'),
+        ),
         isTrue,
         reason: 'Expected error log from exporter shutdown failure',
       );
     });
 
     test('shutdown with pending exports error logs error', () async {
-      // Covers lines 143-145: error waiting for pending exports
+      // Exercises error path when waiting for pending exports
       await OTel.initialize(
         serviceName: 'ssp-pending-err-test',
         detectPlatformResources: false,
@@ -1180,11 +1181,13 @@ void main() {
       await processor.shutdown();
 
       expect(
-        logOutput.any((m) =>
-            m.contains('Export error') ||
-            m.contains('pending export fail') ||
-            m.contains('Error waiting for pending exports') ||
-            m.contains('Shutdown complete')),
+        logOutput.any(
+          (m) =>
+              m.contains('Export error') ||
+              m.contains('pending export fail') ||
+              m.contains('Error waiting for pending exports') ||
+              m.contains('Shutdown complete'),
+        ),
         isTrue,
       );
     });
@@ -1201,13 +1204,10 @@ void main() {
 
       await processor.shutdown();
 
-      // forceFlush after shutdown should return early (lines 178-184)
+      // forceFlush after shutdown should return early
       await processor.forceFlush();
 
-      expect(
-        logOutput.any((m) => m.contains('Cannot force flush')),
-        isTrue,
-      );
+      expect(logOutput.any((m) => m.contains('Cannot force flush')), isTrue);
     });
 
     test('onEnd after shutdown skips export', () async {
@@ -1225,7 +1225,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('post-shutdown');
 
-      // onEnd after shutdown should skip (lines 36-43)
+      // onEnd after shutdown should skip export
       await processor.onEnd(span);
 
       expect(exporter.spans, isEmpty);
@@ -1248,10 +1248,7 @@ void main() {
 
       await processor.onNameUpdate(span, 'new-name');
 
-      expect(
-        logOutput.any((m) => m.contains('Name updated')),
-        isTrue,
-      );
+      expect(logOutput.any((m) => m.contains('Name updated')), isTrue);
 
       span.end();
       await processor.shutdown();
@@ -1268,13 +1265,10 @@ void main() {
       final processor = SimpleSpanProcessor(exporter);
 
       await processor.shutdown();
-      // Second shutdown hits early return (lines 118-123)
+      // Second shutdown hits the already-shutdown early return
       await processor.shutdown();
 
-      expect(
-        logOutput.any((m) => m.contains('Already shut down')),
-        isTrue,
-      );
+      expect(logOutput.any((m) => m.contains('Already shut down')), isTrue);
     });
   });
 
@@ -1361,9 +1355,7 @@ void main() {
   // =========================================================================
   group('OtlpHttpExporterConfig endpoint handling', () {
     test('endpoint with trailing slash is handled', () {
-      final config = OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:4318/',
-      );
+      final config = OtlpHttpExporterConfig(endpoint: 'http://localhost:4318/');
       expect(config.endpoint, equals('http://localhost:4318/'));
     });
 

--- a/test/unit/factory/factory_pattern_test.dart
+++ b/test/unit/factory/factory_pattern_test.dart
@@ -112,8 +112,10 @@ void main() {
       OTel.initialize(serviceName: 'valid-service');
 
       // Test double initialization
-      expect(() => OTel.initialize(serviceName: 'another-service'),
-          throwsStateError);
+      expect(
+        () => OTel.initialize(serviceName: 'another-service'),
+        throwsStateError,
+      );
     });
 
     test('Resource creation through factory', () {
@@ -130,7 +132,9 @@ void main() {
 
       expect(resource, isNotNull);
       expect(
-          resource.attributes.getString('service.name'), equals('my-service'));
+        resource.attributes.getString('service.name'),
+        equals('my-service'),
+      );
       expect(resource.attributes.getString('service.version'), equals('1.0.0'));
     });
 

--- a/test/unit/fixed_scope_test.dart
+++ b/test/unit/fixed_scope_test.dart
@@ -40,15 +40,9 @@ void main() {
       );
 
       // Create spans
-      final httpSpan = httpTracer.startSpan(
-        'http-span',
-        kind: SpanKind.server,
-      );
+      final httpSpan = httpTracer.startSpan('http-span', kind: SpanKind.server);
 
-      final dbSpan = dbTracer.startSpan(
-        'db-span',
-        kind: SpanKind.client,
-      );
+      final dbSpan = dbTracer.startSpan('db-span', kind: SpanKind.client);
 
       // End spans
       httpSpan.end();
@@ -59,9 +53,11 @@ void main() {
       final dbScope = dbSpan.instrumentationScope;
 
       print(
-          'HTTP Span Instrumentation Scope: ${httpScope.name}, version: ${httpScope.version}');
+        'HTTP Span Instrumentation Scope: ${httpScope.name}, version: ${httpScope.version}',
+      );
       print(
-          'DB Span Instrumentation Scope: ${dbScope.name}, version: ${dbScope.version}');
+        'DB Span Instrumentation Scope: ${dbScope.name}, version: ${dbScope.version}',
+      );
 
       // Verify the instrumentation scopes
       expect(httpScope.name, equals('http-instrumentation'));
@@ -103,10 +99,16 @@ void main() {
       print('All scope names: $allScopeNames');
 
       // Check for both instrumentation scopes
-      expect(allScopeNames.contains('http-instrumentation'), isTrue,
-          reason: 'Should contain http-instrumentation scope');
-      expect(allScopeNames.contains('db-instrumentation'), isTrue,
-          reason: 'Should contain db-instrumentation scope');
+      expect(
+        allScopeNames.contains('http-instrumentation'),
+        isTrue,
+        reason: 'Should contain http-instrumentation scope',
+      );
+      expect(
+        allScopeNames.contains('db-instrumentation'),
+        isTrue,
+        reason: 'Should contain db-instrumentation scope',
+      );
     });
   });
 }

--- a/test/unit/infrastructure_coverage_test.dart
+++ b/test/unit/infrastructure_coverage_test.dart
@@ -54,12 +54,15 @@ void main() {
   setUp(() async {
     await OTel.reset();
     logOutput.clear();
-    OTelLog.enableTraceLogging();
     OTelLog.logFunction = logOutput.add;
     await OTel.initialize(
       serviceName: 'remaining-coverage-test',
       detectPlatformResources: false,
+      enableLogs: false,
     );
+    // Set trace logging AFTER initialize, since initializeLogging() reads
+    // OTEL_LOG_LEVEL from env and would override a level set before it.
+    OTelLog.enableTraceLogging();
   });
 
   tearDown(() async {
@@ -85,8 +88,11 @@ void main() {
             '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
       };
       logOutput.clear();
-      final extracted =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final extracted = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       expect(extracted.spanContext, isNotNull);
       expect(extracted.spanContext!.isValid, isTrue);
@@ -106,8 +112,11 @@ void main() {
     test('extract with null/missing traceparent logs debug', () {
       final carrier = <String, String>{};
       logOutput.clear();
-      final extracted =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final extracted = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       // Context returned unchanged.
       expect(extracted.spanContext, isNull);
@@ -124,8 +133,11 @@ void main() {
             '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
       };
       logOutput.clear();
-      final extracted =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final extracted = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       expect(extracted.spanContext, isNull);
       expect(
@@ -187,8 +199,11 @@ void main() {
         'tracestate': 'no-equals,also-bad',
       };
       logOutput.clear();
-      final extracted =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final extracted = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       expect(extracted.spanContext, isNotNull);
       expect(
@@ -206,8 +221,11 @@ void main() {
         'tracestate': 'key=',
       };
       logOutput.clear();
-      final extracted =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final extracted = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       expect(extracted.spanContext, isNotNull);
       expect(
@@ -259,8 +277,10 @@ void main() {
     test('inject with tracestate logs debug for tracestate', () {
       final traceId = OTel.traceIdFrom('4bf92f3577b34da6a3ce929d0e0e4736');
       final spanId = OTel.spanIdFrom('00f067aa0ba902b7');
-      final traceState =
-          OTel.traceState({'vendor1': 'val1', 'vendor2': 'val2'});
+      final traceState = OTel.traceState({
+        'vendor1': 'val1',
+        'vendor2': 'val2',
+      });
       final spanContext = OTel.spanContext(
         traceId: traceId,
         spanId: spanId,
@@ -297,8 +317,11 @@ void main() {
       final carrier = <String, String>{};
 
       propagator.inject(originalCtx, carrier, _MapSetter(carrier));
-      final extractedCtx =
-          propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
+      final extractedCtx = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
 
       final sc = extractedCtx.spanContext;
       expect(sc, isNotNull);
@@ -321,11 +344,13 @@ void main() {
       propagator.extract(OTel.context(), carrier, _MapGetter(carrier));
 
       expect(
-        logOutput.any((m) =>
-            m.contains('Invalid traceparent format') ||
-            m.contains('Invalid trace ID length') ||
-            m.contains('Invalid span ID length') ||
-            m.contains('Invalid trace flags length')),
+        logOutput.any(
+          (m) =>
+              m.contains('Invalid traceparent format') ||
+              m.contains('Invalid trace ID length') ||
+              m.contains('Invalid span ID length') ||
+              m.contains('Invalid trace flags length'),
+        ),
         isTrue,
         reason:
             'Expected some validation debug log for the malformed traceparent',
@@ -403,10 +428,7 @@ void main() {
         }),
       );
       final r2 = OTel.resource(
-        OTel.attributesFromMap({
-          'service.name': 'svc-b',
-          'other': 'value',
-        }),
+        OTel.attributesFromMap({'service.name': 'svc-b', 'other': 'value'}),
       );
 
       logOutput.clear();
@@ -445,8 +467,9 @@ void main() {
 
       final reader = PeriodicExportingMetricReader(
         exporter,
-        interval:
-            const Duration(hours: 1), // long interval so timer doesn't fire
+        interval: const Duration(
+          hours: 1,
+        ), // long interval so timer doesn't fire
       );
       // Do NOT register a MeterProvider.
 
@@ -658,22 +681,25 @@ void main() {
       );
     });
 
-    test('createSecurityContext with test:// client cert and key logs debug',
-        () {
-      logOutput.clear();
-      final ctx = CertificateUtils.createSecurityContext(
-        clientKey: 'test://client.key',
-        clientCertificate: 'test://client.pem',
-      );
+    test(
+      'createSecurityContext with test:// client cert and key logs debug',
+      () {
+        logOutput.clear();
+        final ctx = CertificateUtils.createSecurityContext(
+          clientKey: 'test://client.key',
+          clientCertificate: 'test://client.pem',
+        );
 
-      expect(ctx, isNotNull);
-      expect(
-        logOutput
-            .any((m) => m.contains('Using test client certificate and key')),
-        isTrue,
-        reason: 'Expected debug log about test client certificate and key',
-      );
-    });
+        expect(ctx, isNotNull);
+        expect(
+          logOutput.any(
+            (m) => m.contains('Using test client certificate and key'),
+          ),
+          isTrue,
+          reason: 'Expected debug log about test client certificate and key',
+        );
+      },
+    );
 
     test('createSecurityContext with all test:// certs logs all debug', () {
       logOutput.clear();
@@ -689,8 +715,9 @@ void main() {
         isTrue,
       );
       expect(
-        logOutput
-            .any((m) => m.contains('Using test client certificate and key')),
+        logOutput.any(
+          (m) => m.contains('Using test client certificate and key'),
+        ),
         isTrue,
       );
     });
@@ -704,10 +731,7 @@ void main() {
     });
 
     test('validateCertificates with all null succeeds', () {
-      expect(
-        CertificateUtils.validateCertificates,
-        returnsNormally,
-      );
+      expect(CertificateUtils.validateCertificates, returnsNormally);
     });
 
     test('validateCertificates with test:// paths succeeds', () {
@@ -731,15 +755,17 @@ void main() {
       );
     });
 
-    test('validateCertificates with invalid-cert-path throws ArgumentError',
-        () {
-      expect(
-        () => CertificateUtils.validateCertificates(
-          certificate: 'invalid-cert-path',
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-    });
+    test(
+      'validateCertificates with invalid-cert-path throws ArgumentError',
+      () {
+        expect(
+          () => CertificateUtils.validateCertificates(
+            certificate: 'invalid-cert-path',
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
 
     test('validateCertificates with non-existent certificate throws', () {
       expect(
@@ -775,9 +801,8 @@ void main() {
 
       try {
         expect(
-          () => CertificateUtils.validateCertificates(
-            certificate: certFile.path,
-          ),
+          () =>
+              CertificateUtils.validateCertificates(certificate: certFile.path),
           returnsNormally,
         );
       } finally {

--- a/test/unit/logs/bridge/dart_log_bridge_test.dart
+++ b/test/unit/logs/bridge/dart_log_bridge_test.dart
@@ -1,0 +1,269 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:async';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('DartLogBridge Tests', () {
+    late MemoryLogRecordExporter memoryExporter;
+    late SimpleLogRecordProcessor processor;
+
+    setUp(() async {
+      await OTel.reset();
+
+      memoryExporter = MemoryLogRecordExporter();
+      processor = SimpleLogRecordProcessor(memoryExporter);
+
+      await OTel.initialize(
+        serviceName: 'dart-log-bridge-test',
+        detectPlatformResources: false,
+      );
+
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+    });
+
+    tearDown(() async {
+      DartLogBridge.uninstall();
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('DartLogBridge can be installed with Logger', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      expect(bridge.isActive, isTrue);
+      expect(DartLogBridge.current, equals(bridge));
+    });
+
+    test('DartLogBridge can be installed with LoggerProvider', () {
+      final bridge = DartLogBridge.installWithProvider(
+        OTel.loggerProvider(),
+        defaultLoggerName: 'provider-logger',
+      );
+
+      expect(bridge.isActive, isTrue);
+      expect(DartLogBridge.current, equals(bridge));
+    });
+
+    test('DartLogBridge can be uninstalled', () {
+      final logger = OTel.logger('test-logger');
+      DartLogBridge.install(logger);
+
+      expect(DartLogBridge.current, isNotNull);
+
+      DartLogBridge.uninstall();
+
+      expect(DartLogBridge.current, isNull);
+    });
+
+    test('DartLogBridge can be activated and deactivated', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      expect(bridge.isActive, isTrue);
+
+      bridge.deactivate();
+      expect(bridge.isActive, isFalse);
+
+      bridge.activate();
+      expect(bridge.isActive, isTrue);
+    });
+
+    test('DartLogBridge.log emits log record when active', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      bridge.log('Test message', level: 800); // INFO level
+
+      expect(memoryExporter.count, equals(1));
+      expect(
+          memoryExporter.exportedLogRecords.first.body, equals('Test message'));
+    });
+
+    test('DartLogBridge.log does not emit when inactive', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      bridge.deactivate();
+      bridge.log('Should not be logged');
+
+      expect(memoryExporter.count, equals(0));
+    });
+
+    test('DartLogBridge converts Dart INFO level to OTel INFO severity', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      bridge.log('Test at INFO level', level: 800);
+
+      expect(memoryExporter.count, equals(1));
+      expect(memoryExporter.exportedLogRecords.first.severityNumber,
+          equals(Severity.INFO));
+    });
+
+    test('DartLogBridge converts Dart WARNING level to OTel WARN severity', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      bridge.log('Test at WARNING level', level: 900);
+
+      expect(memoryExporter.count, equals(1));
+      expect(memoryExporter.exportedLogRecords.first.severityNumber,
+          equals(Severity.WARN));
+    });
+
+    test('DartLogBridge converts Dart SEVERE level to OTel ERROR severity', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      bridge.log('Test at SEVERE level', level: 1000);
+
+      expect(memoryExporter.count, equals(1));
+      expect(memoryExporter.exportedLogRecords.first.severityNumber,
+          equals(Severity.ERROR));
+    });
+
+    test('DartLogBridge respects minimum severity filter', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(
+        logger,
+        minimumSeverity: Severity.WARN,
+      );
+
+      // INFO level (800) should be filtered out
+      bridge.log('Info message', level: 800);
+      expect(memoryExporter.count, equals(0));
+
+      // WARNING level (900) should pass
+      bridge.log('Warning message', level: 900);
+      expect(memoryExporter.count, equals(1));
+    });
+
+    test('DartLogBridge includes error information', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      final error = Exception('Test error');
+      bridge.log(
+        'Error occurred',
+        level: 1000,
+        error: error,
+      );
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      final attrs = logRecord.attributes?.toList() ?? [];
+
+      expect(attrs.any((a) => a.key == 'exception.type'), isTrue);
+      expect(attrs.any((a) => a.key == 'exception.message'), isTrue);
+    });
+
+    test('DartLogBridge includes stack trace', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      final stackTrace = StackTrace.current;
+      bridge.log(
+        'Error with stack',
+        level: 1000,
+        stackTrace: stackTrace,
+      );
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      final attrs = logRecord.attributes?.toList() ?? [];
+
+      expect(attrs.any((a) => a.key == 'exception.stacktrace'), isTrue);
+    });
+
+    test('DartLogBridge includes sequence number', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      bridge.log('Test message',
+          level: 800, sequenceNumber: 42); // level 800 = INFO
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      final attrs = logRecord.attributes?.toList() ?? [];
+
+      final seqAttr = attrs.firstWhere(
+        (a) => a.key == 'sequence_number',
+        orElse: () => throw StateError('sequence_number not found'),
+      );
+      expect(seqAttr.value, equals(42));
+    });
+
+    test('DartLogBridge uses logger name from log call when using provider',
+        () {
+      final bridge = DartLogBridge.installWithProvider(
+        OTel.loggerProvider(),
+        defaultLoggerName: 'default-logger',
+      );
+
+      bridge.log('Test message',
+          level: 800, name: 'custom-logger'); // level 800 = INFO
+
+      expect(memoryExporter.count, equals(1));
+      // The instrumentation scope name should be the custom logger name
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.instrumentationScope.name, equals('custom-logger'));
+    });
+
+    test('DartLogBridge uses default logger name when no name provided', () {
+      final bridge = DartLogBridge.installWithProvider(
+        OTel.loggerProvider(),
+        defaultLoggerName: 'my-default-logger',
+      );
+
+      bridge.log('Test message', level: 800); // level 800 = INFO
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.instrumentationScope.name, equals('my-default-logger'));
+    });
+
+    test('DartLogBridge createZoneSpecification captures print', () {
+      final logger = OTel.logger('test-logger');
+      final bridge = DartLogBridge.install(logger);
+
+      final spec = bridge.createZoneSpecification();
+      expect(spec, isNotNull);
+
+      // Run code in the zone
+      runZoned(
+        () {
+          print('Test print message');
+        },
+        zoneSpecification: spec,
+      );
+
+      // The print should have been captured
+      expect(memoryExporter.count, equals(1));
+      expect(
+        memoryExporter.exportedLogRecords.first.body,
+        equals('Test print message'),
+      );
+    });
+
+    test('DartLogBridge static emitLog works', () {
+      final logger = OTel.logger('test-logger');
+      DartLogBridge.install(logger);
+
+      DartDeveloperLogBridge.emitLog(
+        'Static emit message',
+        level: 800,
+        name: 'static-logger',
+      );
+
+      // Should produce at least one log (the OTel log from the bridge)
+      expect(memoryExporter.count, greaterThanOrEqualTo(1));
+    });
+  });
+}

--- a/test/unit/logs/export/batch_log_record_processor_test.dart
+++ b/test/unit/logs/export/batch_log_record_processor_test.dart
@@ -1,0 +1,307 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('BatchLogRecordProcessor Tests', () {
+    late MemoryLogRecordExporter exporter;
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'batch-processor-test',
+        detectPlatformResources: false,
+      );
+
+      exporter = MemoryLogRecordExporter();
+      scope = OTel.instrumentationScope(name: 'test-scope', version: '1.0.0');
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('BatchLogRecordProcessor batches log records', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 5,
+        scheduleDelay:
+            Duration(seconds: 10), // Long delay to prevent auto-export
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        // Add 3 logs (less than batch size)
+        for (int i = 0; i < 3; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Message $i',
+          );
+          await processor.onEmit(logRecord, null);
+        }
+
+        // Force flush to export
+        await processor.forceFlush();
+
+        expect(exporter.count, equals(3));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor queues logs until flush or timer', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 3,
+        scheduleDelay: Duration(seconds: 100), // Long delay - won't auto-export
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        // Add logs to the queue
+        for (int i = 0; i < 3; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Message $i',
+          );
+          await processor.onEmit(logRecord, null);
+        }
+
+        // No export yet since timer hasn't fired
+        expect(exporter.count, equals(0));
+
+        // Force flush to trigger export
+        await processor.forceFlush();
+
+        expect(exporter.count, equals(3));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor exports on schedule delay', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 100, // Large batch size
+        scheduleDelay: Duration(milliseconds: 100), // Short delay for testing
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'Test message',
+        );
+        await processor.onEmit(logRecord, null);
+
+        // Wait for scheduled export
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(exporter.count, equals(1));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor respects max queue size', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxQueueSize: 5,
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100), // Long delay
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        // Add more logs than queue size
+        for (int i = 0; i < 10; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Message $i',
+          );
+          await processor.onEmit(logRecord, null);
+        }
+
+        await processor.forceFlush();
+
+        // Should only have exported up to queue size
+        expect(exporter.count, lessThanOrEqualTo(5));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor shutdown exports remaining logs', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 100,
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      // Add some logs
+      for (int i = 0; i < 3; i++) {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'Message $i',
+        );
+        await processor.onEmit(logRecord, null);
+      }
+
+      // Shutdown should flush remaining
+      await processor.shutdown();
+
+      expect(exporter.count, equals(3));
+    });
+
+    test('BatchLogRecordProcessor does not accept logs after shutdown',
+        () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(milliseconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      await processor.shutdown();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Should not be queued',
+      );
+      await processor.onEmit(logRecord, null);
+
+      // Force flush should do nothing after shutdown
+      await processor.forceFlush();
+
+      expect(exporter.count, equals(0));
+    });
+
+    test('BatchLogRecordProcessor enabled returns true by default', () {
+      final processor = BatchLogRecordProcessor(exporter);
+
+      expect(processor.enabled(), isTrue);
+
+      processor.shutdown();
+    });
+
+    test('BatchLogRecordProcessor forceFlush exports queued logs', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 100,
+        scheduleDelay: Duration(seconds: 100), // Long delay
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        // Add some logs
+        for (int i = 0; i < 5; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Message $i',
+          );
+          await processor.onEmit(logRecord, null);
+        }
+
+        // Force flush
+        await processor.forceFlush();
+
+        expect(exporter.count, equals(5));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor handles concurrent emits', () async {
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 100,
+        scheduleDelay: Duration(milliseconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        // Emit concurrently
+        final futures = <Future<void>>[];
+        for (int i = 0; i < 20; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Concurrent message $i',
+          );
+          futures.add(processor.onEmit(logRecord, null));
+        }
+
+        await Future.wait(futures);
+        await processor.forceFlush();
+
+        expect(exporter.count, equals(20));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor uses default values', () async {
+      // Create with no explicit config to test defaults
+      final processor = BatchLogRecordProcessor(exporter);
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'Test message',
+        );
+        await processor.onEmit(logRecord, null);
+        await processor.forceFlush();
+
+        expect(exporter.count, equals(1));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('BatchLogRecordProcessor handles export failure', () async {
+      final failingExporter = _FailingLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 2,
+        scheduleDelay: Duration(milliseconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(failingExporter, config);
+
+      try {
+        // This should not throw even when export fails
+        for (int i = 0; i < 3; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Message $i',
+          );
+          await processor.onEmit(logRecord, null);
+        }
+
+        await expectLater(processor.forceFlush(), completes);
+      } finally {
+        await processor.shutdown();
+      }
+    });
+  });
+}
+
+/// A log record exporter that always fails for testing error handling.
+class _FailingLogRecordExporter implements LogRecordExporter {
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    return ExportResult.failure;
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}

--- a/test/unit/logs/export/console_log_record_exporter_test.dart
+++ b/test/unit/logs/export/console_log_record_exporter_test.dart
@@ -1,0 +1,272 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ConsoleLogRecordExporter Tests', () {
+    late InstrumentationScope scope;
+    late List<String> printedLines;
+    late ConsoleLogRecordExporter exporter;
+
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'console-exporter-test',
+        detectPlatformResources: false,
+      );
+
+      scope = OTel.instrumentationScope(name: 'test-scope', version: '1.0.0');
+      printedLines = [];
+      exporter = ConsoleLogRecordExporter(
+        printFunction: (line) => printedLines.add(line),
+      );
+    });
+
+    tearDown(() async {
+      await exporter.shutdown();
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('ConsoleLogRecordExporter exports log records', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        severityText: 'INFO',
+        body: 'Test message',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      final result = await exporter.export([logRecord]);
+
+      expect(result, equals(ExportResult.success));
+      expect(printedLines.length, equals(1));
+      expect(printedLines.first, contains('Test message'));
+    });
+
+    test('ConsoleLogRecordExporter formats timestamp', () async {
+      final timestamp = DateTime.utc(2024, 1, 15, 12, 30, 45);
+      final timestampNanos =
+          Int64(timestamp.microsecondsSinceEpoch) * Int64(1000);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        observedTimestamp: timestampNanos,
+      );
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('2024-01-15'));
+    });
+
+    test('ConsoleLogRecordExporter formats severity', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.ERROR,
+        severityText: 'ERROR',
+        body: 'Error message',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('[ERROR]'));
+    });
+
+    test('ConsoleLogRecordExporter formats instrumentation scope', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: OTel.instrumentationScope(
+          name: 'my-library',
+          version: '2.0.0',
+        ),
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('[my-library:2.0.0]'));
+    });
+
+    test('ConsoleLogRecordExporter formats event name', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        eventName: 'user.login',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('{user.login}'));
+    });
+
+    test('ConsoleLogRecordExporter formats trace context', () async {
+      final traceId = OTel.traceId();
+      final spanId = OTel.spanId();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+      logRecord.traceId = traceId;
+      logRecord.spanId = spanId;
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('trace_id='));
+      expect(printedLines.first, contains('span_id='));
+    });
+
+    test('ConsoleLogRecordExporter formats attributes', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        attributes: OTel.attributesFromMap({
+          'key1': 'value1',
+          'key2': 42,
+        }),
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('key1=value1'));
+      expect(printedLines.first, contains('key2=42'));
+    });
+
+    test('ConsoleLogRecordExporter formats resource service name', () async {
+      final resource = OTel.resource(OTel.attributesFromMap({
+        'service.name': 'my-service',
+      }));
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        resource: resource,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      await exporter.export([logRecord]);
+
+      expect(printedLines.first, contains('service=my-service'));
+    });
+
+    test('ConsoleLogRecordExporter exports multiple log records', () async {
+      final logRecords = [
+        SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'Message 1',
+          observedTimestamp:
+              Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+        ),
+        SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.WARN,
+          body: 'Message 2',
+          observedTimestamp:
+              Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+        ),
+        SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.ERROR,
+          body: 'Message 3',
+          observedTimestamp:
+              Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+        ),
+      ];
+
+      final result = await exporter.export(logRecords);
+
+      expect(result, equals(ExportResult.success));
+      expect(printedLines.length, equals(3));
+    });
+
+    test('ConsoleLogRecordExporter returns failure after shutdown', () async {
+      await exporter.shutdown();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+      );
+
+      final result = await exporter.export([logRecord]);
+
+      expect(result, equals(ExportResult.failure));
+      expect(printedLines.isEmpty, isTrue);
+    });
+
+    test('ConsoleLogRecordExporter forceFlush completes successfully',
+        () async {
+      await expectLater(exporter.forceFlush(), completes);
+    });
+
+    test('ConsoleLogRecordExporter uses default print function', () async {
+      // Create exporter without custom print function
+      final defaultExporter = ConsoleLogRecordExporter();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      // This should not throw
+      final result = await defaultExporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+
+      await defaultExporter.shutdown();
+    });
+
+    test('ConsoleLogRecordExporter handles null body', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: null,
+        observedTimestamp:
+            Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000),
+      );
+
+      final result = await exporter.export([logRecord]);
+
+      expect(result, equals(ExportResult.success));
+      // Should still print something even with null body
+      expect(printedLines.length, equals(1));
+    });
+
+    test('ConsoleLogRecordExporter handles missing timestamp', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'No timestamp',
+      );
+
+      final result = await exporter.export([logRecord]);
+
+      expect(result, equals(ExportResult.success));
+      expect(printedLines.length, equals(1));
+    });
+  });
+}

--- a/test/unit/logs/export/otlp/log_record_transformer_test.dart
+++ b/test/unit/logs/export/otlp/log_record_transformer_test.dart
@@ -1,0 +1,391 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OtlpLogRecordTransformer Tests', () {
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'transformer-test',
+        detectPlatformResources: false,
+      );
+
+      scope = OTel.instrumentationScope(name: 'test-scope', version: '1.0.0');
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('transforms empty list correctly', () {
+      final request = OtlpLogRecordTransformer.transformLogRecords([]);
+
+      expect(request.resourceLogs, isEmpty);
+    });
+
+    test('transforms single log record correctly', () {
+      final resource = OTel.resource(OTel.attributesFromMap({
+        'service.name': 'test-service',
+      }));
+
+      final timestamp = Int64(1234567890000000);
+      final observedTimestamp = Int64(1234567891000000);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        resource: resource,
+        timestamp: timestamp,
+        observedTimestamp: observedTimestamp,
+        severityNumber: Severity.INFO,
+        severityText: 'INFO',
+        body: 'Test message',
+        attributes: OTel.attributesFromMap({'key': 'value'}),
+        eventName: 'test.event',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+
+      expect(request.resourceLogs.length, equals(1));
+      expect(request.resourceLogs.first.scopeLogs.length, equals(1));
+      expect(request.resourceLogs.first.scopeLogs.first.logRecords.length,
+          equals(1));
+
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+      expect(otlpLog.timeUnixNano, equals(timestamp));
+      expect(otlpLog.observedTimeUnixNano, equals(observedTimestamp));
+      expect(otlpLog.severityText, equals('INFO'));
+      expect(otlpLog.body.stringValue, equals('Test message'));
+    });
+
+    test('transforms severity levels correctly', () {
+      final severities = [
+        Severity.TRACE,
+        Severity.DEBUG,
+        Severity.INFO,
+        Severity.WARN,
+        Severity.ERROR,
+        Severity.FATAL,
+      ];
+
+      for (final severity in severities) {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: severity,
+          body: 'Test',
+        );
+
+        final request =
+            OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+        final otlpLog =
+            request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+        // Verify severity number is set
+        expect(otlpLog.severityNumber.value, isNonZero);
+      }
+    });
+
+    test('transforms attributes correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+        attributes: OTel.attributesFromMap({
+          'string_attr': 'string_value',
+          'int_attr': 42,
+          'double_attr': 3.14,
+          'bool_attr': true,
+        }),
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.attributes.length, equals(4));
+
+      // Verify each attribute type
+      final stringAttr =
+          otlpLog.attributes.firstWhere((a) => a.key == 'string_attr');
+      expect(stringAttr.value.stringValue, equals('string_value'));
+
+      final intAttr = otlpLog.attributes.firstWhere((a) => a.key == 'int_attr');
+      expect(intAttr.value.intValue, equals(Int64(42)));
+
+      final doubleAttr =
+          otlpLog.attributes.firstWhere((a) => a.key == 'double_attr');
+      expect(doubleAttr.value.doubleValue, equals(3.14));
+
+      final boolAttr =
+          otlpLog.attributes.firstWhere((a) => a.key == 'bool_attr');
+      expect(boolAttr.value.boolValue, isTrue);
+    });
+
+    test('transforms string body correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'String body',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.stringValue, equals('String body'));
+    });
+
+    test('transforms int body correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 42,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.intValue, equals(Int64(42)));
+    });
+
+    test('transforms double body correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 3.14,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.doubleValue, equals(3.14));
+    });
+
+    test('transforms bool body correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: true,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.boolValue, isTrue);
+    });
+
+    test('transforms list body correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: ['a', 'b', 'c'],
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.arrayValue.values.length, equals(3));
+    });
+
+    test('transforms map body correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: {'key1': 'value1', 'key2': 'value2'},
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.kvlistValue.values.length, equals(2));
+    });
+
+    test('transforms trace context correctly', () {
+      final traceId = OTel.traceId();
+      final spanId = OTel.spanId();
+      final traceFlags = TraceFlags.sampled;
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+      );
+      logRecord.traceId = traceId;
+      logRecord.spanId = spanId;
+      logRecord.traceFlags = traceFlags;
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.traceId, equals(traceId.bytes));
+      expect(otlpLog.spanId, equals(spanId.bytes));
+      expect(otlpLog.flags, equals(traceFlags.asByte));
+    });
+
+    test('transforms dropped attributes count correctly', () {
+      final originalLimit = SDKLogRecord.maxAttributeCount;
+      SDKLogRecord.maxAttributeCount = 2;
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'Test',
+          attributes: OTel.attributesFromMap({
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': 'value3',
+            'key4': 'value4',
+          }),
+        );
+
+        final request =
+            OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+        final otlpLog =
+            request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+        expect(otlpLog.droppedAttributesCount, equals(2));
+      } finally {
+        SDKLogRecord.maxAttributeCount = originalLimit;
+      }
+    });
+
+    test('groups logs by resource', () {
+      final resource1 = OTel.resource(OTel.attributesFromMap({
+        'service.name': 'service-1',
+      }));
+      final resource2 = OTel.resource(OTel.attributesFromMap({
+        'service.name': 'service-2',
+      }));
+
+      final logRecords = [
+        SDKLogRecord(
+          instrumentationScope: scope,
+          resource: resource1,
+          severityNumber: Severity.INFO,
+          body: 'Service 1 log',
+        ),
+        SDKLogRecord(
+          instrumentationScope: scope,
+          resource: resource2,
+          severityNumber: Severity.INFO,
+          body: 'Service 2 log',
+        ),
+      ];
+
+      final request = OtlpLogRecordTransformer.transformLogRecords(logRecords);
+
+      // Should have 2 resource logs groups
+      expect(request.resourceLogs.length, equals(2));
+    });
+
+    test('groups logs by instrumentation scope', () {
+      final scope1 =
+          OTel.instrumentationScope(name: 'scope-1', version: '1.0.0');
+      final scope2 =
+          OTel.instrumentationScope(name: 'scope-2', version: '1.0.0');
+
+      final resource = OTel.resource(OTel.attributesFromMap({
+        'service.name': 'test-service',
+      }));
+
+      final logRecords = [
+        SDKLogRecord(
+          instrumentationScope: scope1,
+          resource: resource,
+          severityNumber: Severity.INFO,
+          body: 'Scope 1 log',
+        ),
+        SDKLogRecord(
+          instrumentationScope: scope2,
+          resource: resource,
+          severityNumber: Severity.INFO,
+          body: 'Scope 2 log',
+        ),
+      ];
+
+      final request = OtlpLogRecordTransformer.transformLogRecords(logRecords);
+
+      // Should have 1 resource logs with 2 scope logs
+      expect(request.resourceLogs.length, equals(1));
+      expect(request.resourceLogs.first.scopeLogs.length, equals(2));
+    });
+
+    test('transforms instrumentation scope correctly', () {
+      final scopeWithAttrs = OTel.instrumentationScope(
+        name: 'my-library',
+        version: '2.0.0',
+        schemaUrl: 'https://example.com/schema',
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scopeWithAttrs,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final scopeLogs = request.resourceLogs.first.scopeLogs.first;
+
+      expect(scopeLogs.scope.name, equals('my-library'));
+      expect(scopeLogs.scope.version, equals('2.0.0'));
+    });
+
+    test('transforms resource attributes correctly', () {
+      final resource = OTel.resource(OTel.attributesFromMap({
+        'service.name': 'test-service',
+        'service.version': '1.0.0',
+        'deployment.environment': 'production',
+      }));
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        resource: resource,
+        severityNumber: Severity.INFO,
+        body: 'Test',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final protoResource = request.resourceLogs.first.resource;
+
+      expect(protoResource.attributes.length, equals(3));
+    });
+
+    test('handles null body', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: null,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+
+      // Should not throw and should complete
+      expect(request.resourceLogs.length, equals(1));
+    });
+
+    test('handles missing optional fields', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+
+      // Should not throw
+      expect(request.resourceLogs.length, equals(1));
+    });
+  });
+}

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
@@ -1,0 +1,1522 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/proto/collector/logs/v1/logs_service.pbgrpc.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:grpc/grpc.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// Mock gRPC services
+// ---------------------------------------------------------------------------
+
+/// A simple logs service that always succeeds.
+class SuccessLogsService extends LogsServiceBase {
+  int callCount = 0;
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    callCount++;
+    return ExportLogsServiceResponse();
+  }
+}
+
+/// Service that takes a long time to respond, for testing pending exports,
+/// forceFlush with pending exports, and shutdown with pending exports.
+class SlowLogsService extends LogsServiceBase {
+  final Completer<void> exportStarted = Completer();
+  final Completer<void> shouldComplete = Completer();
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    if (!exportStarted.isCompleted) {
+      exportStarted.complete();
+    }
+    await shouldComplete.future;
+    return ExportLogsServiceResponse();
+  }
+}
+
+/// Service that throws a non-GrpcError (plain Exception), exercising the
+/// generic catch block in _export.
+class GenericThrowLogsService extends LogsServiceBase {
+  int callCount = 0;
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    callCount++;
+    throw Exception('Generic non-gRPC error');
+  }
+}
+
+/// Service that throws a specific gRPC error for a configurable number of
+/// calls, then succeeds. This exercises the channel recreation path and
+/// retry logic.
+class ConfigurableErrorLogsService extends LogsServiceBase {
+  int callCount = 0;
+  final int failCount;
+  final int failCode;
+
+  ConfigurableErrorLogsService({
+    this.failCount = 1,
+    this.failCode = StatusCode.internal,
+  });
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    callCount++;
+    if (callCount <= failCount) {
+      throw GrpcError.custom(failCode, 'Simulated gRPC error');
+    }
+    return ExportLogsServiceResponse();
+  }
+}
+
+/// Service that always throws UNAVAILABLE, for testing shutdown during retries.
+class AlwaysUnavailableLogsService extends LogsServiceBase {
+  int callCount = 0;
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    callCount++;
+    throw const GrpcError.custom(StatusCode.unavailable, 'Always unavailable');
+  }
+}
+
+/// Service that always throws RESOURCE_EXHAUSTED, for testing retryable errors.
+class AlwaysResourceExhaustedLogsService extends LogsServiceBase {
+  int callCount = 0;
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    callCount++;
+    throw const GrpcError.custom(
+        StatusCode.resourceExhausted, 'Resource exhausted');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a test [ReadableLogRecord] for use in export tests.
+ReadableLogRecord _createTestLogRecord({
+  String body = 'Test log message',
+  Severity severity = Severity.INFO,
+  Map<String, Object>? attributes,
+}) {
+  final scope = OTel.instrumentationScope(
+    name: 'test-log-scope',
+    version: '1.0.0',
+  );
+  final resource = OTel.resource(
+    OTel.attributesFromMap({
+      'service.name': 'test-log-service',
+      'service.version': '1.0.0',
+    }),
+  );
+
+  final record = SDKLogRecord(
+    instrumentationScope: scope,
+    resource: resource,
+    severityNumber: severity,
+    severityText: severity.name,
+    body: body,
+    timestamp: Int64(DateTime.now().microsecondsSinceEpoch * 1000),
+    observedTimestamp: Int64(DateTime.now().microsecondsSinceEpoch * 1000),
+    attributes: attributes != null ? OTel.attributesFromMap(attributes) : null,
+  );
+
+  return record;
+}
+
+/// Creates an [OtlpGrpcLogRecordExporter] configured to talk to a local test
+/// server on the given [port].
+OtlpGrpcLogRecordExporter _createExporter(int port, {int maxRetries = 2}) {
+  return OtlpGrpcLogRecordExporter(
+    OtlpGrpcLogRecordExporterConfig(
+      endpoint: 'http://localhost:$port',
+      insecure: true,
+      maxRetries: maxRetries,
+      baseDelay: const Duration(milliseconds: 1),
+      maxDelay: const Duration(milliseconds: 10),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // =========================================================================
+  // Config tests
+  // =========================================================================
+  group('OtlpGrpcLogRecordExporterConfig', () {
+    group('default values', () {
+      test('default config has expected values', () {
+        final config = OtlpGrpcLogRecordExporterConfig();
+
+        expect(config.endpoint, equals('localhost:4317'));
+        expect(config.headers, isEmpty);
+        expect(config.timeout, equals(const Duration(seconds: 10)));
+        expect(config.compression, isFalse);
+        expect(config.insecure, isTrue);
+        expect(config.maxRetries, equals(3));
+        expect(config.baseDelay, equals(const Duration(milliseconds: 100)));
+        expect(config.maxDelay, equals(const Duration(seconds: 1)));
+        expect(config.certificate, isNull);
+        expect(config.clientKey, isNull);
+        expect(config.clientCertificate, isNull);
+      });
+    });
+
+    group('endpoint validation', () {
+      test('custom endpoint is preserved', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'collector.example.com:4317',
+        );
+        expect(config.endpoint, equals('collector.example.com:4317'));
+      });
+
+      test('empty endpoint throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(endpoint: ''),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('empty'),
+            ),
+          ),
+        );
+      });
+
+      test('endpoint with spaces throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(endpoint: 'host name:4317'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('spaces'),
+            ),
+          ),
+        );
+      });
+
+      test('endpoint without port gets :4317 appended', () {
+        final config = OtlpGrpcLogRecordExporterConfig(endpoint: 'localhost');
+        expect(config.endpoint, equals('localhost:4317'));
+      });
+
+      test('endpoint with http:// scheme is stripped', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'http://collector:4317',
+        );
+        expect(config.endpoint, equals('collector:4317'));
+      });
+
+      test('endpoint with https:// scheme is stripped', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'https://collector:4317',
+        );
+        expect(config.endpoint, equals('collector:4317'));
+      });
+
+      test('host-only endpoint gets default port appended', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'collector.example.com',
+        );
+        expect(config.endpoint, equals('collector.example.com:4317'));
+      });
+    });
+
+    group('header validation', () {
+      test('custom headers are normalized to lowercase keys', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          headers: {'Authorization': 'Bearer token123', 'X-Custom': 'value'},
+        );
+        expect(
+          config.headers,
+          containsPair('authorization', 'Bearer token123'),
+        );
+        expect(config.headers, containsPair('x-custom', 'value'));
+        expect(config.headers.containsKey('Authorization'), isFalse);
+      });
+
+      test('empty header key throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(headers: {'': 'value'}),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('empty'),
+            ),
+          ),
+        );
+      });
+
+      test('empty header value throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(headers: {'key': ''}),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('empty'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('retry validation', () {
+      test('negative maxRetries throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(maxRetries: -1),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('negative'),
+            ),
+          ),
+        );
+      });
+
+      test('zero retries is valid', () {
+        final config = OtlpGrpcLogRecordExporterConfig(maxRetries: 0);
+        expect(config.maxRetries, equals(0));
+      });
+
+      test('positive maxRetries is valid', () {
+        final config = OtlpGrpcLogRecordExporterConfig(maxRetries: 10);
+        expect(config.maxRetries, equals(10));
+      });
+    });
+
+    group('timeout validation', () {
+      test('timeout below 1ms throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(timeout: Duration.zero),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Timeout'),
+            ),
+          ),
+        );
+      });
+
+      test('timeout above 10 minutes throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(
+            timeout: const Duration(minutes: 10, milliseconds: 1),
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Timeout'),
+            ),
+          ),
+        );
+      });
+
+      test('timeout at lower bound (1ms) is valid', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          timeout: const Duration(milliseconds: 1),
+        );
+        expect(config.timeout, equals(const Duration(milliseconds: 1)));
+      });
+
+      test('timeout at upper bound (10 minutes) is valid', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          timeout: const Duration(minutes: 10),
+        );
+        expect(config.timeout, equals(const Duration(minutes: 10)));
+      });
+    });
+
+    group('delay validation', () {
+      test('baseDelay below 1ms throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(baseDelay: Duration.zero),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('baseDelay'),
+            ),
+          ),
+        );
+      });
+
+      test('maxDelay below 1ms throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: Duration.zero,
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('maxDelay'),
+            ),
+          ),
+        );
+      });
+
+      test('baseDelay above 5 minutes throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(
+            baseDelay: const Duration(minutes: 5, milliseconds: 1),
+            maxDelay: const Duration(minutes: 5, milliseconds: 2),
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('baseDelay'),
+            ),
+          ),
+        );
+      });
+
+      test('maxDelay above 5 minutes throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(
+            maxDelay: const Duration(minutes: 5, milliseconds: 1),
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('maxDelay'),
+            ),
+          ),
+        );
+      });
+
+      test('baseDelay greater than maxDelay throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(
+            baseDelay: const Duration(seconds: 2),
+            maxDelay: const Duration(seconds: 1),
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('maxDelay cannot be less than baseDelay'),
+            ),
+          ),
+        );
+      });
+
+      test('baseDelay equal to maxDelay is valid', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          baseDelay: const Duration(seconds: 1),
+          maxDelay: const Duration(seconds: 1),
+        );
+        expect(config.baseDelay, equals(const Duration(seconds: 1)));
+        expect(config.maxDelay, equals(const Duration(seconds: 1)));
+      });
+    });
+
+    group('flags', () {
+      test('insecure flag is set correctly', () {
+        final insecureConfig = OtlpGrpcLogRecordExporterConfig(insecure: true);
+        expect(insecureConfig.insecure, isTrue);
+
+        final secureConfig = OtlpGrpcLogRecordExporterConfig(insecure: false);
+        expect(secureConfig.insecure, isFalse);
+      });
+
+      test('compression flag is set correctly', () {
+        final compressedConfig =
+            OtlpGrpcLogRecordExporterConfig(compression: true);
+        expect(compressedConfig.compression, isTrue);
+
+        final uncompressedConfig =
+            OtlpGrpcLogRecordExporterConfig(compression: false);
+        expect(uncompressedConfig.compression, isFalse);
+      });
+    });
+
+    group('certificate validation', () {
+      test('clientKey without clientCertificate throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(clientKey: 'some-key'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('clientCertificate without clientKey throws ArgumentError', () {
+        expect(
+          () => OtlpGrpcLogRecordExporterConfig(clientCertificate: 'some-cert'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('all certificate fields null is valid', () {
+        final config = OtlpGrpcLogRecordExporterConfig();
+        expect(config.certificate, isNull);
+        expect(config.clientKey, isNull);
+        expect(config.clientCertificate, isNull);
+      });
+    });
+
+    group('custom values', () {
+      test('all custom values are preserved', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'otel-collector:4317',
+          headers: {'x-api-key': 'secret'},
+          timeout: const Duration(seconds: 30),
+          compression: true,
+          insecure: false,
+          maxRetries: 5,
+          baseDelay: const Duration(milliseconds: 200),
+          maxDelay: const Duration(seconds: 5),
+        );
+
+        expect(config.endpoint, equals('otel-collector:4317'));
+        expect(config.headers, containsPair('x-api-key', 'secret'));
+        expect(config.timeout, equals(const Duration(seconds: 30)));
+        expect(config.compression, isTrue);
+        expect(config.insecure, isFalse);
+        expect(config.maxRetries, equals(5));
+        expect(config.baseDelay, equals(const Duration(milliseconds: 200)));
+        expect(config.maxDelay, equals(const Duration(seconds: 5)));
+      });
+    });
+  });
+
+  // =========================================================================
+  // Exporter tests
+  // =========================================================================
+  group('OtlpGrpcLogRecordExporter', () {
+    setUp(() async {
+      await OTel.reset();
+      OTelLog.logFunction = (_) {};
+
+      await OTel.initialize(
+        serviceName: 'test-log-service',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+      OTelLog.enableTraceLogging();
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+      OTelLog.logFunction = null;
+    });
+
+    // -----------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------
+    group('constructor', () {
+      test('creates exporter with default config', () {
+        final exporter = OtlpGrpcLogRecordExporter();
+        expect(exporter, isNotNull);
+      });
+
+      test('creates exporter with custom config', () {
+        final config = OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'collector:4317',
+          maxRetries: 5,
+        );
+        final exporter = OtlpGrpcLogRecordExporter(config);
+        expect(exporter, isNotNull);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Export with empty records returns success immediately
+    // -----------------------------------------------------------------------
+    test('export with empty records returns success', () async {
+      final exporter = OtlpGrpcLogRecordExporter();
+      final result = await exporter.export([]);
+      expect(result, equals(ExportResult.success));
+      await exporter.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Export after shutdown returns failure
+    // -----------------------------------------------------------------------
+    test('export after shutdown returns failure', () async {
+      final exporter = OtlpGrpcLogRecordExporter();
+      await exporter.shutdown();
+
+      final logRecord = _createTestLogRecord();
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+    });
+
+    // -----------------------------------------------------------------------
+    // Shutdown idempotency
+    // -----------------------------------------------------------------------
+    test('shutdown is idempotent', () async {
+      final exporter = OtlpGrpcLogRecordExporter();
+
+      // Multiple shutdowns should not throw
+      await exporter.shutdown();
+      await exporter.shutdown();
+      await exporter.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // ForceFlush when not shut down and no pending exports
+    // -----------------------------------------------------------------------
+    test('forceFlush with no pending exports completes immediately', () async {
+      final exporter = OtlpGrpcLogRecordExporter();
+      await exporter.forceFlush();
+      await exporter.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // ForceFlush after shutdown returns immediately
+    // -----------------------------------------------------------------------
+    test('forceFlush after shutdown returns immediately', () async {
+      final exporter = OtlpGrpcLogRecordExporter();
+      await exporter.shutdown();
+      await exporter.forceFlush();
+    });
+
+    // -----------------------------------------------------------------------
+    // Successful export to a real gRPC service
+    // -----------------------------------------------------------------------
+    test('successful export returns success', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Export multiple log records
+    // -----------------------------------------------------------------------
+    test('export multiple log records succeeds', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      final logRecords = List.generate(
+        5,
+        (i) => _createTestLogRecord(body: 'Message $i'),
+      );
+
+      final result = await exporter.export(logRecords);
+      expect(result, equals(ExportResult.success));
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Export with compression headers enabled
+    // -----------------------------------------------------------------------
+    test('export with compression headers enabled', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      final exporter = OtlpGrpcLogRecordExporter(
+        OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'http://localhost:$port',
+          insecure: true,
+          compression: true,
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
+
+      final logRecord = _createTestLogRecord();
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Export with custom headers
+    // -----------------------------------------------------------------------
+    test('export with custom headers', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      final exporter = OtlpGrpcLogRecordExporter(
+        OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'http://localhost:$port',
+          insecure: true,
+          headers: {'x-api-key': 'test-key'},
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
+
+      final logRecord = _createTestLogRecord();
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Shutdown during active export suppresses error
+    // -----------------------------------------------------------------------
+    test('shutdown during active export suppresses error', () async {
+      final service = SlowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+      final logRecord = _createTestLogRecord();
+
+      // Start an export that will block in the slow service
+      final exportFuture = exporter.export([logRecord]);
+
+      // Wait until the service has actually received the request
+      await service.exportStarted.future;
+
+      // Shut down the exporter while the export is in flight
+      final shutdownFuture = exporter.shutdown();
+
+      // Allow the slow service to complete
+      service.shouldComplete.complete();
+
+      // Both should complete without throwing
+      final result = await exportFuture;
+      await shutdownFuture;
+
+      // The result may be success or failure depending on timing
+      expect(result, isA<ExportResult>());
+
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Non-retryable gRPC error (e.g., INTERNAL) returns failure
+    // The gRPC framework wraps server exceptions as GrpcError(UNKNOWN).
+    // -----------------------------------------------------------------------
+    test('server handler exception returns failure', () async {
+      final service = GenericThrowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 1);
+      final logRecord = _createTestLogRecord();
+
+      // The log exporter catches all errors in export() and returns failure
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      // UNKNOWN is non-retryable, so only 1 call to the service
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // INTERNAL error triggers channel recreation
+    // -----------------------------------------------------------------------
+    test('INTERNAL error triggers channel recreation and returns failure',
+        () async {
+      final service = ConfigurableErrorLogsService(
+        failCount: 1,
+        failCode: StatusCode.internal,
+      );
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      // INTERNAL is not in _retryableStatusCodes, so it returns failure
+      final exporter = _createExporter(port, maxRetries: 0);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // UNAVAILABLE error triggers channel recreation AND is retryable
+    // -----------------------------------------------------------------------
+    test('UNAVAILABLE error triggers retry and succeeds', () async {
+      // Fail once with UNAVAILABLE, then succeed on second attempt
+      final service = ConfigurableErrorLogsService(
+        failCount: 1,
+        failCode: StatusCode.unavailable,
+      );
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 2);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+
+      // First call fails, second succeeds
+      expect(service.callCount, equals(2));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // RESOURCE_EXHAUSTED error is retryable
+    // -----------------------------------------------------------------------
+    test('RESOURCE_EXHAUSTED error triggers retry and succeeds', () async {
+      final service = ConfigurableErrorLogsService(
+        failCount: 1,
+        failCode: StatusCode.resourceExhausted,
+      );
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 2);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+      expect(service.callCount, equals(2));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // UNKNOWN error triggers channel recreation
+    // -----------------------------------------------------------------------
+    test('UNKNOWN error triggers channel recreation', () async {
+      final service = ConfigurableErrorLogsService(
+        failCount: 1,
+        failCode: StatusCode.unknown,
+      );
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      // UNKNOWN is not in _retryableStatusCodes, so export fails
+      final exporter = _createExporter(port, maxRetries: 0);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Max retries exhausted with retryable error returns failure
+    // -----------------------------------------------------------------------
+    test('max retries exhausted returns failure', () async {
+      final service = AlwaysUnavailableLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 2);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      // Initial attempt + 2 retries = 3 calls
+      expect(service.callCount, equals(3));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Max retries exhausted with RESOURCE_EXHAUSTED error returns failure
+    // -----------------------------------------------------------------------
+    test('max retries exhausted with RESOURCE_EXHAUSTED returns failure',
+        () async {
+      final service = AlwaysResourceExhaustedLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 1);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      // Initial attempt + 1 retry = 2 calls
+      expect(service.callCount, equals(2));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Non-retryable gRPC error (e.g., PERMISSION_DENIED)
+    // -----------------------------------------------------------------------
+    test('non-retryable gRPC error does not retry', () async {
+      final service = ConfigurableErrorLogsService(
+        failCount: 10,
+        failCode: StatusCode.permissionDenied,
+      );
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 5);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      // Non-retryable: only 1 call
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Generic (non-gRPC) error during export uses generic catch block.
+    // We use a connection-refusing port approach: connect to a port where
+    // nothing is listening, with a short timeout so the gRPC client fails
+    // quickly rather than hanging.
+    // -----------------------------------------------------------------------
+    test(
+      'connection refused exercises generic error handling',
+      () async {
+        // Bind and immediately close to get a port that refuses connections
+        final tempServer = await ServerSocket.bind('127.0.0.1', 0);
+        final port = tempServer.port;
+        await tempServer.close();
+
+        final exporter = OtlpGrpcLogRecordExporter(
+          OtlpGrpcLogRecordExporterConfig(
+            endpoint: '127.0.0.1:$port',
+            insecure: true,
+            maxRetries: 0,
+            timeout: const Duration(seconds: 3),
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        );
+        final logRecord = _createTestLogRecord();
+
+        final result = await exporter.export([logRecord]);
+        expect(result, equals(ExportResult.failure));
+
+        await exporter.shutdown();
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
+
+    // -----------------------------------------------------------------------
+    // Generic error with retries: connection refused with retries exhausted
+    // -----------------------------------------------------------------------
+    test(
+      'connection refused with retries exhausted returns failure',
+      () async {
+        final tempServer = await ServerSocket.bind('127.0.0.1', 0);
+        final port = tempServer.port;
+        await tempServer.close();
+
+        final exporter = OtlpGrpcLogRecordExporter(
+          OtlpGrpcLogRecordExporterConfig(
+            endpoint: '127.0.0.1:$port',
+            insecure: true,
+            maxRetries: 1,
+            timeout: const Duration(seconds: 3),
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        );
+        final logRecord = _createTestLogRecord();
+
+        final result = await exporter.export([logRecord]);
+        expect(result, equals(ExportResult.failure));
+
+        await exporter.shutdown();
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
+
+    // -----------------------------------------------------------------------
+    // ForceFlush with pending export waits for completion
+    // -----------------------------------------------------------------------
+    test('forceFlush with pending export waits for completion', () async {
+      final service = SlowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+      final logRecord = _createTestLogRecord();
+
+      // Start export (it will block in slow service)
+      // ignore: unawaited_futures
+      final exportFuture = exporter.export([logRecord]);
+
+      // Wait until the service has received the export call
+      await service.exportStarted.future;
+
+      // Start forceFlush - it should wait for the pending export
+      bool flushCompleted = false;
+      final flushFuture = exporter.forceFlush().then((_) {
+        flushCompleted = true;
+      });
+
+      // Flush should not have completed yet
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(flushCompleted, isFalse);
+
+      // Now let the export complete
+      service.shouldComplete.complete();
+
+      // Both should finish
+      await exportFuture;
+      await flushFuture;
+      expect(flushCompleted, isTrue);
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // ForceFlush catches error from pending failed export
+    // -----------------------------------------------------------------------
+    test('forceFlush catches error from pending failed export', () async {
+      final service = GenericThrowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 0);
+      final logRecord = _createTestLogRecord();
+
+      // Start export (it will fail)
+      // ignore: unawaited_futures
+      final exportFuture = exporter.export([logRecord]);
+
+      // Give a small delay for the export to start
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Force flush should handle the error gracefully (not throw)
+      await exporter.forceFlush();
+
+      // Wait for the export to finish
+      final result = await exportFuture;
+      expect(result, equals(ExportResult.failure));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Shutdown with pending exports completes
+    // -----------------------------------------------------------------------
+    test('shutdown with pending exports completes', () async {
+      final service = SlowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+      final logRecord = _createTestLogRecord();
+
+      // Start export that will block
+      // ignore: unawaited_futures
+      final exportFuture = exporter.export([logRecord]);
+
+      // Wait until the service has received the request
+      await service.exportStarted.future;
+
+      // Complete the slow service so export finishes before shutdown timeout
+      Future<void>.delayed(const Duration(milliseconds: 100)).then((_) {
+        service.shouldComplete.complete();
+      });
+
+      await exporter.shutdown();
+
+      // The export should complete
+      try {
+        await exportFuture;
+      } catch (_) {
+        // Shutdown errors are acceptable
+      }
+
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Shutdown timeout path when export never completes
+    // -----------------------------------------------------------------------
+    test(
+      'shutdown times out when export hangs',
+      () async {
+        final service = SlowLogsService();
+        final server = Server.create(services: [service]);
+        await server.serve(port: 0);
+        final port = server.port!;
+        final exporter = _createExporter(port);
+        final logRecord = _createTestLogRecord();
+
+        // Start an export that will never complete
+        // ignore: unawaited_futures
+        final exportFuture = exporter.export([logRecord]).catchError(
+          (Object e) => ExportResult.failure,
+        );
+
+        // Wait for the export to start
+        await service.exportStarted.future;
+
+        // Shutdown should complete via its 10s internal timeout
+        await exporter.shutdown().timeout(
+              const Duration(seconds: 15),
+              onTimeout: () =>
+                  fail('shutdown should complete within its internal timeout'),
+            );
+
+        // Clean up
+        service.shouldComplete.complete();
+        try {
+          await exportFuture;
+        } catch (_) {
+          // Expected
+        }
+
+        await server.shutdown();
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    // -----------------------------------------------------------------------
+    // Secure credentials path (no certificates)
+    // -----------------------------------------------------------------------
+    test('secure mode without certificates exercises secure path', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      final exporter = OtlpGrpcLogRecordExporter(
+        OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'http://localhost:$port',
+          insecure: false, // Triggers secure credentials path
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
+
+      final logRecord = _createTestLogRecord();
+
+      // Export will fail due to TLS mismatch but the secure credential
+      // creation path is exercised
+      final result = await exporter.export([logRecord]);
+      // Failure expected due to TLS mismatch
+      expect(result, isA<ExportResult>());
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Shutdown during retry stops retrying
+    // -----------------------------------------------------------------------
+    test('shutdown during retry stops retrying', () async {
+      final service = AlwaysUnavailableLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      // Use higher maxRetries so the export loop runs longer
+      final exporter = _createExporter(port, maxRetries: 10);
+      final logRecord = _createTestLogRecord();
+
+      // Start the export - it will keep retrying due to UNAVAILABLE
+      final exportFuture = exporter.export([logRecord]);
+
+      // Wait for at least one retry attempt, then shut down
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      await exporter.shutdown();
+
+      // The export should return failure (not hang)
+      final result = await exportFuture;
+      expect(result, equals(ExportResult.failure));
+
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // _cleanupChannel handles errors gracefully during shutdown
+    // -----------------------------------------------------------------------
+    test('cleanup channel handles errors gracefully during shutdown', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      // Initialize the channel with a successful export
+      final logRecord = _createTestLogRecord();
+      await exporter.export([logRecord]);
+
+      // Kill the server before shutdown to force channel cleanup errors
+      await server.shutdown();
+
+      // Shutdown should still complete gracefully
+      await exporter.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // _setupChannel returns early when shutdown
+    // -----------------------------------------------------------------------
+    test('export after shutdown prevents channel setup', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      // First export to initialize channel
+      final logRecord1 = _createTestLogRecord(body: 'init');
+      await exporter.export([logRecord1]);
+
+      // Shutdown
+      await exporter.shutdown();
+
+      // Trying to export again should return failure (not throw)
+      final logRecord2 = _createTestLogRecord(body: 'after-shutdown');
+      final result = await exporter.export([logRecord2]);
+      expect(result, equals(ExportResult.failure));
+
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Multiple concurrent exports are tracked in _pendingExports
+    // -----------------------------------------------------------------------
+    test('multiple concurrent exports are tracked', () async {
+      final service = SlowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      final logRecord = _createTestLogRecord();
+
+      // Start an export that will block
+      // ignore: unawaited_futures
+      final exportFuture = exporter.export([logRecord]);
+
+      // Wait for it to start
+      await service.exportStarted.future;
+
+      // Call forceFlush to exercise the pending exports path
+      Future<void>.delayed(const Duration(milliseconds: 50)).then((_) {
+        service.shouldComplete.complete();
+      });
+
+      await exporter.forceFlush();
+      await exportFuture;
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Generic error with shutdown during retry returns failure
+    // -----------------------------------------------------------------------
+    test('generic error with shutdown during retry returns failure', () async {
+      final service = GenericThrowLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      // Use higher maxRetries to give time for shutdown during retries
+      final exporter = _createExporter(port, maxRetries: 10);
+      final logRecord = _createTestLogRecord();
+
+      final exportFuture = exporter.export([logRecord]);
+
+      // Wait for the first attempt to fail and retry to start
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Shutdown during the retry loop
+      await exporter.shutdown();
+
+      final result = await exportFuture;
+      expect(result, equals(ExportResult.failure));
+
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Empty records returns success even with debug logging enabled
+    // -----------------------------------------------------------------------
+    test('empty records with debug logging returns success', () async {
+      final logMessages = <String>[];
+      OTelLog.logFunction = logMessages.add;
+      OTelLog.enableTraceLogging();
+
+      final exporter = OtlpGrpcLogRecordExporter();
+      final result = await exporter.export([]);
+      expect(result, equals(ExportResult.success));
+
+      expect(
+        logMessages.any((msg) => msg.contains('No log records to export')),
+        isTrue,
+      );
+
+      await exporter.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Debug logging covers key export code paths
+    // -----------------------------------------------------------------------
+    test('debug logging covers all export code paths', () async {
+      final logMessages = <String>[];
+      OTelLog.logFunction = logMessages.add;
+      OTelLog.enableTraceLogging();
+
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+      final logRecord = _createTestLogRecord(
+        body: 'debug-logging-test',
+        attributes: {'test.key': 'test.value'},
+      );
+
+      await exporter.export([logRecord]);
+
+      // Verify key log messages were emitted
+      expect(
+        logMessages.any((msg) => msg.contains('Setting up gRPC channel')),
+        isTrue,
+      );
+      expect(
+        logMessages.any(
+          (msg) => msg.contains('Successfully created LogsServiceClient'),
+        ),
+        isTrue,
+      );
+      expect(
+        logMessages.any(
+          (msg) => msg.contains('Export request completed successfully'),
+        ),
+        isTrue,
+      );
+
+      await exporter.shutdown();
+
+      // Verify shutdown logs
+      expect(
+        logMessages.any((msg) => msg.contains('Shutdown requested')),
+        isTrue,
+      );
+
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Endpoint parsing: localhost is converted to 127.0.0.1
+    // -----------------------------------------------------------------------
+    test('endpoint localhost is converted to 127.0.0.1', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
+      final exporter = OtlpGrpcLogRecordExporter(
+        OtlpGrpcLogRecordExporterConfig(
+          endpoint: 'localhost:$port',
+          insecure: true,
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
+
+      final logRecord = _createTestLogRecord();
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Endpoint without port gets default 4317
+    // (testing the _setupChannel parsing)
+    // -----------------------------------------------------------------------
+    test('endpoint empty host defaults to 127.0.0.1', () async {
+      // This exercises the empty host fallback in _setupChannel
+      final exporter = OtlpGrpcLogRecordExporter(
+        OtlpGrpcLogRecordExporterConfig(
+          endpoint: ':4317',
+          insecure: true,
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
+
+      final logRecord = _createTestLogRecord();
+      // This will fail to connect but exercises the host parsing path
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      await exporter.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Zero retries (maxRetries=0) means single attempt
+    // -----------------------------------------------------------------------
+    test('zero retries means single attempt', () async {
+      final service = AlwaysUnavailableLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port, maxRetries: 0);
+      final logRecord = _createTestLogRecord();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      // Only 1 attempt, no retries
+      expect(service.callCount, equals(1));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // _ensureChannel short-circuits when already initialized
+    // -----------------------------------------------------------------------
+    test('second export reuses existing channel', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      final logRecord1 = _createTestLogRecord(body: 'first');
+      final logRecord2 = _createTestLogRecord(body: 'second');
+
+      final result1 = await exporter.export([logRecord1]);
+      final result2 = await exporter.export([logRecord2]);
+
+      expect(result1, equals(ExportResult.success));
+      expect(result2, equals(ExportResult.success));
+      expect(service.callCount, equals(2));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Export with log record that has attributes
+    // -----------------------------------------------------------------------
+    test('export log record with attributes', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      final logRecord = _createTestLogRecord(
+        body: 'with attrs',
+        severity: Severity.ERROR,
+        attributes: {
+          'string.attr': 'hello',
+          'int.attr': 42,
+          'bool.attr': true,
+          'double.attr': 3.14,
+        },
+      );
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+
+    // -----------------------------------------------------------------------
+    // Export with various severity levels
+    // -----------------------------------------------------------------------
+    test('export log records with different severities', () async {
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+      final exporter = _createExporter(port);
+
+      final records = [
+        _createTestLogRecord(body: 'trace msg', severity: Severity.TRACE),
+        _createTestLogRecord(body: 'debug msg', severity: Severity.DEBUG),
+        _createTestLogRecord(body: 'info msg', severity: Severity.INFO),
+        _createTestLogRecord(body: 'warn msg', severity: Severity.WARN),
+        _createTestLogRecord(body: 'error msg', severity: Severity.ERROR),
+        _createTestLogRecord(body: 'fatal msg', severity: Severity.FATAL),
+      ];
+
+      final result = await exporter.export(records);
+      expect(result, equals(ExportResult.success));
+
+      await exporter.shutdown();
+      await server.shutdown();
+    });
+  });
+}

--- a/test/unit/logs/export/simple_log_record_processor_test.dart
+++ b/test/unit/logs/export/simple_log_record_processor_test.dart
@@ -1,0 +1,130 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('SimpleLogRecordProcessor Tests', () {
+    late MemoryLogRecordExporter exporter;
+    late SimpleLogRecordProcessor processor;
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'simple-processor-test',
+        detectPlatformResources: false,
+      );
+
+      exporter = MemoryLogRecordExporter();
+      processor = SimpleLogRecordProcessor(exporter);
+      scope = OTel.instrumentationScope(name: 'test-scope', version: '1.0.0');
+    });
+
+    tearDown(() async {
+      await processor.shutdown();
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('SimpleLogRecordProcessor exports log records immediately', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test message',
+      );
+
+      await processor.onEmit(logRecord, null);
+
+      expect(exporter.count, equals(1));
+      expect(exporter.exportedLogRecords.first.body, equals('Test message'));
+    });
+
+    test('SimpleLogRecordProcessor exports multiple log records', () async {
+      for (int i = 0; i < 5; i++) {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'Message $i',
+        );
+        await processor.onEmit(logRecord, null);
+      }
+
+      expect(exporter.count, equals(5));
+    });
+
+    test('SimpleLogRecordProcessor enabled returns true by default', () {
+      expect(processor.enabled(), isTrue);
+    });
+
+    test('SimpleLogRecordProcessor shutdown stops processing', () async {
+      await processor.shutdown();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Should not be exported',
+      );
+
+      await processor.onEmit(logRecord, null);
+
+      // Should not export after shutdown
+      expect(exporter.count, equals(0));
+    });
+
+    test('SimpleLogRecordProcessor forceFlush calls exporter forceFlush',
+        () async {
+      // forceFlush should complete without error
+      await expectLater(processor.forceFlush(), completes);
+    });
+
+    test('SimpleLogRecordProcessor handles export failure gracefully',
+        () async {
+      // Create a failing exporter
+      final failingExporter = _FailingLogRecordExporter();
+      final failingProcessor = SimpleLogRecordProcessor(failingExporter);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test message',
+      );
+
+      // Should not throw
+      await expectLater(
+        failingProcessor.onEmit(logRecord, null),
+        completes,
+      );
+    });
+
+    test('SimpleLogRecordProcessor passes context to exporter', () async {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test message',
+      );
+
+      final context = Context.current;
+      await processor.onEmit(logRecord, context);
+
+      expect(exporter.count, equals(1));
+    });
+  });
+}
+
+/// A log record exporter that always fails for testing error handling.
+class _FailingLogRecordExporter implements LogRecordExporter {
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    return ExportResult.failure;
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}

--- a/test/unit/logs/logger_provider_test.dart
+++ b/test/unit/logs/logger_provider_test.dart
@@ -18,10 +18,12 @@ void main() {
       memoryExporter = MemoryLogRecordExporter();
       processor = SimpleLogRecordProcessor(memoryExporter);
 
-      // Initialize OTel
+      // Initialize OTel without auto-configuration of logs
+      // (so we can test processor management manually)
       await OTel.initialize(
         serviceName: 'logger-provider-test-service',
         detectPlatformResources: false,
+        enableLogs: false,
       );
 
       // Add the processor to the logger provider

--- a/test/unit/logs/logger_provider_test.dart
+++ b/test/unit/logs/logger_provider_test.dart
@@ -1,0 +1,163 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('LoggerProvider Tests', () {
+    late MemoryLogRecordExporter memoryExporter;
+    late SimpleLogRecordProcessor processor;
+
+    setUp(() async {
+      await OTel.reset();
+
+      // Create a memory exporter for verification
+      memoryExporter = MemoryLogRecordExporter();
+      processor = SimpleLogRecordProcessor(memoryExporter);
+
+      // Initialize OTel
+      await OTel.initialize(
+        serviceName: 'logger-provider-test-service',
+        detectPlatformResources: false,
+      );
+
+      // Add the processor to the logger provider
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('LoggerProvider exposes service information', () {
+      final loggerProvider = OTel.loggerProvider();
+
+      expect(
+          loggerProvider.serviceName, equals('logger-provider-test-service'));
+
+      // Modify service information
+      loggerProvider.serviceName = 'updated-service-name';
+      loggerProvider.serviceVersion = '1.2.3';
+      loggerProvider.endpoint = 'https://updated.endpoint';
+
+      expect(loggerProvider.serviceName, equals('updated-service-name'));
+      expect(loggerProvider.serviceVersion, equals('1.2.3'));
+      expect(loggerProvider.endpoint, equals('https://updated.endpoint'));
+    });
+
+    test('LoggerProvider can be enabled and disabled', () {
+      final loggerProvider = OTel.loggerProvider();
+
+      // By default, enabled is true
+      expect(loggerProvider.enabled, isTrue);
+
+      // Disable logger provider
+      loggerProvider.enabled = false;
+      expect(loggerProvider.enabled, isFalse);
+
+      // Re-enable
+      loggerProvider.enabled = true;
+      expect(loggerProvider.enabled, isTrue);
+    });
+
+    test('LoggerProvider returns same logger for same configuration', () {
+      final loggerProvider = OTel.loggerProvider();
+
+      final logger1 = loggerProvider.getLogger('test-logger');
+      final logger2 = loggerProvider.getLogger('test-logger');
+      final logger3 = loggerProvider.getLogger('different-logger');
+
+      expect(identical(logger1, logger2), isTrue);
+      expect(identical(logger1, logger3), isFalse);
+    });
+
+    test('LoggerProvider returns different loggers for different versions', () {
+      final loggerProvider = OTel.loggerProvider();
+
+      final logger1 = loggerProvider.getLogger('test-logger', version: '1.0.0');
+      final logger2 = loggerProvider.getLogger('test-logger', version: '2.0.0');
+
+      expect(identical(logger1, logger2), isFalse);
+    });
+
+    test('LoggerProvider manages processors', () {
+      final loggerProvider = OTel.loggerProvider();
+
+      // Should have our processor
+      expect(loggerProvider.logRecordProcessors.length, equals(1));
+
+      // Add another processor
+      final anotherExporter = MemoryLogRecordExporter();
+      final anotherProcessor = SimpleLogRecordProcessor(anotherExporter);
+      loggerProvider.addLogRecordProcessor(anotherProcessor);
+
+      expect(loggerProvider.logRecordProcessors.length, equals(2));
+    });
+
+    test('LoggerProvider throws when getting logger after shutdown', () async {
+      final loggerProvider = OTel.loggerProvider();
+      await loggerProvider.shutdown();
+
+      expect(
+        () => loggerProvider.getLogger('test-logger'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('LoggerProvider throws when adding processor after shutdown',
+        () async {
+      final loggerProvider = OTel.loggerProvider();
+      await loggerProvider.shutdown();
+
+      expect(
+        () => loggerProvider.addLogRecordProcessor(
+          SimpleLogRecordProcessor(MemoryLogRecordExporter()),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('LoggerProvider shutdown calls processor shutdown', () async {
+      final loggerProvider = OTel.loggerProvider();
+
+      expect(loggerProvider.isShutdown, isFalse);
+
+      await loggerProvider.shutdown();
+
+      expect(loggerProvider.isShutdown, isTrue);
+    });
+
+    test('LoggerProvider forceFlush flushes all processors', () async {
+      final loggerProvider = OTel.loggerProvider();
+      final logger = loggerProvider.getLogger('test-logger');
+
+      // Emit some logs
+      logger.info('Test message 1');
+      logger.info('Test message 2');
+
+      // Force flush
+      await loggerProvider.forceFlush();
+
+      // Verify logs were exported
+      expect(memoryExporter.count, equals(2));
+    });
+
+    test('LoggerProvider sets resource correctly', () {
+      final loggerProvider = OTel.loggerProvider();
+
+      expect(loggerProvider.resource, isNotNull);
+
+      // Check service name in resource
+      final attrs = loggerProvider.resource!.attributes.toList();
+      final serviceName = attrs.firstWhere(
+        (a) => a.key == 'service.name',
+        orElse: () => throw StateError('service.name not found'),
+      );
+      expect(serviceName.value, equals('logger-provider-test-service'));
+    });
+  });
+}

--- a/test/unit/logs/logger_test.dart
+++ b/test/unit/logs/logger_test.dart
@@ -20,6 +20,8 @@ void main() {
       await OTel.initialize(
         serviceName: 'logger-test-service',
         detectPlatformResources: false,
+        enableLogs:
+            false, // Disable auto-configuration so we control processors manually
       );
 
       OTel.loggerProvider().addLogRecordProcessor(processor);
@@ -162,6 +164,8 @@ void main() {
       await OTel.initialize(
         serviceName: 'no-processor-test',
         detectPlatformResources: false,
+        enableLogs:
+            false, // Disable auto-configuration to test no-processor behavior
       );
 
       final logger = OTel.logger('test-logger');
@@ -181,6 +185,8 @@ void main() {
       await OTel.initialize(
         serviceName: 'disabled-test',
         detectPlatformResources: false,
+        enableLogs:
+            false, // Disable auto-configuration to test disabled behavior
       );
 
       // No processor added, logger should be disabled

--- a/test/unit/logs/logger_test.dart
+++ b/test/unit/logs/logger_test.dart
@@ -1,0 +1,239 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('Logger Tests', () {
+    late MemoryLogRecordExporter memoryExporter;
+    late SimpleLogRecordProcessor processor;
+
+    setUp(() async {
+      await OTel.reset();
+
+      memoryExporter = MemoryLogRecordExporter();
+      processor = SimpleLogRecordProcessor(memoryExporter);
+
+      await OTel.initialize(
+        serviceName: 'logger-test-service',
+        detectPlatformResources: false,
+      );
+
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('Logger has correct name and attributes', () {
+      final logger = OTel.loggerProvider().getLogger(
+        'test-logger',
+        version: '1.0.0',
+      );
+
+      expect(logger.name, equals('test-logger'));
+      expect(logger.version, equals('1.0.0'));
+    });
+
+    test('Logger emits log record with all fields', () {
+      final logger = OTel.logger('test-logger');
+      final timestamp = DateTime.now();
+      final attributes = OTel.attributesFromMap({
+        'key1': 'value1',
+        'key2': 42,
+      });
+
+      logger.emit(
+        timeStamp: timestamp,
+        severityNumber: Severity.INFO,
+        severityText: 'INFO',
+        body: 'Test log message',
+        attributes: attributes,
+        eventName: 'test.event',
+      );
+
+      expect(memoryExporter.count, equals(1));
+
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.body, equals('Test log message'));
+      expect(logRecord.severityNumber, equals(Severity.INFO));
+      expect(logRecord.severityText, equals('INFO'));
+      expect(logRecord.eventName, equals('test.event'));
+      expect(logRecord.attributes, isNotNull);
+      expect(logRecord.observedTimestamp, isNotNull);
+    });
+
+    test('Logger trace() emits TRACE severity', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.trace('Trace message');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.severityNumber, equals(Severity.TRACE));
+      expect(logRecord.body, equals('Trace message'));
+    });
+
+    test('Logger debug() emits DEBUG severity', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.debug('Debug message');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.severityNumber, equals(Severity.DEBUG));
+      expect(logRecord.body, equals('Debug message'));
+    });
+
+    test('Logger info() emits INFO severity', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.info('Info message');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.severityNumber, equals(Severity.INFO));
+      expect(logRecord.body, equals('Info message'));
+    });
+
+    test('Logger warn() emits WARN severity', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.warn('Warning message');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.severityNumber, equals(Severity.WARN));
+      expect(logRecord.body, equals('Warning message'));
+    });
+
+    test('Logger error() emits ERROR severity', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.error('Error message');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.severityNumber, equals(Severity.ERROR));
+      expect(logRecord.body, equals('Error message'));
+    });
+
+    test('Logger fatal() emits FATAL severity', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.fatal('Fatal message');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.severityNumber, equals(Severity.FATAL));
+      expect(logRecord.body, equals('Fatal message'));
+    });
+
+    test('Logger convenience methods accept attributes', () {
+      final logger = OTel.logger('test-logger');
+      final attributes = OTel.attributesFromMap({'error.code': 500});
+
+      logger.error('Error with attributes', attributes: attributes);
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.attributes, isNotNull);
+      final attrs = logRecord.attributes!.toList();
+      expect(attrs.any((a) => a.key == 'error.code'), isTrue);
+    });
+
+    test('Logger convenience methods accept event name', () {
+      final logger = OTel.logger('test-logger');
+
+      logger.info('Event log', eventName: 'user.login');
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+      expect(logRecord.eventName, equals('user.login'));
+    });
+
+    test('Logger is disabled when provider has no processors', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'no-processor-test',
+        detectPlatformResources: false,
+      );
+
+      final logger = OTel.logger('test-logger');
+
+      // Logger should be disabled without processors
+      expect(logger.enabled, isFalse);
+    });
+
+    test('Logger is enabled with processors', () {
+      final logger = OTel.logger('test-logger');
+
+      expect(logger.enabled, isTrue);
+    });
+
+    test('Logger does not emit when disabled', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'disabled-test',
+        detectPlatformResources: false,
+      );
+
+      // No processor added, logger should be disabled
+      final logger = OTel.logger('test-logger');
+      logger.info('Should not be emitted');
+
+      // Nothing should be exported since we haven't added a processor
+      // to this new instance
+      expect(logger.enabled, isFalse);
+    });
+
+    test('Logger captures trace context from current span', () async {
+      await OTel.reset();
+
+      memoryExporter = MemoryLogRecordExporter();
+      processor = SimpleLogRecordProcessor(memoryExporter);
+
+      await OTel.initialize(
+        serviceName: 'trace-context-test',
+        detectPlatformResources: false,
+      );
+
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      final tracer = OTel.tracer();
+      final span = tracer.startSpan('test-span');
+
+      final logger = OTel.logger('test-logger');
+      logger.info('Log within span');
+
+      span.end();
+
+      expect(memoryExporter.count, equals(1));
+      final logRecord = memoryExporter.exportedLogRecords.first;
+
+      // Log record should have trace context from the active span
+      expect(logRecord.traceId, isNotNull);
+      expect(logRecord.spanId, isNotNull);
+      expect(logRecord.traceId!.isValid, isTrue);
+      expect(logRecord.spanId!.isValid, isTrue);
+    });
+
+    test('Logger provider reference is accessible', () {
+      final logger = OTel.logger('test-logger');
+
+      expect(logger.provider, isNotNull);
+      expect(logger.provider, equals(OTel.loggerProvider()));
+    });
+
+    test('Logger resource reference is accessible', () {
+      final logger = OTel.logger('test-logger');
+
+      expect(logger.resource, isNotNull);
+    });
+  });
+}

--- a/test/unit/logs/logs_config_test.dart
+++ b/test/unit/logs/logs_config_test.dart
@@ -1,0 +1,220 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('LogsConfiguration Tests', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test(
+        'configureLoggerProvider creates default exporter when no env vars set',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-config-test',
+        detectPlatformResources: false,
+        enableLogs: false, // Disable auto-config so we can test manual config
+      );
+
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        secure: false,
+        resource: OTel.defaultResource,
+      );
+
+      expect(provider, isNotNull);
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+    });
+
+    test('configureLoggerProvider uses custom exporter when provided',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-config-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final memoryExporter = MemoryLogRecordExporter();
+
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        secure: false,
+        logRecordExporter: memoryExporter,
+        resource: OTel.defaultResource,
+      );
+
+      expect(provider, isNotNull);
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+    });
+
+    test('configureLoggerProvider uses custom processor when provided',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-config-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final memoryExporter = MemoryLogRecordExporter();
+      final customProcessor = SimpleLogRecordProcessor(memoryExporter);
+
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        secure: false,
+        logRecordProcessor: customProcessor,
+        resource: OTel.defaultResource,
+      );
+
+      expect(provider, isNotNull);
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+    });
+
+    test('createSimpleProcessor creates SimpleLogRecordProcessor', () async {
+      await OTel.initialize(
+        serviceName: 'logs-config-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final memoryExporter = MemoryLogRecordExporter();
+      final processor = LogsConfiguration.createSimpleProcessor(memoryExporter);
+
+      expect(processor, isA<SimpleLogRecordProcessor>());
+    });
+  });
+
+  group('OTel.initialize with logs env vars', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('enableLogs=true auto-configures log exporter', () async {
+      await OTel.initialize(
+        serviceName: 'logs-env-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+
+      final provider = OTel.loggerProvider();
+      // With enableLogs=true, a processor should be added automatically
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+    });
+
+    test('enableLogs=false does not add log processor', () async {
+      await OTel.initialize(
+        serviceName: 'logs-env-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      // With enableLogs=false, no processor should be added
+      expect(provider.logRecordProcessors.length, equals(0));
+    });
+
+    test('custom logRecordExporter is used when provided', () async {
+      final memoryExporter = MemoryLogRecordExporter();
+
+      await OTel.initialize(
+        serviceName: 'logs-env-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+        logRecordExporter: memoryExporter,
+      );
+
+      final provider = OTel.loggerProvider();
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+
+      // Test that logs go to the memory exporter
+      final logger = OTel.logger('test-logger');
+      logger.emit(body: 'Test log message');
+
+      // Wait for batch processor to export (default schedule delay is 1 second)
+      // For batch processor, we need to wait longer or force flush
+      await provider.forceFlush();
+
+      expect(memoryExporter.count, equals(1));
+      expect(memoryExporter.exportedLogRecords.first.body,
+          equals('Test log message'));
+    });
+
+    test('custom logRecordProcessor is used when provided', () async {
+      final memoryExporter = MemoryLogRecordExporter();
+      final customProcessor = SimpleLogRecordProcessor(memoryExporter);
+
+      await OTel.initialize(
+        serviceName: 'logs-env-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+        logRecordProcessor: customProcessor,
+      );
+
+      final provider = OTel.loggerProvider();
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+
+      // Test that logs go through the custom processor
+      final logger = OTel.logger('test-logger');
+      logger.emit(body: 'Custom processor test');
+
+      // Wait for async processing
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(memoryExporter.count, equals(1));
+    });
+  });
+
+  group('OTelEnv BLRP config tests', () {
+    test('getBlrpConfig returns empty map when no env vars set', () {
+      // When no env vars are set (which is the case in tests),
+      // getBlrpConfig should return an empty map
+      final config = OTelEnv.getBlrpConfig();
+      expect(config, isA<Map<String, dynamic>>());
+      // Config may be empty or have defaults depending on env
+    });
+
+    test('getLogRecordLimits returns empty map when no env vars set', () {
+      final config = OTelEnv.getLogRecordLimits();
+      expect(config, isA<Map<String, dynamic>>());
+    });
+  });
+
+  group('BatchLogRecordProcessorConfig tests', () {
+    test('default config values are correct per OTel spec', () {
+      const config = BatchLogRecordProcessorConfig();
+
+      expect(config.maxQueueSize, equals(2048));
+      expect(config.scheduleDelay, equals(const Duration(milliseconds: 1000)));
+      expect(config.maxExportBatchSize, equals(512));
+      expect(config.exportTimeout, equals(const Duration(seconds: 30)));
+    });
+
+    test('custom config values are applied', () {
+      const config = BatchLogRecordProcessorConfig(
+        maxQueueSize: 4096,
+        scheduleDelay: Duration(milliseconds: 5000),
+        maxExportBatchSize: 1024,
+        exportTimeout: Duration(seconds: 60),
+      );
+
+      expect(config.maxQueueSize, equals(4096));
+      expect(config.scheduleDelay, equals(const Duration(milliseconds: 5000)));
+      expect(config.maxExportBatchSize, equals(1024));
+      expect(config.exportTimeout, equals(const Duration(seconds: 60)));
+    });
+  });
+}

--- a/test/unit/logs/logs_config_test.dart
+++ b/test/unit/logs/logs_config_test.dart
@@ -108,6 +108,7 @@ void main() {
         serviceName: 'logs-env-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
 
       final provider = OTel.loggerProvider();

--- a/test/unit/logs/logs_coverage_test.dart
+++ b/test/unit/logs/logs_coverage_test.dart
@@ -1,0 +1,1665 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Tests for logs-related source files exercising error paths, edge cases,
+// and configuration branches.
+//
+// Areas tested:
+//   1. logs_config.dart               - 'none'/console/gRPC/unknown exporter, BLRP config
+//   2. logger_provider.dart           - shutdown errors, getLogger/addProcessor after shutdown,
+//                                       forceFlush errors, debug logging, ensureResourceIsSet
+//   3. batch_log_record_processor.dart - queue full, timer callback, export timeout, error paths
+//   4. log_record_transformer.dart    - array attributes, invalid trace/span IDs, schema URL
+//   5. otlp_http_log_record_exporter.dart - export, shutdown, forceFlush, retry, error handling
+//   6. otlp_http_log_record_exporter_config.dart - validation edge cases
+
+import 'dart:async';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+import '../../testing_utils/memory_log_record_exporter.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/// A LogRecordProcessor whose shutdown throws, to exercise error paths in
+/// LoggerProvider.shutdown().
+class _ErrorShutdownProcessor implements LogRecordProcessor {
+  @override
+  Future<void> onEmit(ReadWriteLogRecord logRecord, Context? context) async {}
+
+  @override
+  bool enabled({
+    Context? context,
+    InstrumentationScope? instrumentationScope,
+    Severity? severityNumber,
+    String? eventName,
+  }) =>
+      true;
+
+  @override
+  Future<void> forceFlush() async {
+    throw Exception('forceFlush processor fail');
+  }
+
+  @override
+  Future<void> shutdown() async {
+    throw Exception('shutdown processor fail');
+  }
+}
+
+/// A LogRecordExporter whose export throws, to exercise error paths in
+/// BatchLogRecordProcessor._exportBatch().
+class _ThrowingLogRecordExporter implements LogRecordExporter {
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    throw Exception('export threw');
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}
+
+/// A LogRecordExporter whose export always returns failure.
+class _FailingLogRecordExporter implements LogRecordExporter {
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    return ExportResult.failure;
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}
+
+/// A LogRecordExporter whose export takes a long time, to exercise timeout.
+class _SlowLogRecordExporter implements LogRecordExporter {
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    // Intentionally slow so that a very short exportTimeout fires
+    await Future<void>.delayed(const Duration(seconds: 30));
+    return ExportResult.success;
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+void main() {
+  final List<String> logOutput = [];
+
+  setUp(() async {
+    await OTel.reset();
+    logOutput.clear();
+    OTelLog.enableTraceLogging();
+    OTelLog.logFunction = logOutput.add;
+  });
+
+  tearDown(() async {
+    try {
+      await OTel.shutdown();
+    } catch (_) {}
+    await OTel.reset();
+    OTelLog.currentLevel = LogLevel.info;
+    OTelLog.logFunction = null;
+  });
+
+  // =========================================================================
+  // 1. LogsConfiguration - configuration branches and edge cases
+  // =========================================================================
+  group('LogsConfiguration coverage', () {
+    test(
+        'configureLoggerProvider with none exporter returns provider without processor',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-cfg-none-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      // Manually set the env var effect by configuring with none exporter type.
+      // Since we cannot set env vars in tests, we test the 'none' code path by
+      // verifying the debug log output when configureLoggerProvider is called
+      // without a custom exporter and with no env vars (which defaults to otlp).
+      // The 'none' path is tested by looking at the code logic:
+      // when exporterType == 'none', no processor is added.
+      // We can exercise this indirectly by providing a custom processor.
+      // For direct 'none' coverage, we rely on the debug logging path.
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        resource: OTel.defaultResource,
+      );
+
+      // Should still succeed - default is otlp exporter
+      expect(provider, isNotNull);
+      expect(
+        logOutput.any((m) => m.contains('LogsConfiguration')),
+        isTrue,
+      );
+    });
+
+    test(
+        'configureLoggerProvider with console exporter via ConsoleLogRecordExporter',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-cfg-console-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final consoleExporter = ConsoleLogRecordExporter();
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        logRecordExporter: consoleExporter,
+        resource: OTel.defaultResource,
+      );
+
+      expect(provider, isNotNull);
+      expect(provider.logRecordProcessors.length, greaterThan(0));
+    });
+
+    test('createSimpleProcessor creates SimpleLogRecordProcessor', () async {
+      await OTel.initialize(
+        serviceName: 'logs-cfg-simple-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final memExporter = MemoryLogRecordExporter();
+      final processor = LogsConfiguration.createSimpleProcessor(memExporter);
+      expect(processor, isA<SimpleLogRecordProcessor>());
+    });
+
+    test('configureLoggerProvider without resource sets default resource',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-cfg-no-resource-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+      );
+
+      expect(provider, isNotNull);
+      // The logger provider should still work and get a logger
+      final logger = provider.getLogger('test');
+      expect(logger, isNotNull);
+    });
+
+    test(
+        'configureLoggerProvider with custom processor skips exporter creation',
+        () async {
+      await OTel.initialize(
+        serviceName: 'logs-cfg-custom-proc-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final memExporter = MemoryLogRecordExporter();
+      final customProcessor = SimpleLogRecordProcessor(memExporter);
+
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        logRecordProcessor: customProcessor,
+        resource: OTel.defaultResource,
+      );
+
+      expect(provider, isNotNull);
+      // Should have exactly 1 processor (the custom one)
+      expect(provider.logRecordProcessors.length, equals(1));
+    });
+  });
+
+  // =========================================================================
+  // 2. LoggerProvider - error handling and lifecycle edge cases
+  // =========================================================================
+  group('LoggerProvider coverage', () {
+    test('shutdown with processor error logs debug message', () async {
+      await OTel.initialize(
+        serviceName: 'lp-shutdown-err-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      // Add a processor that will throw on shutdown
+      provider.addLogRecordProcessor(_ErrorShutdownProcessor());
+
+      // Shutdown should not throw even though the processor throws
+      final result = await provider.shutdown();
+      expect(result, isTrue);
+      expect(provider.isShutdown, isTrue);
+
+      // Verify error was logged
+      expect(
+        logOutput.any((m) => m.contains('Error shutting down processor')),
+        isTrue,
+        reason: 'Should log the error from the failing processor',
+      );
+    });
+
+    test('shutdown when already shutdown logs already shut down', () async {
+      await OTel.initialize(
+        serviceName: 'lp-double-shutdown-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      await provider.shutdown();
+      logOutput.clear();
+
+      // Second shutdown should log 'Already shut down'
+      final result = await provider.shutdown();
+      expect(result, isTrue);
+      expect(
+        logOutput.any((m) => m.contains('Already shut down')),
+        isTrue,
+        reason: 'Should log already shut down on second shutdown call',
+      );
+    });
+
+    test('getLogger after shutdown throws StateError', () async {
+      await OTel.initialize(
+        serviceName: 'lp-getlogger-shutdown-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      await provider.shutdown();
+
+      expect(
+        () => provider.getLogger('test-after-shutdown'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('addLogRecordProcessor after shutdown throws StateError', () async {
+      await OTel.initialize(
+        serviceName: 'lp-addproc-shutdown-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      await provider.shutdown();
+
+      expect(
+        () => provider.addLogRecordProcessor(
+          SimpleLogRecordProcessor(MemoryLogRecordExporter()),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('forceFlush when shut down returns early', () async {
+      await OTel.initialize(
+        serviceName: 'lp-flush-shutdown-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      provider.addLogRecordProcessor(
+        SimpleLogRecordProcessor(MemoryLogRecordExporter()),
+      );
+      await provider.shutdown();
+      logOutput.clear();
+
+      // Force flush after shutdown should be a no-op
+      await provider.forceFlush();
+
+      expect(
+        logOutput.any((m) => m.contains('Cannot force flush')),
+        isTrue,
+        reason: 'Should log cannot force flush when shut down',
+      );
+    });
+
+    test('forceFlush with processor error logs error', () async {
+      await OTel.initialize(
+        serviceName: 'lp-flush-err-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      provider.addLogRecordProcessor(_ErrorShutdownProcessor());
+
+      // Force flush should not throw even though processor.forceFlush throws
+      await provider.forceFlush();
+
+      expect(
+        logOutput.any((m) => m.contains('Error flushing processor')),
+        isTrue,
+        reason: 'Should log the error from the failing processor forceFlush',
+      );
+    });
+
+    test('ensureResourceIsSet sets default resource when null', () async {
+      await OTel.initialize(
+        serviceName: 'lp-ensure-resource-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      // The resource will be set from default. Clear it and re-set.
+      provider.resource = null;
+      logOutput.clear();
+
+      provider.ensureResourceIsSet();
+
+      expect(provider.resource, isNotNull);
+      expect(
+        logOutput.any((m) => m.contains('Setting resource from default')),
+        isTrue,
+        reason: 'Should log that resource is being set from default',
+      );
+    });
+
+    test('getLogger with schemaUrl and attributes', () async {
+      await OTel.initialize(
+        serviceName: 'lp-getlogger-opts-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      final logger = provider.getLogger(
+        'my-logger',
+        version: '1.2.3',
+        schemaUrl: 'https://example.com/schema',
+        attributes: OTel.attributesFromMap({'lib': 'test'}),
+      );
+
+      expect(logger, isNotNull);
+
+      // Getting same name+version returns cached instance
+      final sameLogger = provider.getLogger('my-logger', version: '1.2.3');
+      expect(identical(logger, sameLogger), isTrue);
+    });
+
+    test('shutdown logs debug messages with resource', () async {
+      await OTel.initialize(
+        serviceName: 'lp-shutdown-debug-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      final memExporter = MemoryLogRecordExporter();
+      provider.addLogRecordProcessor(SimpleLogRecordProcessor(memExporter));
+
+      logOutput.clear();
+      await provider.shutdown();
+
+      expect(
+        logOutput.any((m) => m.contains('Shutting down with')),
+        isTrue,
+        reason: 'Should log shutdown with processor count',
+      );
+      expect(
+        logOutput.any((m) => m.contains('Cleared cached loggers')),
+        isTrue,
+        reason: 'Should log that cached loggers were cleared',
+      );
+      expect(
+        logOutput.any((m) => m.contains('Shutdown complete')),
+        isTrue,
+        reason: 'Should log shutdown complete',
+      );
+    });
+
+    test('LoggerProvider delegates endpoint/serviceName/serviceVersion',
+        () async {
+      await OTel.initialize(
+        serviceName: 'lp-delegate-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final provider = OTel.loggerProvider();
+
+      provider.endpoint = 'https://new-endpoint.com';
+      expect(provider.endpoint, equals('https://new-endpoint.com'));
+
+      provider.serviceName = 'new-service';
+      expect(provider.serviceName, equals('new-service'));
+
+      provider.serviceVersion = '9.9.9';
+      expect(provider.serviceVersion, equals('9.9.9'));
+
+      provider.enabled = false;
+      expect(provider.enabled, isFalse);
+      provider.enabled = true;
+      expect(provider.enabled, isTrue);
+    });
+  });
+
+  // =========================================================================
+  // 3. BatchLogRecordProcessor - queue, timer, timeout, and error paths
+  // =========================================================================
+  group('BatchLogRecordProcessor coverage', () {
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      // OTel.reset is handled by outer setUp, need to initialize here
+      await OTel.initialize(
+        serviceName: 'blrp-coverage-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+      scope = OTel.instrumentationScope(name: 'blrp-test', version: '1.0.0');
+    });
+
+    test('onEmit after shutdown is no-op', () async {
+      final exporter = MemoryLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+      await processor.shutdown();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'after shutdown',
+      );
+      await processor.onEmit(logRecord, null);
+
+      // Nothing should be exported
+      expect(exporter.count, equals(0));
+    });
+
+    test('queue full drops log records and logs debug', () async {
+      final exporter = MemoryLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxQueueSize: 2,
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        // Fill the queue
+        for (int i = 0; i < 5; i++) {
+          final logRecord = SDKLogRecord(
+            instrumentationScope: scope,
+            severityNumber: Severity.INFO,
+            body: 'Message $i',
+          );
+          await processor.onEmit(logRecord, null);
+        }
+
+        await processor.forceFlush();
+
+        // Only maxQueueSize (2) should be exported
+        expect(exporter.count, lessThanOrEqualTo(2));
+        expect(
+          logOutput.any((m) => m.contains('Queue full')),
+          isTrue,
+          reason: 'Should log that the queue is full',
+        );
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('export batch with throwing exporter logs error', () async {
+      final throwingExporter = _ThrowingLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(throwingExporter, config);
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'will-throw',
+        );
+        await processor.onEmit(logRecord, null);
+        await processor.forceFlush();
+
+        expect(
+          logOutput.any((m) => m.contains('Error exporting batch')),
+          isTrue,
+          reason: 'Should log the export error',
+        );
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('export batch with failing exporter logs failure', () async {
+      final failingExporter = _FailingLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(failingExporter, config);
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'will-fail',
+        );
+        await processor.onEmit(logRecord, null);
+        await processor.forceFlush();
+
+        expect(
+          logOutput.any((m) => m.contains('Export failed')),
+          isTrue,
+          reason: 'Should log that export failed',
+        );
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('export timeout is handled gracefully', () async {
+      final slowExporter = _SlowLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100),
+        exportTimeout: Duration(milliseconds: 50), // Very short timeout
+      );
+      final processor = BatchLogRecordProcessor(slowExporter, config);
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'will-timeout',
+        );
+        await processor.onEmit(logRecord, null);
+
+        // ForceFlush triggers _exportBatch which will timeout
+        await processor.forceFlush();
+
+        expect(
+          logOutput.any((m) => m.contains('Export timed out')),
+          isTrue,
+          reason: 'Should log that export timed out',
+        );
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('enabled returns false after shutdown', () async {
+      final exporter = MemoryLogRecordExporter();
+      final processor = BatchLogRecordProcessor(exporter);
+
+      expect(processor.enabled(), isTrue);
+
+      await processor.shutdown();
+
+      expect(processor.enabled(), isFalse);
+    });
+
+    test('forceFlush after shutdown is no-op', () async {
+      final exporter = MemoryLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'before-shutdown',
+      );
+      await processor.onEmit(logRecord, null);
+      await processor.shutdown();
+
+      // Records should have been exported during shutdown
+      expect(exporter.count, equals(1));
+
+      // ForceFlush after shutdown should be no-op
+      await processor.forceFlush();
+    });
+
+    test('timer callback exports batches periodically', () async {
+      final exporter = MemoryLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 100,
+        scheduleDelay: Duration(milliseconds: 50),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'timer-test',
+        );
+        await processor.onEmit(logRecord, null);
+
+        // Wait for the timer to fire
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+
+        expect(exporter.count, equals(1));
+      } finally {
+        await processor.shutdown();
+      }
+    });
+
+    test('shutdown exports remaining logs before marking shutdown', () async {
+      final exporter = MemoryLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 100,
+        scheduleDelay: Duration(seconds: 100),
+      );
+      final processor = BatchLogRecordProcessor(exporter, config);
+
+      for (int i = 0; i < 5; i++) {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: Severity.INFO,
+          body: 'shutdown-export-$i',
+        );
+        await processor.onEmit(logRecord, null);
+      }
+
+      // No auto-export yet (timer delay is 100s)
+      expect(exporter.count, equals(0));
+
+      await processor.shutdown();
+
+      // All 5 should have been exported during shutdown
+      expect(exporter.count, equals(5));
+    });
+
+    test('shutdown with throwing exporter during final export logs error',
+        () async {
+      final throwingExporter = _ThrowingLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100),
+        exportTimeout: Duration(seconds: 5),
+      );
+      final processor = BatchLogRecordProcessor(throwingExporter, config);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'shutdown-throw',
+      );
+      await processor.onEmit(logRecord, null);
+
+      // Shutdown should not throw, but should log the error
+      await processor.shutdown();
+
+      expect(
+        logOutput
+            .any((m) => m.contains('Error exporting batch during shutdown')),
+        isTrue,
+        reason: 'Should log error during shutdown export',
+      );
+    });
+
+    test('shutdown with slow exporter during final export times out', () async {
+      final slowExporter = _SlowLogRecordExporter();
+      const config = BatchLogRecordProcessorConfig(
+        maxExportBatchSize: 10,
+        scheduleDelay: Duration(seconds: 100),
+        exportTimeout: Duration(milliseconds: 50),
+      );
+      final processor = BatchLogRecordProcessor(slowExporter, config);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'shutdown-slow',
+      );
+      await processor.onEmit(logRecord, null);
+
+      await processor.shutdown();
+
+      expect(
+        logOutput.any((m) => m.contains('Export timed out during shutdown')),
+        isTrue,
+        reason: 'Should log timeout during shutdown export',
+      );
+    });
+  });
+
+  // =========================================================================
+  // 4. OtlpLogRecordTransformer - attribute types, IDs, and edge cases
+  // =========================================================================
+  group('OtlpLogRecordTransformer coverage', () {
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      await OTel.initialize(
+        serviceName: 'transformer-coverage-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+      scope = OTel.instrumentationScope(name: 'xform-test', version: '1.0.0');
+    });
+
+    test('transforms log record with null resource uses default service key',
+        () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        resource: null,
+        severityNumber: Severity.INFO,
+        body: 'no-resource',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+
+      expect(request.resourceLogs.length, equals(1));
+    });
+
+    test('transforms string list attributes correctly', () {
+      final attrs = OTel.attributesFromList([
+        OTel.attributeStringList('tags', ['a', 'b', 'c']),
+      ]);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'string-list-attrs',
+        attributes: attrs,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      final tagAttr = otlpLog.attributes.firstWhere((a) => a.key == 'tags');
+      expect(tagAttr.value.arrayValue.values.length, equals(3));
+      expect(tagAttr.value.arrayValue.values[0].stringValue, equals('a'));
+    });
+
+    test('transforms bool list attributes correctly', () {
+      final attrs = OTel.attributesFromList([
+        OTel.attributeBoolList('flags', [true, false, true]),
+      ]);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'bool-list-attrs',
+        attributes: attrs,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      final flagAttr = otlpLog.attributes.firstWhere((a) => a.key == 'flags');
+      expect(flagAttr.value.arrayValue.values.length, equals(3));
+      expect(flagAttr.value.arrayValue.values[0].boolValue, isTrue);
+    });
+
+    test('transforms int list attributes correctly', () {
+      final attrs = OTel.attributesFromList([
+        OTel.attributeIntList('counts', [1, 2, 3]),
+      ]);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'int-list-attrs',
+        attributes: attrs,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      final countAttr = otlpLog.attributes.firstWhere((a) => a.key == 'counts');
+      expect(countAttr.value.arrayValue.values.length, equals(3));
+      expect(countAttr.value.arrayValue.values[0].intValue, equals(Int64(1)));
+    });
+
+    test('transforms double list attributes correctly', () {
+      final attrs = OTel.attributesFromList([
+        OTel.attributeDoubleList('rates', [1.1, 2.2, 3.3]),
+      ]);
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'double-list-attrs',
+        attributes: attrs,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      final rateAttr = otlpLog.attributes.firstWhere((a) => a.key == 'rates');
+      expect(rateAttr.value.arrayValue.values.length, equals(3));
+      expect(rateAttr.value.arrayValue.values[0].doubleValue, equals(1.1));
+    });
+
+    test('transforms invalid trace ID - does not set traceId on otlpLog', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'invalid-trace-id',
+      );
+      logRecord.traceId = OTel.traceIdInvalid();
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      // Invalid trace ID should not be set on the proto log record
+      expect(otlpLog.traceId, isEmpty);
+    });
+
+    test('transforms invalid span ID - does not set spanId on otlpLog', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'invalid-span-id',
+      );
+      logRecord.spanId = OTel.spanIdInvalid();
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      // Invalid span ID should not be set on the proto log record
+      expect(otlpLog.spanId, isEmpty);
+    });
+
+    test('transforms schemaUrl from instrumentation scope', () {
+      final scopeWithSchema = OTel.instrumentationScope(
+        name: 'schema-test',
+        version: '1.0.0',
+        schemaUrl: 'https://opentelemetry.io/schemas/1.17.0',
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scopeWithSchema,
+        severityNumber: Severity.INFO,
+        body: 'schema-url-test',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+
+      expect(request.resourceLogs.first.schemaUrl,
+          equals('https://opentelemetry.io/schemas/1.17.0'));
+    });
+
+    test('transforms all severity levels including sub-levels', () {
+      // Test severity sub-levels that may not have been covered
+      final subLevels = [
+        Severity.TRACE2,
+        Severity.TRACE3,
+        Severity.TRACE4,
+        Severity.DEBUG2,
+        Severity.DEBUG3,
+        Severity.DEBUG4,
+        Severity.INFO2,
+        Severity.INFO3,
+        Severity.INFO4,
+        Severity.WARN2,
+        Severity.WARN3,
+        Severity.WARN4,
+        Severity.ERROR2,
+        Severity.ERROR3,
+        Severity.ERROR4,
+        Severity.FATAL2,
+        Severity.FATAL3,
+        Severity.FATAL4,
+        Severity.UNSPECIFIED,
+      ];
+
+      for (final severity in subLevels) {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          severityNumber: severity,
+          body: 'severity-${severity.name}',
+        );
+
+        final request =
+            OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+        expect(request.resourceLogs.length, equals(1));
+      }
+    });
+
+    test('transforms body with nested list (array body)', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: [1, 'two', 3.0, true],
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.body.arrayValue.values.length, equals(4));
+      expect(otlpLog.body.arrayValue.values[0].intValue, equals(Int64(1)));
+      expect(otlpLog.body.arrayValue.values[1].stringValue, equals('two'));
+      expect(otlpLog.body.arrayValue.values[2].doubleValue, equals(3.0));
+      expect(otlpLog.body.arrayValue.values[3].boolValue, isTrue);
+    });
+
+    test('transforms body with unknown type falls back to string', () {
+      // Use a non-standard type for body that will be converted to string
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: DateTime.utc(2025, 1, 1),
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      // Should fall back to string conversion
+      expect(otlpLog.body.stringValue, contains('2025'));
+    });
+
+    test('transforms trace flags correctly', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'trace-flags-test',
+      );
+      logRecord.traceFlags = TraceFlags.sampled;
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.flags, equals(TraceFlags.sampled.asByte));
+    });
+
+    test('transforms null attributes does not add to proto', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'no-attrs',
+        attributes: null,
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.attributes, isEmpty);
+    });
+
+    test('transforms log record without timestamps', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.WARN,
+        body: 'no-timestamps',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      // Timestamps should be default (zero)
+      expect(otlpLog.timeUnixNano, equals(Int64.ZERO));
+      expect(otlpLog.observedTimeUnixNano, equals(Int64.ZERO));
+    });
+
+    test('transforms instrumentation scope without version', () {
+      final scopeNoVersion =
+          OTel.instrumentationScope(name: 'no-version-scope');
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scopeNoVersion,
+        severityNumber: Severity.INFO,
+        body: 'no-version',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final scopeLogs = request.resourceLogs.first.scopeLogs.first;
+
+      expect(scopeLogs.scope.name, equals('no-version-scope'));
+      // Version should be empty/default when not set
+    });
+  });
+
+  // =========================================================================
+  // 5. OtlpHttpLogRecordExporter - export, shutdown, retry, and error handling
+  // =========================================================================
+  group('OtlpHttpLogRecordExporter coverage', () {
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      await OTel.initialize(
+        serviceName: 'http-exporter-coverage-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+      scope =
+          OTel.instrumentationScope(name: 'http-exp-test', version: '1.0.0');
+    });
+
+    test('export with empty list returns success', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+        ),
+      );
+
+      final result = await exporter.export([]);
+      expect(result, equals(ExportResult.success));
+      expect(
+        logOutput.any((m) => m.contains('No log records to export')),
+        isTrue,
+      );
+
+      await exporter.shutdown();
+    });
+
+    test('export after shutdown returns failure', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+        ),
+      );
+
+      await exporter.shutdown();
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'after-shutdown',
+      );
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+    });
+
+    test('shutdown when already shut down is no-op', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+        ),
+      );
+
+      await exporter.shutdown();
+      logOutput.clear();
+
+      // Second shutdown should be a no-op
+      await exporter.shutdown();
+
+      // Should not log 'Shutdown complete' again since it returns early
+    });
+
+    test('forceFlush when shut down is no-op', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+        ),
+      );
+
+      await exporter.shutdown();
+      logOutput.clear();
+
+      await exporter.forceFlush();
+      // Should return early without error
+    });
+
+    test('forceFlush with no pending exports completes', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+        ),
+      );
+
+      await exporter.forceFlush();
+      expect(
+        logOutput.any((m) => m.contains('Force flush requested')),
+        isTrue,
+      );
+
+      await exporter.shutdown();
+    });
+
+    test('export to unreachable endpoint returns failure with retry', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://127.0.0.1:1', // unreachable
+          maxRetries: 0, // no retries
+          timeout: const Duration(milliseconds: 500),
+        ),
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'unreachable',
+      );
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      await exporter.shutdown();
+    });
+
+    test('export to unreachable endpoint with retries eventually fails',
+        () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://127.0.0.1:1', // unreachable
+          maxRetries: 1,
+          timeout: const Duration(milliseconds: 200),
+          baseDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'retry-then-fail',
+      );
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      // Connection refused triggers either an HTTP error or unexpected error log
+      expect(
+        logOutput.any((m) =>
+            m.contains('error during export') ||
+            m.contains('Export request failed') ||
+            m.contains('Unexpected error')),
+        isTrue,
+        reason: 'Should log an error for connection refused',
+      );
+
+      await exporter.shutdown();
+    });
+
+    test('exporter with compression enabled', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint:
+              'http://127.0.0.1:1', // unreachable, but exercises compression path
+          maxRetries: 0,
+          compression: true,
+          timeout: const Duration(milliseconds: 200),
+        ),
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'compressed-export',
+      );
+
+      // Will fail due to unreachable endpoint but exercises compression code path
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+
+      await exporter.shutdown();
+    });
+
+    test('exporter with custom headers', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://127.0.0.1:1',
+          headers: {
+            'Authorization': 'Bearer test-token',
+            'X-Custom': 'custom-value',
+          },
+          maxRetries: 0,
+          timeout: const Duration(milliseconds: 200),
+        ),
+      );
+
+      // Constructor should log headers (with Authorization redacted)
+      expect(
+        logOutput.any((m) => m.contains('REDACTED')),
+        isTrue,
+        reason: 'Should redact Authorization header in logs',
+      );
+
+      await exporter.shutdown();
+    });
+
+    test('endpoint URL appends /v1/logs when missing', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+          maxRetries: 0,
+          timeout: const Duration(milliseconds: 200),
+        ),
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'endpoint-test',
+      );
+
+      // This will fail but exercises the _getEndpointUrl path
+      await exporter.export([logRecord]);
+
+      expect(
+        logOutput.any((m) => m.contains('/v1/logs')),
+        isTrue,
+        reason: 'Should append /v1/logs to endpoint',
+      );
+
+      await exporter.shutdown();
+    });
+
+    test('endpoint URL does not double-append /v1/logs', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318/v1/logs',
+          maxRetries: 0,
+          timeout: const Duration(milliseconds: 200),
+        ),
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'no-double-append',
+      );
+
+      await exporter.export([logRecord]);
+
+      // Check that /v1/logs appears but not /v1/logs/v1/logs
+      final endpointLogs =
+          logOutput.where((m) => m.contains('Sending export request')).toList();
+      if (endpointLogs.isNotEmpty) {
+        expect(endpointLogs.first.contains('/v1/logs/v1/logs'), isFalse);
+      }
+
+      await exporter.shutdown();
+    });
+
+    test('endpoint URL strips trailing slash before appending /v1/logs',
+        () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318/',
+          maxRetries: 0,
+          timeout: const Duration(milliseconds: 200),
+        ),
+      );
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'trailing-slash',
+      );
+
+      await exporter.export([logRecord]);
+
+      // The endpoint should have /v1/logs appended without double slash
+      final endpointLogs =
+          logOutput.where((m) => m.contains('Sending export request')).toList();
+      if (endpointLogs.isNotEmpty) {
+        expect(endpointLogs.first.contains('4318//v1/logs'), isFalse);
+      }
+
+      await exporter.shutdown();
+    });
+
+    test('exporter with test certificates creates client', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:4318',
+          certificate: 'test://ca-cert',
+          clientKey: 'test://client-key',
+          clientCertificate: 'test://client-cert',
+        ),
+      );
+
+      // Exporter should have been created successfully with test certs
+      expect(exporter, isNotNull);
+
+      await exporter.shutdown();
+    });
+
+    test('default config exporter creates successfully', () async {
+      final exporter = OtlpHttpLogRecordExporter();
+
+      expect(exporter, isNotNull);
+      expect(
+        logOutput.any((m) => m.contains('Created with endpoint')),
+        isTrue,
+      );
+
+      await exporter.shutdown();
+    });
+  });
+
+  // =========================================================================
+  // 6. OtlpHttpLogRecordExporterConfig - validation edge cases
+  // =========================================================================
+  group('OtlpHttpLogRecordExporterConfig coverage', () {
+    test('default config has correct values', () {
+      final config = OtlpHttpLogRecordExporterConfig();
+      expect(config.endpoint, equals('http://localhost:4318'));
+      expect(config.headers, isEmpty);
+      expect(config.timeout, equals(const Duration(seconds: 10)));
+      expect(config.compression, isFalse);
+      expect(config.maxRetries, equals(3));
+      expect(config.baseDelay, equals(const Duration(milliseconds: 100)));
+      expect(config.maxDelay, equals(const Duration(seconds: 1)));
+      expect(config.certificate, isNull);
+      expect(config.clientKey, isNull);
+      expect(config.clientCertificate, isNull);
+    });
+
+    test('empty endpoint throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(endpoint: ''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('endpoint with spaces throws ArgumentError', () {
+      expect(
+        () =>
+            OtlpHttpLogRecordExporterConfig(endpoint: 'http://local host:4318'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('endpoint without scheme gets http:// prepended', () {
+      final config =
+          OtlpHttpLogRecordExporterConfig(endpoint: 'myhost.example.com:4318');
+      expect(config.endpoint, startsWith('http://'));
+    });
+
+    test('localhost endpoint gets default port appended', () {
+      final config =
+          OtlpHttpLogRecordExporterConfig(endpoint: 'http://localhost');
+      expect(config.endpoint, equals('http://localhost:4318'));
+    });
+
+    test('127.0.0.1 endpoint gets default port appended', () {
+      final config =
+          OtlpHttpLogRecordExporterConfig(endpoint: 'http://127.0.0.1');
+      expect(config.endpoint, equals('http://127.0.0.1:4318'));
+    });
+
+    test('https localhost endpoint gets default port appended', () {
+      final config =
+          OtlpHttpLogRecordExporterConfig(endpoint: 'https://localhost');
+      expect(config.endpoint, equals('https://localhost:4318'));
+    });
+
+    test('https 127.0.0.1 endpoint gets default port appended', () {
+      final config =
+          OtlpHttpLogRecordExporterConfig(endpoint: 'https://127.0.0.1');
+      expect(config.endpoint, equals('https://127.0.0.1:4318'));
+    });
+
+    test('empty header key throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          headers: {'': 'value'},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('empty header value throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          headers: {'key': ''},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('headers are normalized to lowercase keys', () {
+      final config = OtlpHttpLogRecordExporterConfig(
+        headers: {'Content-Type': 'application/json'},
+      );
+      expect(config.headers.containsKey('content-type'), isTrue);
+    });
+
+    test('timeout too short throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          timeout: Duration.zero,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('timeout too long throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          timeout: const Duration(minutes: 11),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('negative maxRetries throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(maxRetries: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('zero maxRetries is valid', () {
+      final config = OtlpHttpLogRecordExporterConfig(maxRetries: 0);
+      expect(config.maxRetries, equals(0));
+    });
+
+    test('baseDelay too short throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          baseDelay: Duration.zero,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('baseDelay too long throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          baseDelay: const Duration(minutes: 6),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('maxDelay too short throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          maxDelay: Duration.zero,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('maxDelay too long throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          maxDelay: const Duration(minutes: 6),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('baseDelay greater than maxDelay throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          baseDelay: const Duration(seconds: 5),
+          maxDelay: const Duration(seconds: 1),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('invalid certificate path throws ArgumentError', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(
+          certificate: 'invalid-cert-path',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('test:// certificate paths are valid', () {
+      final config = OtlpHttpLogRecordExporterConfig(
+        certificate: 'test://ca-cert',
+        clientKey: 'test://client-key',
+        clientCertificate: 'test://client-cert',
+      );
+      expect(config.certificate, equals('test://ca-cert'));
+      expect(config.clientKey, equals('test://client-key'));
+      expect(config.clientCertificate, equals('test://client-cert'));
+    });
+
+    test('endpoint with existing port is preserved', () {
+      final config = OtlpHttpLogRecordExporterConfig(
+        endpoint: 'http://myhost.example.com:9090',
+      );
+      expect(config.endpoint, equals('http://myhost.example.com:9090'));
+    });
+
+    test('custom config with all options', () {
+      final config = OtlpHttpLogRecordExporterConfig(
+        endpoint: 'https://collector.example.com:4318',
+        headers: {'X-Api-Key': 'my-key'},
+        timeout: const Duration(seconds: 30),
+        compression: true,
+        maxRetries: 5,
+        baseDelay: const Duration(milliseconds: 200),
+        maxDelay: const Duration(seconds: 2),
+        certificate: 'test://ca',
+        clientKey: 'test://key',
+        clientCertificate: 'test://cert',
+      );
+
+      expect(config.endpoint, equals('https://collector.example.com:4318'));
+      expect(config.headers['x-api-key'], equals('my-key'));
+      expect(config.timeout, equals(const Duration(seconds: 30)));
+      expect(config.compression, isTrue);
+      expect(config.maxRetries, equals(5));
+      expect(config.baseDelay, equals(const Duration(milliseconds: 200)));
+      expect(config.maxDelay, equals(const Duration(seconds: 2)));
+    });
+  });
+
+  // =========================================================================
+  // 7. ConsoleLogRecordExporter coverage (helps logs_config console branch)
+  // =========================================================================
+  group('ConsoleLogRecordExporter coverage', () {
+    test('export after shutdown returns failure', () async {
+      await OTel.initialize(
+        serviceName: 'console-shutdown-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final printed = <String>[];
+      final exporter = ConsoleLogRecordExporter(printFunction: printed.add);
+      await exporter.shutdown();
+
+      final scope = OTel.instrumentationScope(name: 'console-test');
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'after-shutdown',
+      );
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.failure));
+      expect(printed, isEmpty);
+    });
+
+    test('export prints log records with all fields', () async {
+      await OTel.initialize(
+        serviceName: 'console-export-test',
+        detectPlatformResources: false,
+        enableLogs: false,
+      );
+
+      final printed = <String>[];
+      final exporter = ConsoleLogRecordExporter(printFunction: printed.add);
+
+      final scope = OTel.instrumentationScope(name: 'my-lib', version: '2.0.0');
+      final resource = OTel.resource(
+          OTel.attributesFromMap({'service.name': 'console-svc'}));
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        resource: resource,
+        observedTimestamp: Int64(1234567890000000000),
+        severityNumber: Severity.WARN,
+        severityText: 'WARNING',
+        body: 'Something happened',
+        eventName: 'my.event',
+        attributes: OTel.attributesFromMap({'key1': 'val1', 'key2': 42}),
+      );
+      logRecord.traceId = OTel.traceId();
+      logRecord.spanId = OTel.spanId();
+
+      final result = await exporter.export([logRecord]);
+      expect(result, equals(ExportResult.success));
+      expect(printed.length, equals(1));
+
+      final output = printed.first;
+      expect(output, contains('WARNING'));
+      expect(output, contains('my-lib'));
+      expect(output, contains('2.0.0'));
+      expect(output, contains('my.event'));
+      expect(output, contains('Something happened'));
+      expect(output, contains('trace_id='));
+      expect(output, contains('span_id='));
+      expect(output, contains('service=console-svc'));
+      expect(output, contains('key1=val1'));
+
+      await exporter.shutdown();
+    });
+  });
+
+  // =========================================================================
+  // 8. BatchLogRecordProcessorConfig defaults
+  // =========================================================================
+  group('BatchLogRecordProcessorConfig coverage', () {
+    test('custom config with all parameters', () {
+      const config = BatchLogRecordProcessorConfig(
+        maxQueueSize: 100,
+        scheduleDelay: Duration(milliseconds: 500),
+        maxExportBatchSize: 50,
+        exportTimeout: Duration(seconds: 5),
+      );
+
+      expect(config.maxQueueSize, equals(100));
+      expect(config.scheduleDelay, equals(const Duration(milliseconds: 500)));
+      expect(config.maxExportBatchSize, equals(50));
+      expect(config.exportTimeout, equals(const Duration(seconds: 5)));
+    });
+  });
+}

--- a/test/unit/logs/print_interception_test.dart
+++ b/test/unit/logs/print_interception_test.dart
@@ -1,0 +1,323 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../testing_utils/memory_log_record_exporter.dart';
+
+void main() {
+  group('Print Interception Tests', () {
+    late MemoryLogRecordExporter memoryExporter;
+    late SimpleLogRecordProcessor processor;
+
+    setUp(() async {
+      await OTel.reset();
+      memoryExporter = MemoryLogRecordExporter();
+      processor = SimpleLogRecordProcessor(memoryExporter);
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('logPrint defaults to false', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+      );
+
+      expect(OTel.isLogPrintEnabled, isFalse);
+      expect(OTel.logBridge, isNull);
+    });
+
+    test('logPrint can be enabled', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      expect(OTel.isLogPrintEnabled, isTrue);
+      // Bridge is lazily initialized, so it's null until first use
+      expect(OTel.logBridge, isNull);
+
+      // Trigger lazy initialization
+      OTel.runWithPrintInterception(() {});
+
+      // Now the bridge should be initialized
+      expect(OTel.logBridge, isNotNull);
+      expect(OTel.logBridge!.isActive, isTrue);
+    });
+
+    test(
+        'print is captured when logPrint enabled and runWithPrintInterception used',
+        () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      OTel.runWithPrintInterception(() {
+        print('Test print message');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(memoryExporter.count, equals(1));
+      expect(
+        memoryExporter.exportedLogRecords.first.body,
+        equals('Test print message'),
+      );
+    });
+
+    test('print interception captures severity as INFO', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      OTel.runWithPrintInterception(() {
+        print('Test print');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(memoryExporter.count, equals(1));
+      expect(
+        memoryExporter.exportedLogRecords.first.severityNumber,
+        equals(Severity.INFO),
+      );
+    });
+
+    test('runWithPrintInterception returns callback result', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+
+      final result = OTel.runWithPrintInterception(() {
+        return 42;
+      });
+
+      expect(result, equals(42));
+    });
+
+    test('runWithPrintInterception works without print enabled', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: false,
+      );
+
+      final result = OTel.runWithPrintInterception(() {
+        print('This should not be captured');
+        return 'done';
+      });
+
+      expect(result, equals('done'));
+      // No logs should be captured since logPrint is false
+      expect(memoryExporter.count, equals(0));
+    });
+
+    test('runWithPrintInterceptionAsync works with async code', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      final result = await OTel.runWithPrintInterceptionAsync(() async {
+        print('Async print message');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return 'async result';
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(result, equals('async result'));
+      expect(memoryExporter.count, equals(1));
+      expect(
+        memoryExporter.exportedLogRecords.first.body,
+        equals('Async print message'),
+      );
+    });
+
+    test('custom logPrintLoggerName is used', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+        logPrintLoggerName: 'my.custom.print.logger',
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      OTel.runWithPrintInterception(() {
+        print('Custom logger test');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(memoryExporter.count, equals(1));
+      expect(
+        memoryExporter.exportedLogRecords.first.instrumentationScope.name,
+        equals('my.custom.print.logger'),
+      );
+    });
+
+    test('default logPrintLoggerName is dart.print', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      OTel.runWithPrintInterception(() {
+        print('Default logger test');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(memoryExporter.count, equals(1));
+      expect(
+        memoryExporter.exportedLogRecords.first.instrumentationScope.name,
+        equals('dart.print'),
+      );
+    });
+
+    test('multiple prints in single zone are captured', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      // Verify processor is registered
+      expect(OTel.loggerProvider().logRecordProcessors.length, greaterThan(0));
+
+      OTel.runWithPrintInterception(() {
+        print('First message');
+        print('Second message');
+        print('Third message');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(memoryExporter.count, equals(3));
+      expect(
+          memoryExporter.exportedLogRecords[0].body, equals('First message'));
+      expect(
+          memoryExporter.exportedLogRecords[1].body, equals('Second message'));
+      expect(
+          memoryExporter.exportedLogRecords[2].body, equals('Third message'));
+    });
+
+    test('multiple separate runWithPrintInterception calls work', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      OTel.runWithPrintInterception(() {
+        print('First message');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(memoryExporter.count, equals(1),
+          reason: 'Should have 1 log after first call');
+
+      OTel.runWithPrintInterception(() {
+        print('Second message');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(memoryExporter.count, equals(2),
+          reason: 'Should have 2 logs after second call');
+    });
+
+    test('reset clears print interception state', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+
+      expect(OTel.isLogPrintEnabled, isTrue);
+
+      // Trigger lazy initialization
+      OTel.runWithPrintInterception(() {});
+      expect(OTel.logBridge, isNotNull);
+
+      await OTel.reset();
+
+      expect(OTel.isLogPrintEnabled, isFalse);
+      expect(OTel.logBridge, isNull);
+    });
+
+    test('print interception preserves original print behavior', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      // This test just verifies no exception is thrown and print still works
+      // The actual output goes to stdout which we can't easily capture
+      OTel.runWithPrintInterception(() {
+        print('This should both print and be logged');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Log should be captured
+      expect(memoryExporter.count, equals(1));
+    });
+
+    test('nested runWithPrintInterception calls work', () async {
+      await OTel.initialize(
+        serviceName: 'print-interception-test',
+        detectPlatformResources: false,
+        logPrint: true,
+      );
+      OTel.loggerProvider().addLogRecordProcessor(processor);
+
+      OTel.runWithPrintInterception(() {
+        print('Outer message');
+        OTel.runWithPrintInterception(() {
+          print('Inner message');
+        });
+        print('Another outer message');
+      });
+
+      // Wait for async processor to complete
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // Nested zones may capture differently - at minimum we expect the messages to be logged
+      expect(memoryExporter.count, greaterThanOrEqualTo(1));
+    });
+  });
+}

--- a/test/unit/logs/sdk_log_record_test.dart
+++ b/test/unit/logs/sdk_log_record_test.dart
@@ -1,0 +1,296 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SDKLogRecord Tests', () {
+    late InstrumentationScope scope;
+
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'log-record-test',
+        detectPlatformResources: false,
+      );
+
+      scope = OTel.instrumentationScope(
+        name: 'test-scope',
+        version: '1.0.0',
+      );
+    });
+
+    tearDown(() async {
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('SDKLogRecord stores all fields correctly', () {
+      final timestamp =
+          Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000);
+      final observedTimestamp =
+          Int64(DateTime.now().microsecondsSinceEpoch) * Int64(1000);
+      final attributes = OTel.attributesFromMap({'key': 'value'});
+      final resource =
+          OTel.resource(OTel.attributesFromMap({'service.name': 'test'}));
+
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        resource: resource,
+        timestamp: timestamp,
+        observedTimestamp: observedTimestamp,
+        severityNumber: Severity.INFO,
+        severityText: 'INFO',
+        body: 'Test message',
+        attributes: attributes,
+        eventName: 'test.event',
+      );
+
+      expect(logRecord.timestamp, equals(timestamp));
+      expect(logRecord.observedTimestamp, equals(observedTimestamp));
+      expect(logRecord.severityNumber, equals(Severity.INFO));
+      expect(logRecord.severityText, equals('INFO'));
+      expect(logRecord.body, equals('Test message'));
+      expect(logRecord.attributes, isNotNull);
+      expect(logRecord.eventName, equals('test.event'));
+      expect(logRecord.instrumentationScope, equals(scope));
+      expect(logRecord.resource, equals(resource));
+    });
+
+    test('SDKLogRecord allows setting fields after construction', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+      );
+
+      // All fields should be settable
+      logRecord.timestamp = Int64(1234567890);
+      logRecord.observedTimestamp = Int64(1234567891);
+      logRecord.severityNumber = Severity.ERROR;
+      logRecord.severityText = 'ERROR';
+      logRecord.body = 'Updated body';
+      logRecord.eventName = 'updated.event';
+
+      expect(logRecord.timestamp, equals(Int64(1234567890)));
+      expect(logRecord.observedTimestamp, equals(Int64(1234567891)));
+      expect(logRecord.severityNumber, equals(Severity.ERROR));
+      expect(logRecord.severityText, equals('ERROR'));
+      expect(logRecord.body, equals('Updated body'));
+      expect(logRecord.eventName, equals('updated.event'));
+    });
+
+    test('SDKLogRecord addAttribute adds new attribute', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+      );
+
+      logRecord.addAttribute(OTel.attributeString('key1', 'value1'));
+
+      expect(logRecord.attributes, isNotNull);
+      final attrs = logRecord.attributes!.toList();
+      expect(attrs.length, equals(1));
+      expect(attrs.first.key, equals('key1'));
+      expect(attrs.first.value, equals('value1'));
+    });
+
+    test('SDKLogRecord addAttribute appends to existing attributes', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        attributes: OTel.attributesFromMap({'existing': 'value'}),
+      );
+
+      logRecord.addAttribute(OTel.attributeString('new', 'attribute'));
+
+      final attrs = logRecord.attributes!.toList();
+      expect(attrs.length, equals(2));
+    });
+
+    test('SDKLogRecord removeAttribute removes attribute by key', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        attributes: OTel.attributesFromMap({
+          'keep': 'value1',
+          'remove': 'value2',
+        }),
+      );
+
+      logRecord.removeAttribute('remove');
+
+      final attrs = logRecord.attributes!.toList();
+      expect(attrs.length, equals(1));
+      expect(attrs.first.key, equals('keep'));
+    });
+
+    test('SDKLogRecord clone creates deep copy', () {
+      final original = SDKLogRecord(
+        instrumentationScope: scope,
+        timestamp: Int64(12345),
+        observedTimestamp: Int64(12346),
+        severityNumber: Severity.WARN,
+        severityText: 'WARN',
+        body: 'Original body',
+        attributes: OTel.attributesFromMap({'key': 'value'}),
+        eventName: 'original.event',
+      );
+
+      final clone = original.clone();
+
+      // Clone should have same values
+      expect(clone.timestamp, equals(original.timestamp));
+      expect(clone.observedTimestamp, equals(original.observedTimestamp));
+      expect(clone.severityNumber, equals(original.severityNumber));
+      expect(clone.severityText, equals(original.severityText));
+      expect(clone.body, equals(original.body));
+      expect(clone.eventName, equals(original.eventName));
+
+      // Modifying clone should not affect original
+      clone.body = 'Modified body';
+      clone.severityNumber = Severity.ERROR;
+
+      expect(original.body, equals('Original body'));
+      expect(original.severityNumber, equals(Severity.WARN));
+    });
+
+    test('SDKLogRecord applies attribute limits', () {
+      // Set a low limit for testing
+      final originalLimit = SDKLogRecord.maxAttributeCount;
+      SDKLogRecord.maxAttributeCount = 3;
+
+      try {
+        final attributes = OTel.attributesFromMap({
+          'key1': 'value1',
+          'key2': 'value2',
+          'key3': 'value3',
+          'key4': 'value4',
+          'key5': 'value5',
+        });
+
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          attributes: attributes,
+        );
+
+        // Should have max 3 attributes
+        expect(logRecord.attributes!.length, equals(3));
+        expect(logRecord.droppedAttributesCount, equals(2));
+      } finally {
+        SDKLogRecord.maxAttributeCount = originalLimit;
+      }
+    });
+
+    test('SDKLogRecord addAttribute respects limits', () {
+      final originalLimit = SDKLogRecord.maxAttributeCount;
+      SDKLogRecord.maxAttributeCount = 2;
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          attributes: OTel.attributesFromMap({
+            'key1': 'value1',
+            'key2': 'value2',
+          }),
+        );
+
+        // At limit, adding should increment dropped count
+        logRecord.addAttribute(OTel.attributeString('key3', 'value3'));
+
+        expect(logRecord.attributes!.length, equals(2));
+        expect(logRecord.droppedAttributesCount, equals(1));
+      } finally {
+        SDKLogRecord.maxAttributeCount = originalLimit;
+      }
+    });
+
+    test('SDKLogRecord extracts trace context from Context', () async {
+      // Create a span to get trace context
+      final tracer = OTel.tracer();
+      final span = tracer.startSpan('test-span');
+
+      try {
+        final logRecord = SDKLogRecord(
+          instrumentationScope: scope,
+          context: Context.current,
+        );
+
+        // Should have trace context from the active span
+        expect(logRecord.traceId, isNotNull);
+        expect(logRecord.spanId, isNotNull);
+        expect(logRecord.traceFlags, isNotNull);
+      } finally {
+        span.end();
+      }
+    });
+
+    test('SDKLogRecord traceId/spanId/traceFlags are settable', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+      );
+
+      final traceId = OTel.traceId();
+      final spanId = OTel.spanId();
+      final traceFlags = TraceFlags.sampled;
+
+      logRecord.traceId = traceId;
+      logRecord.spanId = spanId;
+      logRecord.traceFlags = traceFlags;
+
+      expect(logRecord.traceId, equals(traceId));
+      expect(logRecord.spanId, equals(spanId));
+      expect(logRecord.traceFlags, equals(traceFlags));
+    });
+
+    test('SDKLogRecord toString provides useful output', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Test message',
+      );
+
+      final str = logRecord.toString();
+
+      expect(str, contains('SDKLogRecord'));
+      expect(str, contains('severity'));
+      expect(str, contains('body'));
+    });
+
+    test('SDKLogRecord handles null body', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        body: null,
+      );
+
+      expect(logRecord.body, isNull);
+    });
+
+    test('SDKLogRecord handles various body types', () {
+      // String body
+      var logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        body: 'String body',
+      );
+      expect(logRecord.body, equals('String body'));
+
+      // Int body
+      logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        body: 42,
+      );
+      expect(logRecord.body, equals(42));
+
+      // Map body
+      logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        body: {'key': 'value'},
+      );
+      expect(logRecord.body, isA<Map<String, String>>());
+
+      // List body
+      logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        body: [1, 2, 3],
+      );
+      expect(logRecord.body, isA<List<int>>());
+    });
+  });
+}

--- a/test/unit/metrics/attributes_equality_test.dart
+++ b/test/unit/metrics/attributes_equality_test.dart
@@ -31,10 +31,16 @@ void main() {
       map[attrs1] = 10;
 
       // Verify both can retrieve the value since they should be equal
-      expect(map.containsKey(attrs1), isTrue,
-          reason: "Map should contain the exact same key instance");
-      expect(map.containsKey(attrs2), isTrue,
-          reason: "Map should recognize equivalent keys");
+      expect(
+        map.containsKey(attrs1),
+        isTrue,
+        reason: "Map should contain the exact same key instance",
+      );
+      expect(
+        map.containsKey(attrs2),
+        isTrue,
+        reason: "Map should recognize equivalent keys",
+      );
       expect(map[attrs1], equals(10));
       expect(map[attrs2], equals(10));
 

--- a/test/unit/metrics/data/exemplar_test.dart
+++ b/test/unit/metrics/data/exemplar_test.dart
@@ -78,8 +78,10 @@ void main() {
 
       // Create a measurement using factory
       final value = 123.45;
-      final measurement =
-          createTestMeasurement(value, attributesWithMultipleEntries);
+      final measurement = createTestMeasurement(
+        value,
+        attributesWithMultipleEntries,
+      );
       final timestamp = DateTime.now();
 
       // Create exemplar from measurement
@@ -116,10 +118,16 @@ void main() {
         }
       }
 
-      expect(foundInstanceId, isTrue,
-          reason: "instance.id attribute missing or wrong value");
-      expect(foundCustomerId, isTrue,
-          reason: "customer.id attribute missing or wrong value");
+      expect(
+        foundInstanceId,
+        isTrue,
+        reason: "instance.id attribute missing or wrong value",
+      );
+      expect(
+        foundCustomerId,
+        isTrue,
+        reason: "customer.id attribute missing or wrong value",
+      );
 
       // End the span
       span.end();
@@ -166,10 +174,16 @@ void main() {
         }
       }
 
-      expect(foundExtra1, isTrue,
-          reason: "extra1 attribute missing or wrong value");
-      expect(foundExtra2, isTrue,
-          reason: "extra2 attribute missing or wrong value");
+      expect(
+        foundExtra1,
+        isTrue,
+        reason: "extra1 attribute missing or wrong value",
+      );
+      expect(
+        foundExtra2,
+        isTrue,
+        reason: "extra2 attribute missing or wrong value",
+      );
 
       // Verify excluded attributes - check they're not in the list
       bool hasCommon1 = false;
@@ -182,12 +196,21 @@ void main() {
         if (attr.key == 'other') hasOther = true;
       }
 
-      expect(hasCommon1, isFalse,
-          reason: "common1 shouldn't be in filtered attributes");
-      expect(hasCommon2, isFalse,
-          reason: "common2 shouldn't be in filtered attributes");
-      expect(hasOther, isFalse,
-          reason: "other shouldn't be in filtered attributes");
+      expect(
+        hasCommon1,
+        isFalse,
+        reason: "common1 shouldn't be in filtered attributes",
+      );
+      expect(
+        hasCommon2,
+        isFalse,
+        reason: "common2 shouldn't be in filtered attributes",
+      );
+      expect(
+        hasOther,
+        isFalse,
+        reason: "other shouldn't be in filtered attributes",
+      );
     });
 
     test('Exemplar._filterAttributes handles empty attributes', () {
@@ -207,8 +230,10 @@ void main() {
       expect(exemplar1.filteredAttributes.toList(), isEmpty);
 
       // Empty aggregation attributes
-      final someMeasurementAttrs =
-          Attributes.of({'key1': 'value1', 'key2': 'value2'});
+      final someMeasurementAttrs = Attributes.of({
+        'key1': 'value1',
+        'key2': 'value2',
+      });
       final emptyAggregationAttrs = OTelFactory.otelFactory!.attributes();
 
       final measurement2 = createTestMeasurement(100, someMeasurementAttrs);
@@ -347,8 +372,9 @@ Measurement createTestMeasurement(num value, Attributes? attributes) {
   // Access the last recorded measurement (for testing purposes only)
   // In a real implementation, you'd get this from the SDK internals
   return MockMeasurement(
-      value: value,
-      attributes: attributes ?? OTelFactory.otelFactory!.attributes());
+    value: value,
+    attributes: attributes ?? OTelFactory.otelFactory!.attributes(),
+  );
 }
 
 // Mock Measurement class for testing

--- a/test/unit/metrics/data/metric_data_test.dart
+++ b/test/unit/metrics/data/metric_data_test.dart
@@ -30,7 +30,8 @@ void main() {
 
     test('constructor sets properties', () {
       final resource = OTel.resource(
-          OTel.attributes([OTel.attributeString('service.name', 'my-svc')]));
+        OTel.attributes([OTel.attributeString('service.name', 'my-svc')]),
+      );
       final metric = createMetric('test.metric');
       final data = MetricData(resource: resource, metrics: [metric]);
 
@@ -71,7 +72,8 @@ void main() {
 
     test('filter() preserves resource', () {
       final resource = OTel.resource(
-          OTel.attributes([OTel.attributeString('service.name', 'my-svc')]));
+        OTel.attributes([OTel.attributeString('service.name', 'my-svc')]),
+      );
       final m1 = createMetric('requests.count');
       final data = MetricData(resource: resource, metrics: [m1]);
 
@@ -98,9 +100,11 @@ void main() {
 
     test('merge() uses first resource if available', () {
       final resource1 = OTel.resource(
-          OTel.attributes([OTel.attributeString('service.name', 'svc-1')]));
+        OTel.attributes([OTel.attributeString('service.name', 'svc-1')]),
+      );
       final resource2 = OTel.resource(
-          OTel.attributes([OTel.attributeString('service.name', 'svc-2')]));
+        OTel.attributes([OTel.attributeString('service.name', 'svc-2')]),
+      );
 
       final data1 = MetricData(resource: resource1, metrics: []);
       final data2 = MetricData(resource: resource2, metrics: []);
@@ -112,7 +116,8 @@ void main() {
 
     test('merge() uses other resource if first is null', () {
       final resource2 = OTel.resource(
-          OTel.attributes([OTel.attributeString('service.name', 'svc-2')]));
+        OTel.attributes([OTel.attributeString('service.name', 'svc-2')]),
+      );
 
       final data1 = MetricData(metrics: []);
       final data2 = MetricData(resource: resource2, metrics: []);

--- a/test/unit/metrics/data/metric_factory_test.dart
+++ b/test/unit/metrics/data/metric_factory_test.dart
@@ -8,10 +8,7 @@ import 'package:test/test.dart';
 void main() {
   setUp(() async {
     await OTel.reset();
-    await OTel.initialize(
-      serviceName: 'test',
-      detectPlatformResources: false,
-    );
+    await OTel.initialize(serviceName: 'test', detectPlatformResources: false);
   });
 
   tearDown(() async {
@@ -56,33 +53,34 @@ void main() {
 
   group('Metric.sum factory', () {
     test(
-        'sets type to sum with default monotonic true and cumulative temporality',
-        () {
-      final now = DateTime.now();
-      final points = <MetricPoint<dynamic>>[
-        MetricPoint<int>(
-          attributes: Attributes.of({'key': 'value'}),
-          startTime: now.subtract(const Duration(seconds: 5)),
-          endTime: now,
-          value: 10,
-        ),
-      ];
+      'sets type to sum with default monotonic true and cumulative temporality',
+      () {
+        final now = DateTime.now();
+        final points = <MetricPoint<dynamic>>[
+          MetricPoint<int>(
+            attributes: Attributes.of({'key': 'value'}),
+            startTime: now.subtract(const Duration(seconds: 5)),
+            endTime: now,
+            value: 10,
+          ),
+        ];
 
-      final metric = Metric.sum(
-        name: 'sum_metric',
-        description: 'A sum metric',
-        unit: 'requests',
-        points: points,
-      );
+        final metric = Metric.sum(
+          name: 'sum_metric',
+          description: 'A sum metric',
+          unit: 'requests',
+          points: points,
+        );
 
-      expect(metric.name, equals('sum_metric'));
-      expect(metric.description, equals('A sum metric'));
-      expect(metric.unit, equals('requests'));
-      expect(metric.type, equals(MetricType.sum));
-      expect(metric.temporality, equals(AggregationTemporality.cumulative));
-      expect(metric.isMonotonic, isTrue);
-      expect(metric.points, equals(points));
-    });
+        expect(metric.name, equals('sum_metric'));
+        expect(metric.description, equals('A sum metric'));
+        expect(metric.unit, equals('requests'));
+        expect(metric.type, equals(MetricType.sum));
+        expect(metric.temporality, equals(AggregationTemporality.cumulative));
+        expect(metric.isMonotonic, isTrue);
+        expect(metric.points, equals(points));
+      },
+    );
 
     test('with delta temporality', () {
       final now = DateTime.now();
@@ -223,10 +221,14 @@ void main() {
   group('AggregationTemporality enum', () {
     test('has all expected values', () {
       expect(AggregationTemporality.values, hasLength(2));
-      expect(AggregationTemporality.values,
-          contains(AggregationTemporality.cumulative));
-      expect(AggregationTemporality.values,
-          contains(AggregationTemporality.delta));
+      expect(
+        AggregationTemporality.values,
+        contains(AggregationTemporality.cumulative),
+      );
+      expect(
+        AggregationTemporality.values,
+        contains(AggregationTemporality.delta),
+      );
     });
   });
 
@@ -236,8 +238,10 @@ void main() {
       expect(MetricPointKind.values, contains(MetricPointKind.sum));
       expect(MetricPointKind.values, contains(MetricPointKind.gauge));
       expect(MetricPointKind.values, contains(MetricPointKind.histogram));
-      expect(MetricPointKind.values,
-          contains(MetricPointKind.exponentialHistogram));
+      expect(
+        MetricPointKind.values,
+        contains(MetricPointKind.exponentialHistogram),
+      );
     });
   });
 }

--- a/test/unit/metrics/data/metric_point_test.dart
+++ b/test/unit/metrics/data/metric_point_test.dart
@@ -233,10 +233,7 @@ void main() {
           value: 42,
         );
 
-        expect(
-          point.histogram,
-          throwsA(isA<StateError>()),
-        );
+        expect(point.histogram, throwsA(isA<StateError>()));
       });
     });
   });

--- a/test/unit/metrics/export/composite_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/composite_metric_exporter_full_test.dart
@@ -7,10 +7,7 @@ import 'package:test/test.dart';
 void main() {
   setUp(() async {
     await OTel.reset();
-    await OTel.initialize(
-      serviceName: 'test',
-      detectPlatformResources: false,
-    );
+    await OTel.initialize(serviceName: 'test', detectPlatformResources: false);
   });
 
   tearDown(() async {

--- a/test/unit/metrics/export/composite_metric_exporter_test.dart
+++ b/test/unit/metrics/export/composite_metric_exporter_test.dart
@@ -61,12 +61,14 @@ void main() {
       expect(metrics2.isNotEmpty, isTrue);
 
       // Find the test_counter metric in each exporter
-      final metric1 = metrics1.firstWhere((m) => m.name == 'test_counter',
-          orElse: () =>
-              throw StateError('test_counter not found in exporter1'));
-      final metric2 = metrics2.firstWhere((m) => m.name == 'test_counter',
-          orElse: () =>
-              throw StateError('test_counter not found in exporter2'));
+      final metric1 = metrics1.firstWhere(
+        (m) => m.name == 'test_counter',
+        orElse: () => throw StateError('test_counter not found in exporter1'),
+      );
+      final metric2 = metrics2.firstWhere(
+        (m) => m.name == 'test_counter',
+        orElse: () => throw StateError('test_counter not found in exporter2'),
+      );
 
       // Verify the metrics exist
       expect(metric1, isNotNull);
@@ -77,90 +79,94 @@ void main() {
       expect(metric2.name, equals('test_counter'));
     });
 
-    test('CompositeMetricExporter handles exporter failures gracefully',
-        () async {
-      // Create a test exporter that fails on export
-      final failingExporter = _FailingMetricExporter();
+    test(
+      'CompositeMetricExporter handles exporter failures gracefully',
+      () async {
+        // Create a test exporter that fails on export
+        final failingExporter = _FailingMetricExporter();
 
-      // Create a composite with the failing exporter and one normal one
-      final compositeWithFailure = CompositeMetricExporter([
-        failingExporter,
-        exporter1,
-      ]);
+        // Create a composite with the failing exporter and one normal one
+        final compositeWithFailure = CompositeMetricExporter([
+          failingExporter,
+          exporter1,
+        ]);
 
-      // Clear previous metrics
-      exporter1.clear();
+        // Clear previous metrics
+        exporter1.clear();
 
-      // Create a new instance with our test reader
-      await OTel.reset();
-      // Use a separate reader for test infrastructure
-      final memoryMetricReader = MemoryMetricReader();
+        // Create a new instance with our test reader
+        await OTel.reset();
+        // Use a separate reader for test infrastructure
+        final memoryMetricReader = MemoryMetricReader();
 
-      await OTel.initialize(
-        serviceName: 'failure-test-service',
-        metricReader: memoryMetricReader,
-        detectPlatformResources: false,
-      );
+        await OTel.initialize(
+          serviceName: 'failure-test-service',
+          metricReader: memoryMetricReader,
+          detectPlatformResources: false,
+        );
 
-      // Get a meter and record data
-      final meter = OTel.meter('failure-test');
-      final counter = meter.createCounter<int>(name: 'failure_counter');
-      counter.add(42);
+        // Get a meter and record data
+        final meter = OTel.meter('failure-test');
+        final counter = meter.createCounter<int>(name: 'failure_counter');
+        counter.add(42);
 
-      // Collect metrics
-      final data = await memoryMetricReader.collect();
+        // Collect metrics
+        final data = await memoryMetricReader.collect();
 
-      // Manually export through our composite exporter
-      final bool result = await compositeWithFailure.export(data);
+        // Manually export through our composite exporter
+        final bool result = await compositeWithFailure.export(data);
 
-      // Since one exporter fails, the composite should return false
-      expect(result, isFalse);
+        // Since one exporter fails, the composite should return false
+        expect(result, isFalse);
 
-      // But metrics should still reach the working exporter
-      expect(exporter1.exportedMetrics.isNotEmpty, isTrue);
-    });
+        // But metrics should still reach the working exporter
+        expect(exporter1.exportedMetrics.isNotEmpty, isTrue);
+      },
+    );
 
-    test('CompositeMetricExporter forceFlush and shutdown calls all exporters',
-        () async {
-      // Create tracked exporters
-      final trackedExporter1 = _TrackedMetricExporter();
-      final trackedExporter2 = _TrackedMetricExporter();
+    test(
+      'CompositeMetricExporter forceFlush and shutdown calls all exporters',
+      () async {
+        // Create tracked exporters
+        final trackedExporter1 = _TrackedMetricExporter();
+        final trackedExporter2 = _TrackedMetricExporter();
 
-      // Create composite
-      final composite = CompositeMetricExporter([
-        trackedExporter1,
-        trackedExporter2,
-      ]);
+        // Create composite
+        final composite = CompositeMetricExporter([
+          trackedExporter1,
+          trackedExporter2,
+        ]);
 
-      // Create an empty MetricData for testing
-      final emptyData = MetricData.empty();
+        // Create an empty MetricData for testing
+        final emptyData = MetricData.empty();
 
-      // Call export
-      final bool result = await composite.export(emptyData);
+        // Call export
+        final bool result = await composite.export(emptyData);
 
-      // Export should succeed
-      expect(result, isTrue);
+        // Export should succeed
+        expect(result, isTrue);
 
-      // Verify both exporters had export called
-      expect(trackedExporter1.exportCalled, isTrue);
-      expect(trackedExporter2.exportCalled, isTrue);
+        // Verify both exporters had export called
+        expect(trackedExporter1.exportCalled, isTrue);
+        expect(trackedExporter2.exportCalled, isTrue);
 
-      // Call forceFlush
-      final bool flushResult = await composite.forceFlush();
-      expect(flushResult, isTrue);
+        // Call forceFlush
+        final bool flushResult = await composite.forceFlush();
+        expect(flushResult, isTrue);
 
-      // Verify both exporters had forceFlush called
-      expect(trackedExporter1.forceFlushCalled, isTrue);
-      expect(trackedExporter2.forceFlushCalled, isTrue);
+        // Verify both exporters had forceFlush called
+        expect(trackedExporter1.forceFlushCalled, isTrue);
+        expect(trackedExporter2.forceFlushCalled, isTrue);
 
-      // Call shutdown
-      final bool shutdownResult = await composite.shutdown();
-      expect(shutdownResult, isTrue);
+        // Call shutdown
+        final bool shutdownResult = await composite.shutdown();
+        expect(shutdownResult, isTrue);
 
-      // Verify both exporters had shutdown called
-      expect(trackedExporter1.shutdownCalled, isTrue);
-      expect(trackedExporter2.shutdownCalled, isTrue);
-    });
+        // Verify both exporters had shutdown called
+        expect(trackedExporter1.shutdownCalled, isTrue);
+        expect(trackedExporter2.shutdownCalled, isTrue);
+      },
+    );
   });
 }
 
@@ -170,7 +176,7 @@ class _FailingMetricExporter implements MetricExporter {
 
   @override
   Future<bool> export(MetricData data) async {
-// This exporter intentionally fails and returns false to test that the composite exporter correctly propagates failures
+    // This exporter intentionally fails and returns false to test that the composite exporter correctly propagates failures
     print('Intentional export failure that should be caught internally');
     return false;
   }

--- a/test/unit/metrics/export/metric_exporter_shutdown_test.dart
+++ b/test/unit/metrics/export/metric_exporter_shutdown_test.dart
@@ -42,8 +42,10 @@ void main() {
 
     setUp(() async {
       exporter = MockMetricExporter();
-      reader = PeriodicExportingMetricReader(exporter,
-          interval: const Duration(milliseconds: 100));
+      reader = PeriodicExportingMetricReader(
+        exporter,
+        interval: const Duration(milliseconds: 100),
+      );
 
       await OTel.reset();
       await OTel.initialize(

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
@@ -25,15 +25,14 @@ void main() {
       endTime: now,
       value: 42,
     );
-    return MetricData(metrics: [
-      Metric.sum(name: 'c', points: [point])
-    ]);
+    return MetricData(
+      metrics: [
+        Metric.sum(name: 'c', points: [point]),
+      ],
+    );
   }
 
-  Future<void> startServer({
-    List<int>? codes,
-    Duration? delay,
-  }) async {
+  Future<void> startServer({List<int>? codes, Duration? delay}) async {
     responseCodes = codes ?? [200];
     requestCount = 0;
     server = await HttpServer.bind('localhost', 0);
@@ -55,22 +54,30 @@ void main() {
     String? clientKey,
     String? clientCertificate,
   }) =>
-      OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: endpoint ?? 'http://localhost:$port',
-        compression: compression,
-        maxRetries: 2,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-        certificate: certificate,
-        clientKey: clientKey,
-        clientCertificate: clientCertificate,
-      ));
+      OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: endpoint ?? 'http://localhost:$port',
+          compression: compression,
+          maxRetries: 2,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+          certificate: certificate,
+          clientKey: clientKey,
+          clientCertificate: clientCertificate,
+        ),
+      );
 
   setUp(() async {
     await OTel.reset();
-    OTelLog.enableTraceLogging();
     OTelLog.logFunction = (_) {};
-    await OTel.initialize(serviceName: 'test', detectPlatformResources: false);
+    await OTel.initialize(
+      serviceName: 'test',
+      detectPlatformResources: false,
+      enableLogs: false,
+    );
+    // Set trace logging AFTER initialize, since initializeLogging() reads
+    // OTEL_LOG_LEVEL from env and would override a level set before it.
+    OTelLog.enableTraceLogging();
   });
 
   tearDown(() async {
@@ -83,11 +90,11 @@ void main() {
   });
 
   // ---------------------------------------------------------------
-  // _createHttpClient certificate paths (lines 55-77)
+  // _createHttpClient certificate paths
   // ---------------------------------------------------------------
   group('_createHttpClient certificate paths', () {
     test('null security context falls back to default client', () async {
-      // test:// certs cause createSecurityContext to return null -> line 62
+      // test:// certs cause createSecurityContext to return null
       await startServer();
       final exp = createExporter(certificate: 'test://ca.pem');
       final result = await exp.export(makeMetrics());
@@ -98,7 +105,7 @@ void main() {
 
     test('test:// client cert+key exercises certificate error path', () async {
       // test:// scheme passes config validation but createSecurityContext
-      // returns null for test:// -> line 62, or throws -> lines 71-76
+      // returns null for test://, or throws on invalid cert loading
       await startServer();
       final exp = createExporter(
         certificate: 'test://ca.pem',
@@ -112,7 +119,7 @@ void main() {
   });
 
   // ---------------------------------------------------------------
-  // _export retry on ClientException (lines 174-221)
+  // _export retry on ClientException
   // Now reachable after the _tryExport bug fix.
   // ---------------------------------------------------------------
   group('_export retry on ClientException', () {
@@ -136,7 +143,7 @@ void main() {
     });
 
     test('gives up after max retries on 503', () async {
-      // 3 attempts: initial + 2 retries, all 503 -> lines 208-213
+      // 3 attempts: initial + 2 retries, all 503 -> gives up after max retries
       await startServer(codes: [503, 503, 503]);
       final exp = createExporter();
       final result = await exp.export(makeMetrics());
@@ -146,7 +153,7 @@ void main() {
     });
 
     test('non-retryable 400 returns false immediately', () async {
-      // 400 -> ClientException caught -> not retryable -> lines 200-205
+      // 400 -> ClientException caught -> not retryable -> returns false immediately
       await startServer(codes: [400]);
       final exp = createExporter();
       final result = await exp.export(makeMetrics());
@@ -165,7 +172,7 @@ void main() {
     });
 
     test('_calculateJitteredDelay is exercised during retry', () async {
-      // Retry triggers _calculateJitteredDelay at line 216 -> lines 80-84
+      // Retry triggers _calculateJitteredDelay during the backoff wait
       await startServer(codes: [503, 200]);
       final exp = createExporter();
       final result = await exp.export(makeMetrics());
@@ -175,21 +182,23 @@ void main() {
   });
 
   // ---------------------------------------------------------------
-  // _export generic catch block (lines 222-245)
+  // _export generic catch block
   // Triggered by non-ClientException errors like SocketException
   // ---------------------------------------------------------------
   group('_export generic catch block', () {
     test('connection refused triggers generic catch and retries', () async {
       // Connect to a port with no server -> SocketException
-      // -> caught by generic catch block lines 223-245
+      // -> caught by the generic catch block
       await startServer(); // start then close to get a valid port
       await server.close(force: true);
-      final exp = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 1,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exp = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 1,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final result = await exp.export(makeMetrics());
       expect(result, isFalse);
       await exp.shutdown();
@@ -198,12 +207,14 @@ void main() {
     test('generic error gives up after max retries', () async {
       await startServer();
       await server.close(force: true);
-      final exp = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 2,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exp = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 2,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final result = await exp.export(makeMetrics());
       expect(result, isFalse);
       await exp.shutdown();
@@ -211,7 +222,7 @@ void main() {
   });
 
   // ---------------------------------------------------------------
-  // Shutdown-during-export paths (lines 125-130, 143, 160-165)
+  // Shutdown-during-export paths
   // ---------------------------------------------------------------
   group('shutdown during export', () {
     test('export catches shutdown-interrupted StateError', () async {
@@ -232,7 +243,7 @@ void main() {
     });
 
     test('_export at start detects shutdown', () async {
-      // Shutdown before calling _export -> line 143
+      // Shutdown before calling _export -> detects shutdown at start
       await startServer();
       final exp = createExporter();
       await exp.shutdown();
@@ -240,14 +251,16 @@ void main() {
     });
 
     test('shutdown during retry stops retrying', () async {
-      // 503 triggers retry, but shutdown during delay -> lines 160-165
+      // 503 triggers retry, but shutdown during delay stops retrying
       await startServer(codes: [503, 503, 503, 503]);
-      final exp = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 5,
-        baseDelay: const Duration(milliseconds: 50),
-        maxDelay: const Duration(milliseconds: 100),
-      ));
+      final exp = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 5,
+          baseDelay: const Duration(milliseconds: 50),
+          maxDelay: const Duration(milliseconds: 100),
+        ),
+      );
 
       // Start export (will get 503 and start retrying)
       final exportFuture = exp.export(makeMetrics());
@@ -261,30 +274,37 @@ void main() {
       expect(requestCount, lessThan(5));
     });
 
-    test('ClientException during shutdown-flagged export throws StateError',
-        () async {
-      // When wasShutdownDuringRetry is true and ClientException caught
-      // -> lines 182-186
-      await startServer(codes: [503], delay: const Duration(milliseconds: 100));
-      final exp = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 50),
-        maxDelay: const Duration(milliseconds: 100),
-      ));
+    test(
+      'ClientException during shutdown-flagged export throws StateError',
+      () async {
+        // When wasShutdownDuringRetry is true and ClientException caught,
+        // the export throws a StateError
+        await startServer(
+          codes: [503],
+          delay: const Duration(milliseconds: 100),
+        );
+        final exp = OtlpHttpMetricExporter(
+          OtlpHttpMetricExporterConfig(
+            endpoint: 'http://localhost:$port',
+            maxRetries: 3,
+            baseDelay: const Duration(milliseconds: 50),
+            maxDelay: const Duration(milliseconds: 100),
+          ),
+        );
 
-      final exportFuture = exp.export(makeMetrics());
-      // Shutdown while waiting for retry
-      await Future<void>.delayed(const Duration(milliseconds: 200));
-      await exp.shutdown();
+        final exportFuture = exp.export(makeMetrics());
+        // Shutdown while waiting for retry
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+        await exp.shutdown();
 
-      final result = await exportFuture;
-      expect(result, isFalse);
-    });
+        final result = await exportFuture;
+        expect(result, isFalse);
+      },
+    );
   });
 
   // ---------------------------------------------------------------
-  // forceFlush with pending exports (lines 380-393)
+  // forceFlush with pending exports
   // ---------------------------------------------------------------
   group('forceFlush with pending exports', () {
     test('waits for pending exports to complete', () async {
@@ -296,7 +316,7 @@ void main() {
       exp.export(makeMetrics());
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
-      // forceFlush should wait for it -> lines 380-390
+      // forceFlush should wait for the pending export to complete
       final flushed = await exp.forceFlush();
       expect(flushed, isTrue);
       await exp.shutdown();
@@ -315,7 +335,7 @@ void main() {
       // Kill the server mid-request
       await server.close(force: true);
 
-      // forceFlush should catch the error -> lines 391-395
+      // forceFlush should catch the error from the failed export
       // It may return true or false depending on timing
       await exp.forceFlush();
       await exp.shutdown();
@@ -323,7 +343,7 @@ void main() {
   });
 
   // ---------------------------------------------------------------
-  // shutdown with pending exports (lines 427-444)
+  // shutdown with pending exports
   // ---------------------------------------------------------------
   group('shutdown with pending exports', () {
     test('waits for pending exports with timeout', () async {
@@ -335,7 +355,7 @@ void main() {
       exp.export(makeMetrics());
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
-      // Shutdown waits for pending -> lines 427-440
+      // Shutdown waits for pending exports to complete with timeout
       final result = await exp.shutdown();
       expect(result, isTrue);
     });
@@ -352,7 +372,7 @@ void main() {
       // Kill server so export fails
       await server.close(force: true);
 
-      // Shutdown should handle the error -> lines 441-444
+      // Shutdown should handle the error from the failing pending export
       final result = await exp.shutdown();
       expect(result, isTrue); // shutdown still returns true
     });

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -20,8 +20,10 @@ void main() {
       server.listen((request) async {
         receivedRequests.add(request);
         // Drain the request body so the connection completes properly
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         request.response.statusCode = 200;
         await request.response.close();
       });
@@ -51,9 +53,9 @@ void main() {
     }
 
     test('export sends metrics to endpoint', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final metricData = createTestMetricData();
       final result = await exporter.export(metricData);
@@ -64,9 +66,9 @@ void main() {
     });
 
     test('export sends protobuf content type', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final metricData = createTestMetricData();
       await exporter.export(metricData);
@@ -80,9 +82,9 @@ void main() {
     });
 
     test('export appends /v1/metrics to endpoint', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final metricData = createTestMetricData();
       await exporter.export(metricData);
@@ -93,10 +95,12 @@ void main() {
     });
 
     test('export with compression sends gzip content encoding', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        compression: true,
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          compression: true,
+        ),
+      );
 
       final metricData = createTestMetricData();
       await exporter.export(metricData);
@@ -110,10 +114,12 @@ void main() {
     });
 
     test('export with custom headers includes them', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        headers: {'x-custom': 'test-value'},
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          headers: {'x-custom': 'test-value'},
+        ),
+      );
 
       final metricData = createTestMetricData();
       await exporter.export(metricData);
@@ -127,9 +133,9 @@ void main() {
     });
 
     test('export with empty metrics returns true', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final result = await exporter.export(MetricData.empty());
 
@@ -140,17 +146,14 @@ void main() {
     });
 
     test('export after shutdown throws StateError', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       await exporter.shutdown();
 
       final metricData = createTestMetricData();
-      expect(
-        () => exporter.export(metricData),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export(metricData), throwsA(isA<StateError>()));
     });
 
     test('export retries on 503', () async {
@@ -162,8 +165,10 @@ void main() {
       port = server.port;
       server.listen((request) async {
         requestCount++;
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         if (requestCount == 1) {
           request.response.statusCode = 503;
         } else {
@@ -172,12 +177,14 @@ void main() {
         await request.response.close();
       });
 
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 10),
-        maxDelay: const Duration(milliseconds: 50),
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 3,
+          baseDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
 
       final metricData = createTestMetricData();
       final result = await exporter.export(metricData);
@@ -197,18 +204,22 @@ void main() {
       port = server.port;
       server.listen((request) async {
         requestCount++;
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         request.response.statusCode = 400;
         await request.response.close();
       });
 
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 10),
-        maxDelay: const Duration(milliseconds: 50),
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 3,
+          baseDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
 
       final metricData = createTestMetricData();
       final result = await exporter.export(metricData);
@@ -220,9 +231,9 @@ void main() {
     });
 
     test('forceFlush returns true', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final result = await exporter.forceFlush();
       expect(result, isTrue);
@@ -230,23 +241,20 @@ void main() {
     });
 
     test('shutdown then export throws', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       await exporter.shutdown();
 
       final metricData = createTestMetricData();
-      expect(
-        () => exporter.export(metricData),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export(metricData), throwsA(isA<StateError>()));
     });
 
     test('_getEndpointUrl appends /v1/metrics', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final metricData = createTestMetricData();
       await exporter.export(metricData);
@@ -257,9 +265,9 @@ void main() {
     });
 
     test('export with trailing slash endpoint appends /v1/metrics', () async {
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port/',
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port/'),
+      );
 
       final metricData = createTestMetricData();
       await exporter.export(metricData);

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_retry_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_retry_test.dart
@@ -17,7 +17,6 @@ void main() {
 
     setUp(() async {
       await OTel.reset();
-      OTelLog.enableTraceLogging();
       OTelLog.metricLogFunction = (_) {};
       OTelLog.logFunction = (_) {};
       requestCount = 0;
@@ -34,7 +33,11 @@ void main() {
       await OTel.initialize(
         serviceName: 'test',
         detectPlatformResources: false,
+        enableLogs: false,
       );
+      // Set trace logging AFTER initialize, since initializeLogging() reads
+      // OTEL_LOG_LEVEL from env and would override a level set before it.
+      OTelLog.enableTraceLogging();
     });
 
     tearDown(() async {
@@ -60,12 +63,14 @@ void main() {
     }
 
     OtlpHttpMetricExporter createExporter({int maxRetries = 2}) {
-      return OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: maxRetries,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      return OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: maxRetries,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
     }
 
     test('export with debug logging exercises all log paths', () async {
@@ -122,29 +127,33 @@ void main() {
       await exporter.shutdown();
     });
 
-    test('constructor with certificate config exercises _createHttpClient',
-        () async {
-      // Using test:// scheme paths exercises the certificate code path
-      // in _createHttpClient without requiring real cert files
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        certificate: 'test://ca-cert',
-        clientKey: 'test://client-key',
-        clientCertificate: 'test://client-cert',
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
-      expect(exporter, isNotNull);
+    test(
+      'constructor with certificate config exercises _createHttpClient',
+      () async {
+        // Using test:// scheme paths exercises the certificate code path
+        // in _createHttpClient without requiring real cert files
+        final exporter = OtlpHttpMetricExporter(
+          OtlpHttpMetricExporterConfig(
+            endpoint: 'http://localhost:$port',
+            certificate: 'test://ca-cert',
+            clientKey: 'test://client-key',
+            clientCertificate: 'test://client-cert',
+            maxRetries: 0,
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        );
+        expect(exporter, isNotNull);
 
-      // It should still work with the test:// certificate client
-      statusCodes = [200];
-      final metricData = createTestMetricData();
-      final result = await exporter.export(metricData);
-      expect(result, isTrue);
-      expect(requestCount, equals(1));
-      await exporter.shutdown();
-    });
+        // It should still work with the test:// certificate client
+        statusCodes = [200];
+        final metricData = createTestMetricData();
+        final result = await exporter.export(metricData);
+        expect(result, isTrue);
+        expect(requestCount, equals(1));
+        await exporter.shutdown();
+      },
+    );
 
     test('retries on 503 and gives up after max retries', () async {
       // After the _tryExport fix, ClientException is rethrown,
@@ -302,12 +311,14 @@ void main() {
       final logMessages = <String>[];
       OTelLog.logFunction = logMessages.add;
 
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final metricData = createTestMetricData();
 
       final result = await exporter.export(metricData);
@@ -345,10 +356,7 @@ void main() {
       await exporter.shutdown();
 
       final metricData = createTestMetricData();
-      expect(
-        () => exporter.export(metricData),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export(metricData), throwsA(isA<StateError>()));
     });
 
     test('shutdown debug log shows pending export count', () async {
@@ -364,13 +372,15 @@ void main() {
 
     test('export with compression succeeds', () async {
       statusCodes = [200];
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port',
-        compression: true,
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          compression: true,
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final metricData = createTestMetricData();
 
       final result = await exporter.export(metricData);
@@ -448,12 +458,14 @@ void main() {
 
     test('endpoint url with trailing slash', () async {
       statusCodes = [200];
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port/',
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port/',
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final metricData = createTestMetricData();
 
       final result = await exporter.export(metricData);
@@ -464,12 +476,14 @@ void main() {
 
     test('endpoint url already has /v1/metrics', () async {
       statusCodes = [200];
-      final exporter = OtlpHttpMetricExporter(OtlpHttpMetricExporterConfig(
-        endpoint: 'http://localhost:$port/v1/metrics',
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port/v1/metrics',
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final metricData = createTestMetricData();
 
       final result = await exporter.export(metricData);

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_test.dart
@@ -51,15 +51,10 @@ void main() {
         await exporter.shutdown();
 
         final metricData = MetricData(
-          metrics: [
-            Metric.sum(name: 'test-metric', points: []),
-          ],
+          metrics: [Metric.sum(name: 'test-metric', points: [])],
         );
 
-        expect(
-          () => exporter.export(metricData),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => exporter.export(metricData), throwsA(isA<StateError>()));
       });
 
       test('with empty metrics returns true', () async {
@@ -102,15 +97,10 @@ void main() {
 
         // After shutdown, export should throw
         final metricData = MetricData(
-          metrics: [
-            Metric.sum(name: 'test-metric', points: []),
-          ],
+          metrics: [Metric.sum(name: 'test-metric', points: [])],
         );
 
-        expect(
-          () => exporter.export(metricData),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => exporter.export(metricData), throwsA(isA<StateError>()));
       });
     });
 

--- a/test/unit/metrics/export/otlp/metric_transformer_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/metric_transformer_coverage_test.dart
@@ -25,10 +25,9 @@ void main() {
 
     group('transformResource', () {
       test('converts resource attributes to proto', () {
-        final resource = OTel.resource(Attributes.of({
-          'service.name': 'my-service',
-          'version': '2.0',
-        }));
+        final resource = OTel.resource(
+          Attributes.of({'service.name': 'my-service', 'version': '2.0'}),
+        );
 
         final proto = MetricTransformer.transformResource(resource);
         expect(proto.attributes, isNotEmpty);
@@ -41,12 +40,14 @@ void main() {
       });
 
       test('converts resource with list attributes', () {
-        final resource = ResourceCreate.create(OTel.attributesFromList([
-          OTel.attributeStringList('string_list', ['a', 'b']),
-          OTel.attributeBoolList('bool_list', [true, false]),
-          OTel.attributeIntList('int_list', [1, 2, 3]),
-          OTel.attributeDoubleList('double_list', [1.0, 2.0]),
-        ]));
+        final resource = ResourceCreate.create(
+          OTel.attributesFromList([
+            OTel.attributeStringList('string_list', ['a', 'b']),
+            OTel.attributeBoolList('bool_list', [true, false]),
+            OTel.attributeIntList('int_list', [1, 2, 3]),
+            OTel.attributeDoubleList('double_list', [1.0, 2.0]),
+          ]),
+        );
 
         final resourceProto = MetricTransformer.transformResource(resource);
         expect(resourceProto.attributes.length, equals(4));
@@ -92,10 +93,7 @@ void main() {
           time: now,
           value: 100,
         );
-        final metric = Metric.sum(
-          name: 'test.sum',
-          points: [point],
-        );
+        final metric = Metric.sum(name: 'test.sum', points: [point]);
 
         final metricProto = MetricTransformer.transformMetric(metric);
         expect(metricProto.name, equals('test.sum'));
@@ -104,7 +102,8 @@ void main() {
         expect(
           metricProto.sum.aggregationTemporality,
           equals(
-              proto.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE),
+            proto.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE,
+          ),
         );
       });
 
@@ -117,10 +116,7 @@ void main() {
           time: now,
           value: 42.5,
         );
-        final metric = Metric.gauge(
-          name: 'test.gauge',
-          points: [point],
-        );
+        final metric = Metric.gauge(name: 'test.gauge', points: [point]);
 
         final metricProto = MetricTransformer.transformMetric(metric);
         expect(metricProto.name, equals('test.gauge'));
@@ -273,10 +269,7 @@ void main() {
           exemplars: [exemplar],
         );
 
-        final metric = Metric.sum(
-          name: 'test.sum.exemplars',
-          points: [point],
-        );
+        final metric = Metric.sum(name: 'test.sum.exemplars', points: [point]);
 
         final metricProto = MetricTransformer.transformMetric(metric);
         final dp = metricProto.sum.dataPoints.first;
@@ -421,54 +414,53 @@ void main() {
 
     group('_createKeyValue scalar types', () {
       test('handles String value via resource', () {
-        final resource = ResourceCreate.create(
-          Attributes.of({'key': 'value'}),
-        );
+        final resource = ResourceCreate.create(Attributes.of({'key': 'value'}));
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'key');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'key',
+        );
         expect(attr.value.stringValue, equals('value'));
       });
 
       test('handles bool value via resource', () {
-        final resource = ResourceCreate.create(
-          Attributes.of({'flag': true}),
-        );
+        final resource = ResourceCreate.create(Attributes.of({'flag': true}));
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'flag');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'flag',
+        );
         expect(attr.value.boolValue, isTrue);
       });
 
       test('handles int value via resource', () {
-        final resource = ResourceCreate.create(
-          Attributes.of({'count': 42}),
-        );
+        final resource = ResourceCreate.create(Attributes.of({'count': 42}));
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'count');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'count',
+        );
         expect(attr.value.intValue, equals(Int64(42)));
       });
 
       test('handles double value via resource', () {
-        final resource = ResourceCreate.create(
-          Attributes.of({'ratio': 3.14}),
-        );
+        final resource = ResourceCreate.create(Attributes.of({'ratio': 3.14}));
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'ratio');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'ratio',
+        );
         expect(attr.value.doubleValue, equals(3.14));
       });
     });
 
     group('_createKeyValue array types', () {
       test('handles List<String> value', () {
-        final resource = ResourceCreate.create(OTel.attributesFromList([
-          OTel.attributeStringList('tags', ['web', 'prod']),
-        ]));
+        final resource = ResourceCreate.create(
+          OTel.attributesFromList([
+            OTel.attributeStringList('tags', ['web', 'prod']),
+          ]),
+        );
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'tags');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'tags',
+        );
         final arr = attr.value.arrayValue;
         expect(arr.values.length, equals(2));
         expect(arr.values[0].stringValue, equals('web'));
@@ -476,12 +468,15 @@ void main() {
       });
 
       test('handles List<bool> value', () {
-        final resource = ResourceCreate.create(OTel.attributesFromList([
-          OTel.attributeBoolList('flags', [true, false, true]),
-        ]));
+        final resource = ResourceCreate.create(
+          OTel.attributesFromList([
+            OTel.attributeBoolList('flags', [true, false, true]),
+          ]),
+        );
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'flags');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'flags',
+        );
         final arr = attr.value.arrayValue;
         expect(arr.values.length, equals(3));
         expect(arr.values[0].boolValue, isTrue);
@@ -490,12 +485,15 @@ void main() {
       });
 
       test('handles List<int> value', () {
-        final resource = ResourceCreate.create(OTel.attributesFromList([
-          OTel.attributeIntList('ids', [10, 20, 30]),
-        ]));
+        final resource = ResourceCreate.create(
+          OTel.attributesFromList([
+            OTel.attributeIntList('ids', [10, 20, 30]),
+          ]),
+        );
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'ids');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'ids',
+        );
         final arr = attr.value.arrayValue;
         expect(arr.values.length, equals(3));
         expect(arr.values[0].intValue, equals(Int64(10)));
@@ -504,12 +502,15 @@ void main() {
       });
 
       test('handles List<double> value', () {
-        final resource = ResourceCreate.create(OTel.attributesFromList([
-          OTel.attributeDoubleList('scores', [1.1, 2.2, 3.3]),
-        ]));
+        final resource = ResourceCreate.create(
+          OTel.attributesFromList([
+            OTel.attributeDoubleList('scores', [1.1, 2.2, 3.3]),
+          ]),
+        );
         final resourceProto = MetricTransformer.transformResource(resource);
-        final attr =
-            resourceProto.attributes.firstWhere((kv) => kv.key == 'scores');
+        final attr = resourceProto.attributes.firstWhere(
+          (kv) => kv.key == 'scores',
+        );
         final arr = attr.value.arrayValue;
         expect(arr.values.length, equals(3));
         expect(arr.values[0].doubleValue, equals(1.1));
@@ -531,18 +532,12 @@ void main() {
           time: now,
           value: 10,
         );
-        final metric = Metric.gauge(
-          name: 'logged.metric',
-          points: [point],
-        );
+        final metric = Metric.gauge(name: 'logged.metric', points: [point]);
 
         MetricTransformer.transformMetric(metric);
 
         expect(logs, isNotEmpty);
-        expect(
-          logs.any((l) => l.contains('logged.metric')),
-          isTrue,
-        );
+        expect(logs.any((l) => l.contains('logged.metric')), isTrue);
 
         OTelLog.metricLogFunction = null;
       });

--- a/test/unit/metrics/export/otlp/metric_transformer_test.dart
+++ b/test/unit/metrics/export/otlp/metric_transformer_test.dart
@@ -21,14 +21,16 @@ void main() {
 
     test('transformResource converts Resource attributes correctly', () {
       // Resource with various attribute types
-      final resource = OTel.resource(Attributes.of({
-        'service.name': 'test-service',
-        'service.version': '1.0.0',
-        'host.id': 'test-host',
-        'process.pid': 1234,
-        'is.test': true,
-        'cpu.usage': 0.75,
-      }));
+      final resource = OTel.resource(
+        Attributes.of({
+          'service.name': 'test-service',
+          'service.version': '1.0.0',
+          'host.id': 'test-host',
+          'process.pid': 1234,
+          'is.test': true,
+          'cpu.usage': 0.75,
+        }),
+      );
 
       // Transform the resourceAttributes
       final resourceProto = MetricTransformer.transformResource(resource);
@@ -38,7 +40,8 @@ void main() {
 
       // Check each attribute
       final attributeMap = Map.fromEntries(
-          resourceProto.attributes.map((kv) => MapEntry(kv.key, kv.value)));
+        resourceProto.attributes.map((kv) => MapEntry(kv.key, kv.value)),
+      );
 
       expect(attributeMap['service.name']!.stringValue, equals('test-service'));
       expect(attributeMap['service.version']!.stringValue, equals('1.0.0'));
@@ -83,10 +86,14 @@ void main() {
       // Check point details
       final gaugePoint = metricProto.gauge.dataPoints.first;
       expect(gaugePoint.asDouble, equals(42.5));
-      expect(gaugePoint.startTimeUnixNano,
-          equals(Int64(startTime.microsecondsSinceEpoch * 1000)));
-      expect(gaugePoint.timeUnixNano,
-          equals(Int64(nowTime.microsecondsSinceEpoch * 1000)));
+      expect(
+        gaugePoint.startTimeUnixNano,
+        equals(Int64(startTime.microsecondsSinceEpoch * 1000)),
+      );
+      expect(
+        gaugePoint.timeUnixNano,
+        equals(Int64(nowTime.microsecondsSinceEpoch * 1000)),
+      );
 
       // Check attributes
       expect(gaugePoint.attributes.length, equals(1));
@@ -129,17 +136,21 @@ void main() {
       expect(metricProto.sum.dataPoints.length, equals(1));
       expect(metricProto.sum.isMonotonic, isTrue);
       expect(
-          metricProto.sum.aggregationTemporality,
-          equals(
-              proto.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE));
+        metricProto.sum.aggregationTemporality,
+        equals(proto.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE),
+      );
 
       // Check point details
       final sumPoint = metricProto.sum.dataPoints.first;
       expect(sumPoint.asDouble, equals(100.0));
-      expect(sumPoint.startTimeUnixNano,
-          equals(Int64(startTime.microsecondsSinceEpoch * 1000)));
-      expect(sumPoint.timeUnixNano,
-          equals(Int64(nowTime.microsecondsSinceEpoch * 1000)));
+      expect(
+        sumPoint.startTimeUnixNano,
+        equals(Int64(startTime.microsecondsSinceEpoch * 1000)),
+      );
+      expect(
+        sumPoint.timeUnixNano,
+        equals(Int64(nowTime.microsecondsSinceEpoch * 1000)),
+      );
 
       // Check attributes
       expect(sumPoint.attributes.length, equals(1));
@@ -190,8 +201,10 @@ void main() {
 
       // Verify it was transformed as a histogram
       expect(metricProto.histogram.dataPoints.length, equals(1));
-      expect(metricProto.histogram.aggregationTemporality,
-          equals(proto.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA));
+      expect(
+        metricProto.histogram.aggregationTemporality,
+        equals(proto.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA),
+      );
 
       // Check point details
       final histogramPoint = metricProto.histogram.dataPoints.first;
@@ -202,8 +215,10 @@ void main() {
 
       // Check buckets
       expect(histogramPoint.explicitBounds, equals([0, 10, 20, 50, 100]));
-      expect(histogramPoint.bucketCounts.map((c) => c.toInt()).toList(),
-          equals([1, 1, 2, 1, 0]));
+      expect(
+        histogramPoint.bucketCounts.map((c) => c.toInt()).toList(),
+        equals([1, 1, 2, 1, 0]),
+      );
 
       // Check attributes
       expect(histogramPoint.attributes.length, equals(1));
@@ -246,7 +261,8 @@ void main() {
 
       // Create a map for easier verification
       final attributeMap = Map.fromEntries(
-          protoAttributes.map((kv) => MapEntry(kv.key, kv.value)));
+        protoAttributes.map((kv) => MapEntry(kv.key, kv.value)),
+      );
 
       // Verify each attribute type was converted correctly
       expect(attributeMap['string_key']!.stringValue, equals('string_value'));

--- a/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
@@ -20,7 +20,9 @@ class MockMetricsService extends MetricsServiceBase {
 
   @override
   Future<ExportMetricsServiceResponse> export(
-      ServiceCall call, ExportMetricsServiceRequest request) async {
+    ServiceCall call,
+    ExportMetricsServiceRequest request,
+  ) async {
     exportCount++;
     requests.add(request);
     if (errorCode != null) {
@@ -52,21 +54,26 @@ MetricData _createTestMetricData({String metricName = 'test.counter'}) {
   );
 
   return MetricData(
-    resource: OTel.resource(OTel.attributesFromMap({
-      'service.name': 'test-service',
-    })),
+    resource: OTel.resource(
+      OTel.attributesFromMap({'service.name': 'test-service'}),
+    ),
     metrics: [metric],
   );
 }
 
-OtlpGrpcMetricExporter _createExporter(int port,
-    {Map<String, String>? headers, bool compression = false}) {
-  return OtlpGrpcMetricExporter(OtlpGrpcMetricExporterConfig(
-    endpoint: 'http://localhost:$port',
-    insecure: true,
-    headers: headers,
-    compression: compression,
-  ));
+OtlpGrpcMetricExporter _createExporter(
+  int port, {
+  Map<String, String>? headers,
+  bool compression = false,
+}) {
+  return OtlpGrpcMetricExporter(
+    OtlpGrpcMetricExporterConfig(
+      endpoint: 'http://localhost:$port',
+      insecure: true,
+      headers: headers,
+      compression: compression,
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -81,7 +88,6 @@ void main() {
 
     setUp(() async {
       await OTel.reset();
-      OTelLog.enableTraceLogging();
       OTelLog.logFunction = (_) {};
       OTelLog.exportLogFunction = (_) {};
 
@@ -93,7 +99,11 @@ void main() {
       await OTel.initialize(
         serviceName: 'test',
         detectPlatformResources: false,
+        enableLogs: false,
       );
+      // Set trace logging AFTER initialize, since initializeLogging() reads
+      // OTEL_LOG_LEVEL from env and would override a level set before it.
+      OTelLog.enableTraceLogging();
     });
 
     tearDown(() async {
@@ -123,17 +133,19 @@ void main() {
     });
 
     // 2
-    test('export with empty metrics returns true without calling server',
-        () async {
-      final exporter = _createExporter(port);
+    test(
+      'export with empty metrics returns true without calling server',
+      () async {
+        final exporter = _createExporter(port);
 
-      final result = await exporter.export(MetricData.empty());
+        final result = await exporter.export(MetricData.empty());
 
-      expect(result, isTrue);
-      expect(mockService.exportCount, equals(0));
+        expect(result, isTrue);
+        expect(mockService.exportCount, equals(0));
 
-      await exporter.shutdown();
-    });
+        await exporter.shutdown();
+      },
+    );
 
     // 3
     test('export after shutdown returns false', () async {
@@ -230,10 +242,7 @@ void main() {
         endTime: now,
         value: 10,
       );
-      final metric = Metric.sum(
-        name: 'test.no-resource',
-        points: [point],
-      );
+      final metric = Metric.sum(name: 'test.no-resource', points: [point]);
       // MetricData with null resource
       final data = MetricData(resource: null, metrics: [metric]);
 
@@ -246,42 +255,44 @@ void main() {
     });
 
     // 10
-    test('export logs each metric detail when export logging enabled',
-        () async {
-      final logMessages = <String>[];
-      OTelLog.exportLogFunction = logMessages.add;
-      OTelLog.enableTraceLogging();
+    test(
+      'export logs each metric detail when export logging enabled',
+      () async {
+        final logMessages = <String>[];
+        OTelLog.exportLogFunction = logMessages.add;
+        OTelLog.enableTraceLogging();
 
-      final exporter = _createExporter(port);
-      final now = DateTime.now();
-      final point = MetricPoint<int>(
-        attributes: OTel.attributes(),
-        startTime: now.subtract(const Duration(seconds: 5)),
-        endTime: now,
-        value: 99,
-      );
-      final metric = Metric.sum(
-        name: 'test.detailed',
-        description: 'detailed metric',
-        unit: 'ops',
-        points: [point],
-      );
-      final data = MetricData(
-        resource: OTel.resource(null),
-        metrics: [metric],
-      );
+        final exporter = _createExporter(port);
+        final now = DateTime.now();
+        final point = MetricPoint<int>(
+          attributes: OTel.attributes(),
+          startTime: now.subtract(const Duration(seconds: 5)),
+          endTime: now,
+          value: 99,
+        );
+        final metric = Metric.sum(
+          name: 'test.detailed',
+          description: 'detailed metric',
+          unit: 'ops',
+          points: [point],
+        );
+        final data = MetricData(
+          resource: OTel.resource(null),
+          metrics: [metric],
+        );
 
-      await exporter.export(data);
+        await exporter.export(data);
 
-      // Should log individual metric details
-      expect(
-        logMessages.any((msg) => msg.contains('test.detailed')),
-        isTrue,
-        reason: 'Expected metric name in log output',
-      );
+        // Should log individual metric details
+        expect(
+          logMessages.any((msg) => msg.contains('test.detailed')),
+          isTrue,
+          reason: 'Expected metric name in log output',
+        );
 
-      await exporter.shutdown();
-    });
+        await exporter.shutdown();
+      },
+    );
 
     // 11
     test('export failure returns false', () async {
@@ -323,10 +334,13 @@ void main() {
 
     // 13
     test('exporter with custom headers', () async {
-      final exporter = _createExporter(port, headers: {
-        'x-custom-header': 'custom-value',
-        'authorization': 'Bearer test-token',
-      });
+      final exporter = _createExporter(
+        port,
+        headers: {
+          'x-custom-header': 'custom-value',
+          'authorization': 'Bearer test-token',
+        },
+      );
       final data = _createTestMetricData();
 
       final result = await exporter.export(data);
@@ -388,10 +402,7 @@ void main() {
         Metric.sum(name: 'test.requests', points: [point1]),
         Metric.gauge(name: 'test.temperature', points: [point2]),
       ];
-      final data = MetricData(
-        resource: OTel.resource(null),
-        metrics: metrics,
-      );
+      final data = MetricData(resource: OTel.resource(null), metrics: metrics);
 
       final exporter = _createExporter(port);
       final result = await exporter.export(data);

--- a/test/unit/metrics/export/prometheus/prometheus_exporter_test.dart
+++ b/test/unit/metrics/export/prometheus/prometheus_exporter_test.dart
@@ -40,8 +40,10 @@ void main() {
       final exportData = exporter.prometheusData;
       expect(exportData, contains('# HELP test_counter A test counter'));
       expect(exportData, contains('# TYPE test_counter counter'));
-      expect(exportData,
-          contains('test_counter{label1="value1",label2="value2"} 42.0'));
+      expect(
+        exportData,
+        contains('test_counter{label1="value1",label2="value2"} 42.0'),
+      );
     });
 
     test('exports a gauge metric correctly', () async {
@@ -67,7 +69,9 @@ void main() {
       expect(exportData, contains('# HELP test_gauge A test gauge'));
       expect(exportData, contains('# TYPE test_gauge gauge'));
       expect(
-          exportData, contains('test_gauge{environment="production"} 123.45'));
+        exportData,
+        contains('test_gauge{environment="production"} 123.45'),
+      );
     });
 
     test('exports a histogram metric correctly', () async {
@@ -101,27 +105,47 @@ void main() {
       expect(exportData, contains('# HELP test_histogram A test histogram'));
       expect(exportData, contains('# TYPE test_histogram histogram'));
       expect(
-          exportData, contains('test_histogram_sum{operation="fetch"} 2250.0'));
+        exportData,
+        contains('test_histogram_sum{operation="fetch"} 2250.0'),
+      );
       expect(
-          exportData, contains('test_histogram_count{operation="fetch"} 30'));
+        exportData,
+        contains('test_histogram_count{operation="fetch"} 30'),
+      );
 
       // Check each bucket
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="0"} 0'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="5"} 2'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="10"} 5'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="25"} 15'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="50"} 23'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="75"} 28'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="100"} 30'));
-      expect(exportData,
-          contains('test_histogram_bucket{operation="fetch",le="+Inf"} 30'));
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="0"} 0'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="5"} 2'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="10"} 5'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="25"} 15'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="50"} 23'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="75"} 28'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="100"} 30'),
+      );
+      expect(
+        exportData,
+        contains('test_histogram_bucket{operation="fetch",le="+Inf"} 30'),
+      );
     });
 
     test('handles special characters in metric names and label values',
@@ -134,7 +158,8 @@ void main() {
         points: [
           MetricPoint(
             attributes: Attributes.of({
-              'label.with-special_chars': 'value with "quotes" and \\ backslash'
+              'label.with-special_chars':
+                  'value with "quotes" and \\ backslash',
             }),
             value: 10.0,
             startTime: DateTime.now(),
@@ -148,14 +173,18 @@ void main() {
 
       final exportData = exporter.prometheusData;
       expect(
-          exportData,
-          contains(
-              '# HELP test_metric_name Description with \\\\ backslash and \\n newline'));
+        exportData,
+        contains(
+          '# HELP test_metric_name Description with \\\\ backslash and \\n newline',
+        ),
+      );
       expect(exportData, contains('# TYPE test_metric_name counter'));
       expect(
-          exportData,
-          contains(
-              'test_metric_name{label_with_special_chars="value with \\"quotes\\" and \\\\ backslash"} 10.0'));
+        exportData,
+        contains(
+          'test_metric_name{label_with_special_chars="value with \\"quotes\\" and \\\\ backslash"} 10.0',
+        ),
+      );
     });
 
     test('handles multiple metrics in one export', () async {

--- a/test/unit/metrics/generic_types_test.dart
+++ b/test/unit/metrics/generic_types_test.dart
@@ -201,9 +201,7 @@ void main() {
     test('Metrics with attributes have correct generic types', () {
       // Create counters with different generic types
       final intCounter = meter.createCounter<int>(
-        name: 'attr-int-counter',
-        unit: 'items',
-      ) as Counter<int>;
+          name: 'attr-int-counter', unit: 'items') as Counter<int>;
 
       final doubleCounter = meter.createCounter<double>(
         name: 'attr-double-counter',

--- a/test/unit/metrics/instruments/counter_test.dart
+++ b/test/unit/metrics/instruments/counter_test.dart
@@ -84,8 +84,11 @@ void main() {
 
       // If things are working properly, verify specifics
       if (totalValue > 0) {
-        expect(totalValue, equals(30),
-            reason: 'Total sum should be 30'); // Total sum
+        expect(
+          totalValue,
+          equals(30),
+          reason: 'Total sum should be 30',
+        ); // Total sum
 
         final value1 = counter.getValue(attributes1);
         final value2 = counter.getValue(attributes2);
@@ -94,20 +97,23 @@ void main() {
         expect(value2, greaterThanOrEqualTo(0));
 
         if (value1 > 0 && value2 > 0) {
-          expect(value1, equals(20),
-              reason: 'Sum for attributes1 should be 20');
-          expect(value2, equals(10),
-              reason: 'Sum for attributes2 should be 10');
+          expect(
+            value1,
+            equals(20),
+            reason: 'Sum for attributes1 should be 20',
+          );
+          expect(
+            value2,
+            equals(10),
+            reason: 'Sum for attributes2 should be 10',
+          );
         }
       }
     });
 
     test('throws when adding negative value', () {
       // Assert
-      expect(
-        () => counter.add(-1),
-        throwsArgumentError,
-      );
+      expect(() => counter.add(-1), throwsArgumentError);
     });
 
     test('collects metrics', () {

--- a/test/unit/metrics/instruments/counter_test_update.dart
+++ b/test/unit/metrics/instruments/counter_test_update.dart
@@ -82,22 +82,31 @@ void main() {
       counter.add(20, emptyAttributes); // Empty attributes
 
       // Assert - verify each attribute combination separately
-      expect(counter.getValue(attributes1), equals(20),
-          reason: 'Should have 5+15=20 for attributes1');
-      expect(counter.getValue(attributes2), equals(10),
-          reason: 'Should have 10 for attributes2');
-      expect(counter.getValue(emptyAttributes), equals(20),
-          reason: 'Should have 20 for empty attributes');
-      expect(counter.getValue(), equals(50),
-          reason: 'Total should be 5+10+15+20=50');
+      expect(
+        counter.getValue(attributes1),
+        equals(20),
+        reason: 'Should have 5+15=20 for attributes1',
+      );
+      expect(
+        counter.getValue(attributes2),
+        equals(10),
+        reason: 'Should have 10 for attributes2',
+      );
+      expect(
+        counter.getValue(emptyAttributes),
+        equals(20),
+        reason: 'Should have 20 for empty attributes',
+      );
+      expect(
+        counter.getValue(),
+        equals(50),
+        reason: 'Total should be 5+10+15+20=50',
+      );
     });
 
     test('throws when adding negative value', () {
       // Assert
-      expect(
-        () => counter.add(-1),
-        throwsArgumentError,
-      );
+      expect(() => counter.add(-1), throwsArgumentError);
     });
 
     test('collects metrics', () {
@@ -110,8 +119,11 @@ void main() {
 
       // Assert
       expect(metrics, isNotNull);
-      expect(metrics.isNotEmpty, isTrue,
-          reason: 'Should have at least one metric');
+      expect(
+        metrics.isNotEmpty,
+        isTrue,
+        reason: 'Should have at least one metric',
+      );
 
       final metric = metrics.first;
       expect(metric.name, equals('test-counter'));
@@ -119,8 +131,11 @@ void main() {
       expect(metric.unit, equals('items'));
       expect(metric.type, equals(MetricType.sum));
 
-      expect(metric.points.isNotEmpty, isTrue,
-          reason: 'Should have at least one point');
+      expect(
+        metric.points.isNotEmpty,
+        isTrue,
+        reason: 'Should have at least one point',
+      );
       expect(metric.points.first.value, equals(42));
     });
 
@@ -128,15 +143,21 @@ void main() {
       // Arrange - add value and verify
       counter.reset(); // Clear any existing data
       counter.add(42);
-      expect(counter.getValue(), equals(42),
-          reason: 'Counter should have 42 before reset');
+      expect(
+        counter.getValue(),
+        equals(42),
+        reason: 'Counter should have 42 before reset',
+      );
 
       // Act - reset the counter
       counter.reset();
 
       // Assert - value should be 0 after reset
-      expect(counter.getValue(), equals(0),
-          reason: 'Counter should be 0 after reset');
+      expect(
+        counter.getValue(),
+        equals(0),
+        reason: 'Counter should be 0 after reset',
+      );
     });
 
     test('handles multiple attributes with addWithMap', () {
@@ -152,8 +173,11 @@ void main() {
 
       // Get the points and check their attributes
       final points = counter.collectPoints();
-      expect(points.length, equals(2),
-          reason: 'Should have 2 points for different attribute combinations');
+      expect(
+        points.length,
+        equals(2),
+        reason: 'Should have 2 points for different attribute combinations',
+      );
     });
   });
 }

--- a/test/unit/metrics/instruments/gauge_extended_test.dart
+++ b/test/unit/metrics/instruments/gauge_extended_test.dart
@@ -97,10 +97,7 @@ void main() {
 
     test('Gauge supports different number types', () async {
       // Integer gauge
-      final intGauge = meter.createGauge<int>(
-        name: 'int-gauge',
-        unit: 'count',
-      );
+      final intGauge = meter.createGauge<int>(name: 'int-gauge', unit: 'count');
 
       // Double gauge
       final doubleGauge = meter.createGauge<double>(
@@ -135,17 +132,15 @@ void main() {
           double>; // Cast to implementation class to access recordWithMap
 
       // Record using recordWithMap
-      gauge.recordWithMap(23.5, {
-        'location': 'outside',
-        'sensor': 'primary',
-      });
+      gauge.recordWithMap(23.5, {'location': 'outside', 'sensor': 'primary'});
 
       // Force collection
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'map-attributes-gauge');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'map-attributes-gauge',
+      );
 
       // Verify value
       expect(metric.points.length, equals(1));
@@ -158,9 +153,8 @@ void main() {
     });
 
     test('Gauge.getValue returns most recent value', () {
-      final gauge = meter.createGauge<int>(
-        name: 'get-value-gauge',
-      ) as Gauge<int>; // Cast to implementation class to access getValue
+      final gauge = meter.createGauge<int>(name: 'get-value-gauge')
+          as Gauge<int>; // Cast to implementation class to access getValue
 
       // Record values with different attributes
       final attrs1 = {'region': 'north'}.toAttributes();
@@ -194,8 +188,9 @@ void main() {
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'temperature-gauge');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'temperature-gauge',
+      );
 
       // Verify negative value
       expect(metric.points.first.value, equals(-15.5));
@@ -219,8 +214,9 @@ void main() {
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'update-gauge');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'update-gauge',
+      );
 
       // Verify only latest value is reported
       expect(metric.points.length, equals(1));
@@ -228,9 +224,8 @@ void main() {
     });
 
     test('Gauge collectMetrics respects enabled state', () {
-      final gauge = meter.createGauge<double>(
-        name: 'collect-metrics-gauge',
-      ) as Gauge<double>;
+      final gauge = meter.createGauge<double>(name: 'collect-metrics-gauge')
+          as Gauge<double>;
 
       // Record a value
       gauge.record(42.5);

--- a/test/unit/metrics/instruments/gauge_test.dart
+++ b/test/unit/metrics/instruments/gauge_test.dart
@@ -65,7 +65,8 @@ void main() {
       final metric = metrics.firstWhere(
         (m) => m.name == 'test_gauge',
         orElse: () => throw StateError(
-            'Gauge metric not found: ${metrics.map((m) => m.name).join(', ')}'),
+          'Gauge metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
       );
 
       // Check properties
@@ -74,8 +75,11 @@ void main() {
 
       // We should have 3 data points (one for each attributes set)
       final points = metric.points;
-      expect(points.length, equals(3),
-          reason: "Expected 3 points, got ${points.length}");
+      expect(
+        points.length,
+        equals(3),
+        reason: "Expected 3 points, got ${points.length}",
+      );
 
       // Find each data point by attributes
       final apiPoints = points
@@ -90,12 +94,21 @@ void main() {
           points.where((p) => p.attributes.toList().isEmpty).toList();
 
       // Verify we found the points
-      expect(apiPoints.isNotEmpty, isTrue,
-          reason: "No points with 'api' service attribute found");
-      expect(dbPoints.isNotEmpty, isTrue,
-          reason: "No points with 'database' service attribute found");
-      expect(noAttrPoints.isNotEmpty, isTrue,
-          reason: "No points without attributes found");
+      expect(
+        apiPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with 'api' service attribute found",
+      );
+      expect(
+        dbPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with 'database' service attribute found",
+      );
+      expect(
+        noAttrPoints.isNotEmpty,
+        isTrue,
+        reason: "No points without attributes found",
+      );
 
       // Verify each point's value
       expect(apiPoints.first.value, equals(60.0)); // Updated from 50.0 to 60.0
@@ -121,13 +134,19 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final metric = metrics.firstWhere((m) => m.name == 'int_gauge',
-          orElse: () => throw StateError(
-              'int_gauge metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'int_gauge',
+        orElse: () => throw StateError(
+          'int_gauge metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // Verify we have 2 data points
-      expect(metric.points.length, equals(2),
-          reason: "Expected 2 points, got ${metric.points.length}");
+      expect(
+        metric.points.length,
+        equals(2),
+        reason: "Expected 2 points, got ${metric.points.length}",
+      );
 
       // Find each point
       final noAttrsPoints =
@@ -138,10 +157,16 @@ void main() {
           .toList();
 
       // Verify we found the points
-      expect(noAttrsPoints.isNotEmpty, isTrue,
-          reason: "No points without attributes found");
-      expect(withAttrsPoints.isNotEmpty, isTrue,
-          reason: "No points with 'request' type attribute found");
+      expect(
+        noAttrsPoints.isNotEmpty,
+        isTrue,
+        reason: "No points without attributes found",
+      );
+      expect(
+        withAttrsPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with 'request' type attribute found",
+      );
 
       // Verify values
       expect(noAttrsPoints.first.value, equals(10));
@@ -162,8 +187,11 @@ void main() {
 
       // Verify initial value was recorded
       var metrics = memoryExporter.exportedMetrics;
-      expect(metrics.isNotEmpty, isTrue,
-          reason: "No metrics were exported in first collection");
+      expect(
+        metrics.isNotEmpty,
+        isTrue,
+        reason: "No metrics were exported in first collection",
+      );
 
       // Clear the exporter to make verification clearer
       memoryExporter.clear();
@@ -176,25 +204,37 @@ void main() {
 
       // Get the collected metrics from the second collection
       metrics = memoryExporter.exportedMetrics;
-      expect(metrics.isNotEmpty, isTrue,
-          reason: "No metrics were exported in second collection");
+      expect(
+        metrics.isNotEmpty,
+        isTrue,
+        reason: "No metrics were exported in second collection",
+      );
 
-      final metric = metrics.firstWhere((m) => m.name == 'overwrite_gauge',
-          orElse: () => throw StateError(
-              'overwrite_gauge metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'overwrite_gauge',
+        orElse: () => throw StateError(
+          'overwrite_gauge metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // Verify we have at least one point
-      expect(metric.points.isNotEmpty, isTrue,
-          reason: "No points found in metric");
+      expect(
+        metric.points.isNotEmpty,
+        isTrue,
+        reason: "No points found in metric",
+      );
 
       // Find the point with our attributes
       final matchingPoints = metric.points
           .where((p) => p.attributes.getString('endpoint') == '/api/users')
           .toList();
 
-      expect(matchingPoints.isNotEmpty, isTrue,
-          reason:
-              "No points with '/api/users' endpoint attribute found. Available points: ${metric.points.map((p) => p.attributes.toString()).join(', ')}");
+      expect(
+        matchingPoints.isNotEmpty,
+        isTrue,
+        reason:
+            "No points with '/api/users' endpoint attribute found. Available points: ${metric.points.map((p) => p.attributes.toString()).join(', ')}",
+      );
 
       // Verify the value was overwritten
       expect(matchingPoints.first.value, equals(75.0));
@@ -216,20 +256,31 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final intMetric = metrics.firstWhere((m) => m.name == 'int_gauge_type',
-          orElse: () => throw StateError(
-              'int_gauge_type metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+      final intMetric = metrics.firstWhere(
+        (m) => m.name == 'int_gauge_type',
+        orElse: () => throw StateError(
+          'int_gauge_type metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       final doubleMetric = metrics.firstWhere(
-          (m) => m.name == 'double_gauge_type',
-          orElse: () => throw StateError(
-              'double_gauge_type metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+        (m) => m.name == 'double_gauge_type',
+        orElse: () => throw StateError(
+          'double_gauge_type metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // Verify we have at least one point for each metric
-      expect(intMetric.points.isNotEmpty, isTrue,
-          reason: "No points found in int_gauge_type metric");
-      expect(doubleMetric.points.isNotEmpty, isTrue,
-          reason: "No points found in double_gauge_type metric");
+      expect(
+        intMetric.points.isNotEmpty,
+        isTrue,
+        reason: "No points found in int_gauge_type metric",
+      );
+      expect(
+        doubleMetric.points.isNotEmpty,
+        isTrue,
+        reason: "No points found in double_gauge_type metric",
+      );
 
       // Verify values and types
       expect(intMetric.points.first.value, equals(42));

--- a/test/unit/metrics/instruments/histogram_extended_test.dart
+++ b/test/unit/metrics/instruments/histogram_extended_test.dart
@@ -124,16 +124,19 @@ void main() {
 
       // Find our histograms
       final intMetric = metrics.firstWhere((m) => m.name == 'int-histogram');
-      final doubleMetric =
-          metrics.firstWhere((m) => m.name == 'double-histogram');
+      final doubleMetric = metrics.firstWhere(
+        (m) => m.name == 'double-histogram',
+      );
 
       // Verify int histogram
       expect(intMetric.points.first.histogram().sum, equals(142.0)); // 42 + 100
       expect(intMetric.points.first.histogram().count, equals(2));
 
       // Verify double histogram
-      expect(doubleMetric.points.first.histogram().sum,
-          equals(4.25)); // 1.5 + 2.75
+      expect(
+        doubleMetric.points.first.histogram().sum,
+        equals(4.25),
+      ); // 1.5 + 2.75
       expect(doubleMetric.points.first.histogram().count, equals(2));
     });
 
@@ -148,7 +151,7 @@ void main() {
         100.0,
         250.0,
         500.0,
-        1000.0
+        1000.0,
       ];
 
       final histogram = meter.createHistogram<double>(
@@ -168,8 +171,9 @@ void main() {
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'custom-boundaries-histogram');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'custom-boundaries-histogram',
+      );
 
       // Verify histogram data
       final histData = metric.points.first.histogram();
@@ -210,9 +214,10 @@ void main() {
     });
 
     test('Histogram.getValue returns sum of recorded values', () {
-      final histogram = meter.createHistogram<double>(
-        name: 'get-value-histogram',
-      ) as Histogram<double>; // Cast to implementation class to access getValue
+      final histogram =
+          meter.createHistogram<double>(name: 'get-value-histogram')
+              as Histogram<
+                  double>; // Cast to implementation class to access getValue
 
       // Record values with different attributes
       final attrs1 = {'endpoint': '/api/users'}.toAttributes();
@@ -247,32 +252,29 @@ void main() {
           double>; // Cast to implementation class to access recordWithMap
 
       // Record using recordWithMap
-      histogram.recordWithMap(15.5, {
-        'method': 'GET',
-        'status': 200,
-      });
+      histogram.recordWithMap(15.5, {'method': 'GET', 'status': 200});
 
-      histogram.recordWithMap(250.0, {
-        'method': 'POST',
-        'status': 201,
-      });
+      histogram.recordWithMap(250.0, {'method': 'POST', 'status': 201});
 
       // Force collection
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'map-attributes-histogram');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'map-attributes-histogram',
+      );
 
       // Verify we have two data points (one for each attribute set)
       expect(metric.points.length, equals(2));
 
       // Find each point
-      final getPoint = metric.points
-          .firstWhere((p) => p.attributes.getString('method') == 'GET');
+      final getPoint = metric.points.firstWhere(
+        (p) => p.attributes.getString('method') == 'GET',
+      );
 
-      final postPoint = metric.points
-          .firstWhere((p) => p.attributes.getString('method') == 'POST');
+      final postPoint = metric.points.firstWhere(
+        (p) => p.attributes.getString('method') == 'POST',
+      );
 
       // Verify values
       expect(getPoint.histogram().sum, equals(15.5));
@@ -284,8 +286,7 @@ void main() {
 
     test('Histogram collectMetrics respects enabled state', () {
       final histogram = meter.createHistogram<double>(
-        name: 'collect-metrics-histogram',
-      ) as Histogram<double>;
+          name: 'collect-metrics-histogram') as Histogram<double>;
 
       // Record a value
       histogram.record(42.5);
@@ -304,8 +305,7 @@ void main() {
 
     test('Histogram collectPoints returns all points', () {
       final histogram = meter.createHistogram<double>(
-        name: 'collect-points-histogram',
-      ) as Histogram<double>;
+          name: 'collect-points-histogram') as Histogram<double>;
 
       // Record values with different attributes
       final attrs1 = {'region': 'east'}.toAttributes();
@@ -321,11 +321,13 @@ void main() {
       expect(points.length, equals(2));
 
       // Find each point
-      final eastPoint =
-          points.firstWhere((p) => p.attributes.getString('region') == 'east');
+      final eastPoint = points.firstWhere(
+        (p) => p.attributes.getString('region') == 'east',
+      );
 
-      final westPoint =
-          points.firstWhere((p) => p.attributes.getString('region') == 'west');
+      final westPoint = points.firstWhere(
+        (p) => p.attributes.getString('region') == 'west',
+      );
 
       // Verify values
       expect(eastPoint.histogram().sum, equals(100.0));
@@ -333,9 +335,8 @@ void main() {
     });
 
     test('Histogram reset clears accumulated values', () async {
-      final histogram = meter.createHistogram<double>(
-        name: 'reset-histogram',
-      ) as Histogram<double>;
+      final histogram = meter.createHistogram<double>(name: 'reset-histogram')
+          as Histogram<double>;
 
       // Record initial values
       histogram.record(10.0);
@@ -345,8 +346,9 @@ void main() {
       await metricReader.forceFlush();
 
       // Verify the exported metric
-      var metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'reset-histogram');
+      var metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'reset-histogram',
+      );
 
       expect(metric.points.first.histogram().sum, equals(30.0)); // 10 + 20
 
@@ -363,8 +365,9 @@ void main() {
       await metricReader.forceFlush();
 
       // Get the new metric
-      metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'reset-histogram');
+      metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'reset-histogram',
+      );
 
       // Verify only new value is present
       expect(metric.points.first.histogram().sum, equals(5.0));

--- a/test/unit/metrics/instruments/histogram_test.dart
+++ b/test/unit/metrics/instruments/histogram_test.dart
@@ -71,7 +71,8 @@ void main() {
       final metric = metrics.firstWhere(
         (m) => m.name == 'test_histogram',
         orElse: () => throw StateError(
-            'Histogram metric not found: ${metrics.map((m) => m.name).join(', ')}'),
+          'Histogram metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
       );
 
       // Check properties
@@ -80,8 +81,11 @@ void main() {
 
       // We should have 3 data points (one for each attributes set)
       final points = metric.points;
-      expect(points.length, equals(3),
-          reason: "Expected 3 points, got ${points.length}");
+      expect(
+        points.length,
+        equals(3),
+        reason: "Expected 3 points, got ${points.length}",
+      );
 
       // Find each data point by attributes
       final usersPoints = points
@@ -96,12 +100,21 @@ void main() {
           points.where((p) => p.attributes.toList().isEmpty).toList();
 
       // Verify we found the points
-      expect(usersPoints.isNotEmpty, isTrue,
-          reason: "No points with '/api/users' endpoint attribute found");
-      expect(productsPoints.isNotEmpty, isTrue,
-          reason: "No points with '/api/products' endpoint attribute found");
-      expect(noAttrPoints.isNotEmpty, isTrue,
-          reason: "No points without attributes found");
+      expect(
+        usersPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with '/api/users' endpoint attribute found",
+      );
+      expect(
+        productsPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with '/api/products' endpoint attribute found",
+      );
+      expect(
+        noAttrPoints.isNotEmpty,
+        isTrue,
+        reason: "No points without attributes found",
+      );
 
       // Verify each point's aggregated values
       expect(usersPoints.first.histogram().sum, equals(60.0)); // 10 + 20 + 30
@@ -143,13 +156,19 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final metric = metrics.firstWhere((m) => m.name == 'custom_histogram',
-          orElse: () => throw StateError(
-              'custom_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'custom_histogram',
+        orElse: () => throw StateError(
+          'custom_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // Verify we have at least one data point
-      expect(metric.points.isNotEmpty, isTrue,
-          reason: "No points found in metric");
+      expect(
+        metric.points.isNotEmpty,
+        isTrue,
+        reason: "No points found in metric",
+      );
 
       // Get the data point
       final point = metric.points.first;
@@ -161,20 +180,32 @@ void main() {
       // Verify buckets match our expectations
       // Buckets should be length boundaries + 1 (for overflow bucket)
       expect(
-          point.histogram().bucketCounts.length, equals(boundaries.length + 1));
+        point.histogram().bucketCounts.length,
+        equals(boundaries.length + 1),
+      );
 
       // Verify bucket counts
       // The buckets should have counts: [1, 1, 1, 1, 1]
       expect(
-          point.histogram().bucketCounts[0], equals(1)); // ≤10 (contains 5.0)
-      expect(point.histogram().bucketCounts[1],
-          equals(1)); // >10, ≤20 (contains 15.0)
-      expect(point.histogram().bucketCounts[2],
-          equals(1)); // >20, ≤50 (contains 35.0)
-      expect(point.histogram().bucketCounts[3],
-          equals(1)); // >50, ≤100 (contains 75.0)
-      expect(point.histogram().bucketCounts[4],
-          equals(1)); // >100 (contains 150.0)
+        point.histogram().bucketCounts[0],
+        equals(1),
+      ); // ≤10 (contains 5.0)
+      expect(
+        point.histogram().bucketCounts[1],
+        equals(1),
+      ); // >10, ≤20 (contains 15.0)
+      expect(
+        point.histogram().bucketCounts[2],
+        equals(1),
+      ); // >20, ≤50 (contains 35.0)
+      expect(
+        point.histogram().bucketCounts[3],
+        equals(1),
+      ); // >50, ≤100 (contains 75.0)
+      expect(
+        point.histogram().bucketCounts[4],
+        equals(1),
+      ); // >100 (contains 150.0)
     });
 
     test('Histogram with integer values', () async {
@@ -196,20 +227,28 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final metric = metrics.firstWhere((m) => m.name == 'int_histogram',
-          orElse: () => throw StateError(
-              'int_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'int_histogram',
+        orElse: () => throw StateError(
+          'int_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // Verify we have at least one data point
-      expect(metric.points.isNotEmpty, isTrue,
-          reason: "No points found in metric");
+      expect(
+        metric.points.isNotEmpty,
+        isTrue,
+        reason: "No points found in metric",
+      );
 
       // Get the data point
       final point = metric.points.first;
 
       // Verify values
-      expect(point.histogram().sum,
-          equals(60.0)); // 10 + 20 + 30, note conversion to double
+      expect(
+        point.histogram().sum,
+        equals(60.0),
+      ); // 10 + 20 + 30, note conversion to double
       expect(point.histogram().count, equals(3));
     });
 
@@ -239,17 +278,25 @@ void main() {
 
       // Get the latest metrics
       final metrics = memoryExporter.exportedMetrics;
-      expect(metrics.isNotEmpty, isTrue,
-          reason: "No metrics were exported in second collection");
+      expect(
+        metrics.isNotEmpty,
+        isTrue,
+        reason: "No metrics were exported in second collection",
+      );
 
       final metric = metrics.firstWhere(
-          (m) => m.name == 'multi_collection_histogram',
-          orElse: () => throw StateError(
-              'multi_collection_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+        (m) => m.name == 'multi_collection_histogram',
+        orElse: () => throw StateError(
+          'multi_collection_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // Verify we have at least one data point
-      expect(metric.points.isNotEmpty, isTrue,
-          reason: "No points found in metric after second collection");
+      expect(
+        metric.points.isNotEmpty,
+        isTrue,
+        reason: "No points found in metric after second collection",
+      );
 
       // Get the data point from the second collection
       final point = metric.points.first;
@@ -257,14 +304,14 @@ void main() {
       // With cumulative aggregation temporality, we expect all values to be present
       expect(point.histogram().sum, equals(100.0)); // 10 + 20 + 30 + 40
       expect(
-          point.histogram().count, equals(4)); // All 4 values (10, 20, 30, 40)
+        point.histogram().count,
+        equals(4),
+      ); // All 4 values (10, 20, 30, 40)
     });
 
     test('Histogram with attributes', () async {
       // Create a histogram
-      final histogram = meter.createHistogram<double>(
-        name: 'attr_histogram',
-      );
+      final histogram = meter.createHistogram<double>(name: 'attr_histogram');
 
       // Create diverse attributes
       final attrs1 = {'service': 'auth', 'endpoint': '/login'}.toAttributes();
@@ -287,14 +334,20 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final metric = metrics.firstWhere((m) => m.name == 'attr_histogram',
-          orElse: () => throw StateError(
-              'attr_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'attr_histogram',
+        orElse: () => throw StateError(
+          'attr_histogram metric not found: ${metrics.map((m) => m.name).join(', ')}',
+        ),
+      );
 
       // We should have 3 data points (one for each attribute set)
-      expect(metric.points.length, equals(3),
-          reason:
-              "Expected 3 points (one for each attribute set), got ${metric.points.length}");
+      expect(
+        metric.points.length,
+        equals(3),
+        reason:
+            "Expected 3 points (one for each attribute set), got ${metric.points.length}",
+      );
 
       // Find each point
       final loginPoints = metric.points
@@ -310,12 +363,21 @@ void main() {
           .toList();
 
       // Verify we found all points
-      expect(loginPoints.isNotEmpty, isTrue,
-          reason: "No points with '/login' endpoint attribute found");
-      expect(logoutPoints.isNotEmpty, isTrue,
-          reason: "No points with '/logout' endpoint attribute found");
-      expect(queryPoints.isNotEmpty, isTrue,
-          reason: "No points with '/query' endpoint attribute found");
+      expect(
+        loginPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with '/login' endpoint attribute found",
+      );
+      expect(
+        logoutPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with '/logout' endpoint attribute found",
+      );
+      expect(
+        queryPoints.isNotEmpty,
+        isTrue,
+        reason: "No points with '/query' endpoint attribute found",
+      );
 
       // Verify values
       expect(loginPoints.first.histogram().sum, equals(30.0)); // 10 + 20

--- a/test/unit/metrics/instruments/observable_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_counter_test.dart
@@ -106,11 +106,13 @@ void main() {
 
       // Values should match our initial increments (delta calculation doesn't apply to first observation)
       expect(
-          measurements1.where((m) => m.attributes == attributes1).first.value,
-          equals(5));
+        measurements1.where((m) => m.attributes == attributes1).first.value,
+        equals(5),
+      );
       expect(
-          measurements1.where((m) => m.attributes == attributes2).first.value,
-          equals(3));
+        measurements1.where((m) => m.attributes == attributes2).first.value,
+        equals(3),
+      );
 
       // Second collection
       final measurements2 = counter.collect();
@@ -118,21 +120,27 @@ void main() {
 
       // Values should be the deltas of the second observation
       expect(
-          measurements2.where((m) => m.attributes == attributes1).first.value,
-          equals(10));
+        measurements2.where((m) => m.attributes == attributes1).first.value,
+        equals(10),
+      );
       expect(
-          measurements2.where((m) => m.attributes == attributes2).first.value,
-          equals(6));
+        measurements2.where((m) => m.attributes == attributes2).first.value,
+        equals(6),
+      );
 
       // Get metric points (cumulative)
       final points = counter.collectPoints();
       expect(points.length, equals(2));
 
       // Points should still have cumulative values
-      expect(points.where((p) => p.attributes == attributes1).first.value,
-          equals(10));
-      expect(points.where((p) => p.attributes == attributes2).first.value,
-          equals(6));
+      expect(
+        points.where((p) => p.attributes == attributes1).first.value,
+        equals(10),
+      );
+      expect(
+        points.where((p) => p.attributes == attributes2).first.value,
+        equals(6),
+      );
     });
 
     test('ObservableCounter with multiple callbacks', () {
@@ -145,8 +153,9 @@ void main() {
       // First callback
       int callback1Value = 100;
       final attributes1 = {'source': 'callback1'}.toAttributes();
-      final registration1 =
-          counter.addCallback((APIObservableResult<int> result) {
+      final registration1 = counter.addCallback((
+        APIObservableResult<int> result,
+      ) {
         result.observe(callback1Value, attributes1);
         callback1Value += 50; // Increment for next call
       });
@@ -154,8 +163,9 @@ void main() {
       // Second callback
       int callback2Value = 200;
       final attributes2 = {'source': 'callback2'}.toAttributes();
-      final registration2 =
-          counter.addCallback((APIObservableResult<int> result) {
+      final registration2 = counter.addCallback((
+        APIObservableResult<int> result,
+      ) {
         result.observe(callback2Value, attributes2);
         callback2Value += 100; // Increment for next call
       });
@@ -167,21 +177,25 @@ void main() {
       final measurements1 = counter.collect();
       expect(measurements1.length, equals(2));
       expect(
-          measurements1.where((m) => m.attributes == attributes1).first.value,
-          equals(100));
+        measurements1.where((m) => m.attributes == attributes1).first.value,
+        equals(100),
+      );
       expect(
-          measurements1.where((m) => m.attributes == attributes2).first.value,
-          equals(200));
+        measurements1.where((m) => m.attributes == attributes2).first.value,
+        equals(200),
+      );
 
       // Second collection should have deltas
       final measurements2 = counter.collect();
       expect(measurements2.length, equals(2));
       expect(
-          measurements2.where((m) => m.attributes == attributes1).first.value,
-          equals(150));
+        measurements2.where((m) => m.attributes == attributes1).first.value,
+        equals(150),
+      );
       expect(
-          measurements2.where((m) => m.attributes == attributes2).first.value,
-          equals(300));
+        measurements2.where((m) => m.attributes == attributes2).first.value,
+        equals(300),
+      );
 
       // Unregister first callback
       registration1.unregister();
@@ -397,8 +411,10 @@ void main() {
       newCounter.collect();
       final metrics3 = newCounter.collectMetrics();
       expect(metrics3[0].points.length, equals(1));
-      expect(metrics3[0].points[0].value,
-          equals(200)); // New value after shutdown/reset
+      expect(
+        metrics3[0].points[0].value,
+        equals(200),
+      ); // New value after shutdown/reset
     });
   });
 }

--- a/test/unit/metrics/instruments/observable_gauge_test.dart
+++ b/test/unit/metrics/instruments/observable_gauge_test.dart
@@ -109,11 +109,13 @@ void main() {
 
       // Values should match our initial values
       expect(
-          measurements1.where((m) => m.attributes == attributes1).first.value,
-          closeTo(22.5, 0.001));
+        measurements1.where((m) => m.attributes == attributes1).first.value,
+        closeTo(22.5, 0.001),
+      );
       expect(
-          measurements1.where((m) => m.attributes == attributes2).first.value,
-          closeTo(24.8, 0.001));
+        measurements1.where((m) => m.attributes == attributes2).first.value,
+        closeTo(24.8, 0.001),
+      );
 
       // Second collection
       final measurements2 = gauge.collect();
@@ -121,11 +123,13 @@ void main() {
 
       // Values should reflect the changes
       expect(
-          measurements2.where((m) => m.attributes == attributes1).first.value,
-          closeTo(23.0, 0.001));
+        measurements2.where((m) => m.attributes == attributes1).first.value,
+        closeTo(23.0, 0.001),
+      );
       expect(
-          measurements2.where((m) => m.attributes == attributes2).first.value,
-          closeTo(24.6, 0.001));
+        measurements2.where((m) => m.attributes == attributes2).first.value,
+        closeTo(24.6, 0.001),
+      );
 
       // Get metric points
       final metrics = gauge.collectMetrics();
@@ -148,11 +152,13 @@ void main() {
 
       // Values should reflect the changes
       expect(
-          measurements3.where((m) => m.attributes == attributes1).first.value,
-          closeTo(23.5, 0.001));
+        measurements3.where((m) => m.attributes == attributes1).first.value,
+        closeTo(23.5, 0.001),
+      );
       expect(
-          measurements3.where((m) => m.attributes == attributes2).first.value,
-          closeTo(24.4, 0.001));
+        measurements3.where((m) => m.attributes == attributes2).first.value,
+        closeTo(24.4, 0.001),
+      );
     });
 
     test('ObservableGauge with multiple callbacks', () {
@@ -165,8 +171,9 @@ void main() {
       // First callback
       double cpu1Usage = 45.2;
       final attributes1 = {'cpu': 'cpu0'}.toAttributes();
-      final registration1 =
-          gauge.addCallback((APIObservableResult<double> result) {
+      final registration1 = gauge.addCallback((
+        APIObservableResult<double> result,
+      ) {
         result.observe(cpu1Usage, attributes1);
         cpu1Usage = (cpu1Usage + 5.5) % 100; // Cycle between 0-100%
       });
@@ -174,8 +181,9 @@ void main() {
       // Second callback
       double cpu2Usage = 67.8;
       final attributes2 = {'cpu': 'cpu1'}.toAttributes();
-      final registration2 =
-          gauge.addCallback((APIObservableResult<double> result) {
+      final registration2 = gauge.addCallback((
+        APIObservableResult<double> result,
+      ) {
         result.observe(cpu2Usage, attributes2);
         cpu2Usage = (cpu2Usage - 3.2) % 100; // Cycle between 0-100%
       });
@@ -187,21 +195,25 @@ void main() {
       final measurements1 = gauge.collect();
       expect(measurements1.length, equals(2));
       expect(
-          measurements1.where((m) => m.attributes == attributes1).first.value,
-          closeTo(45.2, 0.001));
+        measurements1.where((m) => m.attributes == attributes1).first.value,
+        closeTo(45.2, 0.001),
+      );
       expect(
-          measurements1.where((m) => m.attributes == attributes2).first.value,
-          closeTo(67.8, 0.001));
+        measurements1.where((m) => m.attributes == attributes2).first.value,
+        closeTo(67.8, 0.001),
+      );
 
       // Second collection should have updated values
       final measurements2 = gauge.collect();
       expect(measurements2.length, equals(2));
       expect(
-          measurements2.where((m) => m.attributes == attributes1).first.value,
-          closeTo(50.7, 0.001));
+        measurements2.where((m) => m.attributes == attributes1).first.value,
+        closeTo(50.7, 0.001),
+      );
       expect(
-          measurements2.where((m) => m.attributes == attributes2).first.value,
-          closeTo(64.6, 0.001));
+        measurements2.where((m) => m.attributes == attributes2).first.value,
+        closeTo(64.6, 0.001),
+      );
 
       // Unregister first callback
       registration1.unregister();
@@ -360,7 +372,9 @@ void main() {
       // The SDK should handle exceptions gracefully and not crash
       final measurements1 = gauge.collect();
       expect(
-          measurements1.length, equals(0)); // No measurements due to exception
+        measurements1.length,
+        equals(0),
+      ); // No measurements due to exception
 
       // Fix the callback and collect again
       callbackThrows = false;

--- a/test/unit/metrics/instruments/observable_instruments_coverage_test.dart
+++ b/test/unit/metrics/instruments/observable_instruments_coverage_test.dart
@@ -157,8 +157,7 @@ void main() {
     group('Multiple callbacks', () {
       test('ObservableCounter with multiple callbacks works', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'multi_callback_counter',
-        ) as ObservableCounter<int>;
+            name: 'multi_callback_counter') as ObservableCounter<int>;
 
         final attr1 = {'source': 'cb1'}.toAttributes();
         final attr2 = {'source': 'cb2'}.toAttributes();
@@ -174,16 +173,19 @@ void main() {
 
         final measurements = counter.collect();
         expect(measurements, hasLength(2));
-        expect(measurements.where((m) => m.attributes == attr1).first.value,
-            equals(100));
-        expect(measurements.where((m) => m.attributes == attr2).first.value,
-            equals(200));
+        expect(
+          measurements.where((m) => m.attributes == attr1).first.value,
+          equals(100),
+        );
+        expect(
+          measurements.where((m) => m.attributes == attr2).first.value,
+          equals(200),
+        );
       });
 
       test('ObservableGauge with multiple callbacks works', () {
         final gauge = meter.createObservableGauge<double>(
-          name: 'multi_callback_gauge',
-        ) as ObservableGauge<double>;
+            name: 'multi_callback_gauge') as ObservableGauge<double>;
 
         final attr1 = {'sensor': 'indoor'}.toAttributes();
         final attr2 = {'sensor': 'outdoor'}.toAttributes();
@@ -199,10 +201,14 @@ void main() {
 
         final measurements = gauge.collect();
         expect(measurements, hasLength(2));
-        expect(measurements.where((m) => m.attributes == attr1).first.value,
-            closeTo(22.5, 0.001));
-        expect(measurements.where((m) => m.attributes == attr2).first.value,
-            closeTo(15.0, 0.001));
+        expect(
+          measurements.where((m) => m.attributes == attr1).first.value,
+          closeTo(22.5, 0.001),
+        );
+        expect(
+          measurements.where((m) => m.attributes == attr2).first.value,
+          closeTo(15.0, 0.001),
+        );
       });
 
       test('ObservableUpDownCounter with multiple callbacks works', () {
@@ -224,33 +230,39 @@ void main() {
 
         final measurements = counter.collect();
         expect(measurements, hasLength(2));
-        expect(measurements.where((m) => m.attributes == attr1).first.value,
-            equals(10));
-        expect(measurements.where((m) => m.attributes == attr2).first.value,
-            equals(-5));
+        expect(
+          measurements.where((m) => m.attributes == attr1).first.value,
+          equals(10),
+        );
+        expect(
+          measurements.where((m) => m.attributes == attr2).first.value,
+          equals(-5),
+        );
       });
     });
 
     group('Observable with attributes', () {
-      test('ObservableCounter with attributes reports per-attribute values',
-          () {
-        final attr1 = {'region': 'us-east'}.toAttributes();
-        final attr2 = {'region': 'eu-west'}.toAttributes();
+      test(
+        'ObservableCounter with attributes reports per-attribute values',
+        () {
+          final attr1 = {'region': 'us-east'}.toAttributes();
+          final attr2 = {'region': 'eu-west'}.toAttributes();
 
-        final counter = meter.createObservableCounter<int>(
-          name: 'obs_counter_attrs',
-          callback: (APIObservableResult<int> result) {
-            result.observe(100, attr1);
-            result.observe(200, attr2);
-          },
-        ) as ObservableCounter<int>;
+          final counter = meter.createObservableCounter<int>(
+            name: 'obs_counter_attrs',
+            callback: (APIObservableResult<int> result) {
+              result.observe(100, attr1);
+              result.observe(200, attr2);
+            },
+          ) as ObservableCounter<int>;
 
-        counter.collect();
+          counter.collect();
 
-        final metrics = counter.collectMetrics();
-        expect(metrics, isNotEmpty);
-        expect(metrics.first.points, hasLength(2));
-      });
+          final metrics = counter.collectMetrics();
+          expect(metrics, isNotEmpty);
+          expect(metrics.first.points, hasLength(2));
+        },
+      );
 
       test('ObservableGauge with attributes reports per-attribute values', () {
         final attr1 = {'host': 'server1'}.toAttributes();
@@ -272,106 +284,118 @@ void main() {
       });
 
       test(
-          'ObservableUpDownCounter with attributes reports per-attribute values',
-          () {
-        final attr1 = {'queue': 'high'}.toAttributes();
-        final attr2 = {'queue': 'low'}.toAttributes();
+        'ObservableUpDownCounter with attributes reports per-attribute values',
+        () {
+          final attr1 = {'queue': 'high'}.toAttributes();
+          final attr2 = {'queue': 'low'}.toAttributes();
 
-        final counter = meter.createObservableUpDownCounter<int>(
-          name: 'obs_updown_attrs',
-          callback: (APIObservableResult<int> result) {
-            result.observe(30, attr1);
-            result.observe(-12, attr2);
-          },
-        ) as ObservableUpDownCounter<int>;
+          final counter = meter.createObservableUpDownCounter<int>(
+            name: 'obs_updown_attrs',
+            callback: (APIObservableResult<int> result) {
+              result.observe(30, attr1);
+              result.observe(-12, attr2);
+            },
+          ) as ObservableUpDownCounter<int>;
 
-        counter.collect();
+          counter.collect();
 
-        final metrics = counter.collectMetrics();
-        expect(metrics, isNotEmpty);
-        expect(metrics.first.points, hasLength(2));
-      });
+          final metrics = counter.collectMetrics();
+          expect(metrics, isNotEmpty);
+          expect(metrics.first.points, hasLength(2));
+        },
+      );
     });
 
     group('Collection returns metrics', () {
       test(
-          'ObservableCounter collection returns metrics with correct properties',
-          () {
-        final counter = meter.createObservableCounter<int>(
-          name: 'exported_counter',
-          unit: 'requests',
-          description: 'A counter for exported metrics',
-          callback: (APIObservableResult<int> result) {
-            result.observe(500);
-          },
-        ) as ObservableCounter<int>;
+        'ObservableCounter collection returns metrics with correct properties',
+        () {
+          final counter = meter.createObservableCounter<int>(
+            name: 'exported_counter',
+            unit: 'requests',
+            description: 'A counter for exported metrics',
+            callback: (APIObservableResult<int> result) {
+              result.observe(500);
+            },
+          ) as ObservableCounter<int>;
 
-        counter.collect();
+          counter.collect();
 
-        final metrics = counter.collectMetrics();
-        expect(metrics, isNotEmpty);
+          final metrics = counter.collectMetrics();
+          expect(metrics, isNotEmpty);
 
-        final counterMetric = metrics.first;
-        expect(counterMetric.type, equals(MetricType.sum));
-        expect(counterMetric.name, equals('exported_counter'));
-        expect(counterMetric.unit, equals('requests'));
-        expect(counterMetric.description,
-            equals('A counter for exported metrics'));
-        expect(counterMetric.points.isNotEmpty, isTrue);
-        expect(counterMetric.points.first.value, equals(500));
-      });
-
-      test('ObservableGauge collection returns metrics with correct properties',
-          () {
-        final gauge = meter.createObservableGauge<double>(
-          name: 'exported_gauge',
-          unit: 'percent',
-          description: 'A gauge for exported metrics',
-          callback: (APIObservableResult<double> result) {
-            result.observe(87.5);
-          },
-        ) as ObservableGauge<double>;
-
-        gauge.collect();
-
-        final metrics = gauge.collectMetrics();
-        expect(metrics, isNotEmpty);
-
-        final gaugeMetric = metrics.first;
-        expect(gaugeMetric.type, equals(MetricType.gauge));
-        expect(gaugeMetric.name, equals('exported_gauge'));
-        expect(gaugeMetric.unit, equals('percent'));
-        expect(gaugeMetric.description, equals('A gauge for exported metrics'));
-        expect(gaugeMetric.points.isNotEmpty, isTrue);
-        expect(gaugeMetric.points.first.value, closeTo(87.5, 0.001));
-      });
+          final counterMetric = metrics.first;
+          expect(counterMetric.type, equals(MetricType.sum));
+          expect(counterMetric.name, equals('exported_counter'));
+          expect(counterMetric.unit, equals('requests'));
+          expect(
+            counterMetric.description,
+            equals('A counter for exported metrics'),
+          );
+          expect(counterMetric.points.isNotEmpty, isTrue);
+          expect(counterMetric.points.first.value, equals(500));
+        },
+      );
 
       test(
-          'ObservableUpDownCounter collection returns metrics with correct properties',
-          () {
-        final counter = meter.createObservableUpDownCounter<int>(
-          name: 'exported_updown',
-          unit: 'connections',
-          description: 'An up-down counter for exported metrics',
-          callback: (APIObservableResult<int> result) {
-            result.observe(42);
-          },
-        ) as ObservableUpDownCounter<int>;
+        'ObservableGauge collection returns metrics with correct properties',
+        () {
+          final gauge = meter.createObservableGauge<double>(
+            name: 'exported_gauge',
+            unit: 'percent',
+            description: 'A gauge for exported metrics',
+            callback: (APIObservableResult<double> result) {
+              result.observe(87.5);
+            },
+          ) as ObservableGauge<double>;
 
-        counter.collect();
+          gauge.collect();
 
-        final metrics = counter.collectMetrics();
-        expect(metrics, isNotEmpty);
+          final metrics = gauge.collectMetrics();
+          expect(metrics, isNotEmpty);
 
-        final updownMetric = metrics.first;
-        expect(updownMetric.type, equals(MetricType.sum));
-        expect(updownMetric.name, equals('exported_updown'));
-        expect(updownMetric.unit, equals('connections'));
-        expect(updownMetric.description,
-            equals('An up-down counter for exported metrics'));
-        expect(updownMetric.points.isNotEmpty, isTrue);
-        expect(updownMetric.points.first.value, equals(42));
-      });
+          final gaugeMetric = metrics.first;
+          expect(gaugeMetric.type, equals(MetricType.gauge));
+          expect(gaugeMetric.name, equals('exported_gauge'));
+          expect(gaugeMetric.unit, equals('percent'));
+          expect(
+            gaugeMetric.description,
+            equals('A gauge for exported metrics'),
+          );
+          expect(gaugeMetric.points.isNotEmpty, isTrue);
+          expect(gaugeMetric.points.first.value, closeTo(87.5, 0.001));
+        },
+      );
+
+      test(
+        'ObservableUpDownCounter collection returns metrics with correct properties',
+        () {
+          final counter = meter.createObservableUpDownCounter<int>(
+            name: 'exported_updown',
+            unit: 'connections',
+            description: 'An up-down counter for exported metrics',
+            callback: (APIObservableResult<int> result) {
+              result.observe(42);
+            },
+          ) as ObservableUpDownCounter<int>;
+
+          counter.collect();
+
+          final metrics = counter.collectMetrics();
+          expect(metrics, isNotEmpty);
+
+          final updownMetric = metrics.first;
+          expect(updownMetric.type, equals(MetricType.sum));
+          expect(updownMetric.name, equals('exported_updown'));
+          expect(updownMetric.unit, equals('connections'));
+          expect(
+            updownMetric.description,
+            equals('An up-down counter for exported metrics'),
+          );
+          expect(updownMetric.points.isNotEmpty, isTrue);
+          expect(updownMetric.points.first.value, equals(42));
+        },
+      );
     });
   });
 }

--- a/test/unit/metrics/instruments/observable_instruments_full_test.dart
+++ b/test/unit/metrics/instruments/observable_instruments_full_test.dart
@@ -50,8 +50,7 @@ void main() {
 
       test('callbacks list starts empty when no initial callback', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'empty_callbacks_counter',
-        ) as ObservableCounter<int>;
+            name: 'empty_callbacks_counter') as ObservableCounter<int>;
         expect(counter.callbacks, isEmpty);
       });
 
@@ -100,8 +99,7 @@ void main() {
 
       test('collectMetrics returns empty when no data collected', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'no_data_counter',
-        ) as ObservableCounter<int>;
+            name: 'no_data_counter') as ObservableCounter<int>;
 
         final metrics = counter.collectMetrics();
         expect(metrics, isEmpty);
@@ -111,8 +109,7 @@ void main() {
     group('ObservableCounter callback management', () {
       test('addCallback and unregister', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'unreg_counter',
-        ) as ObservableCounter<int>;
+            name: 'unreg_counter') as ObservableCounter<int>;
 
         final registration = counter.addCallback((result) {
           result.observe(100);
@@ -127,8 +124,7 @@ void main() {
 
       test('multiple registrations and selective unregister', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'multi_reg_counter',
-        ) as ObservableCounter<int>;
+            name: 'multi_reg_counter') as ObservableCounter<int>;
 
         final reg1 = counter.addCallback((result) {
           result.observe(10);
@@ -151,8 +147,7 @@ void main() {
 
       test('removeCallback removes callback directly', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'remove_cb_counter',
-        ) as ObservableCounter<int>;
+            name: 'remove_cb_counter') as ObservableCounter<int>;
 
         void myCallback(APIObservableResult<int> result) {
           result.observe(42);
@@ -169,8 +164,7 @@ void main() {
     group('ObservableCounter error handling', () {
       test('error in callback does not prevent other callbacks', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'error_cb_counter',
-        ) as ObservableCounter<int>;
+            name: 'error_cb_counter') as ObservableCounter<int>;
 
         counter.addCallback((result) {
           throw Exception('Callback error');
@@ -186,8 +180,7 @@ void main() {
 
       test('collect returns empty when no callbacks', () {
         final counter = meter.createObservableCounter<int>(
-          name: 'no_cb_counter',
-        ) as ObservableCounter<int>;
+            name: 'no_cb_counter') as ObservableCounter<int>;
 
         final measurements = counter.collect();
         expect(measurements, isEmpty);
@@ -382,8 +375,7 @@ void main() {
 
       test('collectMetrics returns empty when no data', () {
         final counter = meter.createObservableUpDownCounter<int>(
-          name: 'no_data_updown',
-        ) as ObservableUpDownCounter<int>;
+            name: 'no_data_updown') as ObservableUpDownCounter<int>;
 
         final metrics = counter.collectMetrics();
         expect(metrics, isEmpty);
@@ -393,8 +385,7 @@ void main() {
     group('ObservableUpDownCounter callback management', () {
       test('addCallback and unregister', () {
         final counter = meter.createObservableUpDownCounter<int>(
-          name: 'unreg_updown',
-        ) as ObservableUpDownCounter<int>;
+            name: 'unreg_updown') as ObservableUpDownCounter<int>;
 
         final registration = counter.addCallback((result) {
           result.observe(10);
@@ -409,8 +400,7 @@ void main() {
 
       test('removeCallback directly', () {
         final counter = meter.createObservableUpDownCounter<int>(
-          name: 'remove_cb_updown',
-        ) as ObservableUpDownCounter<int>;
+            name: 'remove_cb_updown') as ObservableUpDownCounter<int>;
 
         void myCallback(APIObservableResult<int> result) {
           result.observe(7);
@@ -427,8 +417,7 @@ void main() {
     group('ObservableUpDownCounter error handling', () {
       test('error in callback does not prevent other callbacks', () {
         final counter = meter.createObservableUpDownCounter<int>(
-          name: 'error_updown',
-        ) as ObservableUpDownCounter<int>;
+            name: 'error_updown') as ObservableUpDownCounter<int>;
 
         counter.addCallback((result) {
           throw Exception('Callback error');
@@ -444,8 +433,7 @@ void main() {
 
       test('collect returns empty when no callbacks', () {
         final counter = meter.createObservableUpDownCounter<int>(
-          name: 'no_cb_updown',
-        ) as ObservableUpDownCounter<int>;
+            name: 'no_cb_updown') as ObservableUpDownCounter<int>;
 
         final measurements = counter.collect();
         expect(measurements, isEmpty);
@@ -603,9 +591,8 @@ void main() {
       });
 
       test('collectMetrics returns empty when no data', () {
-        final gauge = meter.createObservableGauge<double>(
-          name: 'no_data_gauge',
-        ) as ObservableGauge<double>;
+        final gauge = meter.createObservableGauge<double>(name: 'no_data_gauge')
+            as ObservableGauge<double>;
 
         final metrics = gauge.collectMetrics();
         expect(metrics, isEmpty);
@@ -614,9 +601,8 @@ void main() {
 
     group('ObservableGauge callback management', () {
       test('addCallback and unregister', () {
-        final gauge = meter.createObservableGauge<double>(
-          name: 'unreg_gauge',
-        ) as ObservableGauge<double>;
+        final gauge = meter.createObservableGauge<double>(name: 'unreg_gauge')
+            as ObservableGauge<double>;
 
         final registration = gauge.addCallback((result) {
           result.observe(99.9);
@@ -631,8 +617,7 @@ void main() {
 
       test('removeCallback directly', () {
         final gauge = meter.createObservableGauge<double>(
-          name: 'remove_cb_gauge',
-        ) as ObservableGauge<double>;
+            name: 'remove_cb_gauge') as ObservableGauge<double>;
 
         void myCallback(APIObservableResult<double> result) {
           result.observe(55.5);
@@ -648,9 +633,8 @@ void main() {
 
     group('ObservableGauge error handling', () {
       test('error in callback does not prevent other callbacks', () {
-        final gauge = meter.createObservableGauge<double>(
-          name: 'error_gauge',
-        ) as ObservableGauge<double>;
+        final gauge = meter.createObservableGauge<double>(name: 'error_gauge')
+            as ObservableGauge<double>;
 
         gauge.addCallback((result) {
           throw Exception('Callback error');
@@ -665,9 +649,8 @@ void main() {
       });
 
       test('collect returns empty list when no callbacks', () {
-        final gauge = meter.createObservableGauge<double>(
-          name: 'no_cb_gauge',
-        ) as ObservableGauge<double>;
+        final gauge = meter.createObservableGauge<double>(name: 'no_cb_gauge')
+            as ObservableGauge<double>;
 
         final measurements = gauge.collect();
         expect(measurements, isEmpty);
@@ -690,9 +673,8 @@ void main() {
       });
 
       test('getValue with no points returns 0', () {
-        final gauge = meter.createObservableGauge<double>(
-          name: 'empty_gauge',
-        ) as ObservableGauge<double>;
+        final gauge = meter.createObservableGauge<double>(name: 'empty_gauge')
+            as ObservableGauge<double>;
 
         final value = gauge.getValue();
         expect(value, equals(0.0));

--- a/test/unit/metrics/instruments/observable_up_down_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_up_down_counter_test.dart
@@ -66,9 +66,9 @@ void main() {
       final measurements1 = counter.collect();
       expect(measurements1.length, equals(1));
       expect(
-          measurements1[0].value,
-          equals(
-              100)); // First observation (collectPoints() is called first internally)
+        measurements1[0].value,
+        equals(100),
+      ); // First observation (collectPoints() is called first internally)
 
       // Collect again - should get the second value (increased)
       final measurements2 = counter.collect();
@@ -99,10 +99,7 @@ void main() {
       final attributes2 = {'region': 'west'}.toAttributes();
 
       // Create value maps to simulate values that can go up or down
-      final Map<String, int> regionValues = {
-        'east': 50,
-        'west': 75,
-      };
+      final Map<String, int> regionValues = {'east': 50, 'west': 75};
 
       // Create an ObservableUpDownCounter
       final counter = meter.createObservableUpDownCounter<int>(
@@ -125,11 +122,13 @@ void main() {
 
       // Values should match our initial values
       expect(
-          measurements1.where((m) => m.attributes == attributes1).first.value,
-          equals(50));
+        measurements1.where((m) => m.attributes == attributes1).first.value,
+        equals(50),
+      );
       expect(
-          measurements1.where((m) => m.attributes == attributes2).first.value,
-          equals(75));
+        measurements1.where((m) => m.attributes == attributes2).first.value,
+        equals(75),
+      );
 
       // Second collection
       final measurements2 = counter.collect();
@@ -137,11 +136,13 @@ void main() {
 
       // Values should reflect the changes
       expect(
-          measurements2.where((m) => m.attributes == attributes1).first.value,
-          equals(55));
+        measurements2.where((m) => m.attributes == attributes1).first.value,
+        equals(55),
+      );
       expect(
-          measurements2.where((m) => m.attributes == attributes2).first.value,
-          equals(67));
+        measurements2.where((m) => m.attributes == attributes2).first.value,
+        equals(67),
+      );
 
       // Get metric points
       final metrics = counter.collectMetrics();
@@ -169,8 +170,9 @@ void main() {
       // First callback
       int serverProcesses = 42;
       final attributes1 = {'server': 'app'}.toAttributes();
-      final registration1 =
-          counter.addCallback((APIObservableResult<int> result) {
+      final registration1 = counter.addCallback((
+        APIObservableResult<int> result,
+      ) {
         result.observe(serverProcesses, attributes1);
         // Increment by 1 for each observation
         serverProcesses++;
@@ -179,8 +181,9 @@ void main() {
       // Second callback
       int dbProcesses = 15;
       final attributes2 = {'server': 'db'}.toAttributes();
-      final registration2 =
-          counter.addCallback((APIObservableResult<int> result) {
+      final registration2 = counter.addCallback((
+        APIObservableResult<int> result,
+      ) {
         result.observe(dbProcesses, attributes2);
         // Sometimes goes up, sometimes down
         dbProcesses = (dbProcesses == 15) ? 17 : 15;
@@ -193,21 +196,25 @@ void main() {
       final measurements1 = counter.collect();
       expect(measurements1.length, equals(2));
       expect(
-          measurements1.where((m) => m.attributes == attributes1).first.value,
-          equals(42));
+        measurements1.where((m) => m.attributes == attributes1).first.value,
+        equals(42),
+      );
       expect(
-          measurements1.where((m) => m.attributes == attributes2).first.value,
-          equals(15));
+        measurements1.where((m) => m.attributes == attributes2).first.value,
+        equals(15),
+      );
 
       // Second collection should have updated values
       final measurements2 = counter.collect();
       expect(measurements2.length, equals(2));
       expect(
-          measurements2.where((m) => m.attributes == attributes1).first.value,
-          equals(43));
+        measurements2.where((m) => m.attributes == attributes1).first.value,
+        equals(43),
+      );
       expect(
-          measurements2.where((m) => m.attributes == attributes2).first.value,
-          equals(17));
+        measurements2.where((m) => m.attributes == attributes2).first.value,
+        equals(17),
+      );
 
       // Unregister first callback
       registration1.unregister();
@@ -401,8 +408,10 @@ void main() {
       newCounter.collect();
       final metrics3 = newCounter.collectMetrics();
       expect(metrics3[0].points.length, equals(1));
-      expect(metrics3[0].points[0].value,
-          equals(200)); // New value after shutdown/reset
+      expect(
+        metrics3[0].points[0].value,
+        equals(200),
+      ); // New value after shutdown/reset
     });
 
     test('ObservableUpDownCounter with exceptions in callbacks', () {
@@ -423,7 +432,9 @@ void main() {
       // The SDK should handle exceptions gracefully and not crash
       final measurements1 = counter.collect();
       expect(
-          measurements1.length, equals(0)); // No measurements due to exception
+        measurements1.length,
+        equals(0),
+      ); // No measurements due to exception
 
       // Fix the callback and collect again
       callbackThrows = false;

--- a/test/unit/metrics/instruments/up_down_counter_extended_test.dart
+++ b/test/unit/metrics/instruments/up_down_counter_extended_test.dart
@@ -119,10 +119,12 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
 
       // Find our counters
-      final intMetric =
-          metrics.firstWhere((m) => m.name == 'int-up-down-counter');
-      final doubleMetric =
-          metrics.firstWhere((m) => m.name == 'double-up-down-counter');
+      final intMetric = metrics.firstWhere(
+        (m) => m.name == 'int-up-down-counter',
+      );
+      final doubleMetric = metrics.firstWhere(
+        (m) => m.name == 'double-up-down-counter',
+      );
 
       // Verify values
       expect(intMetric.points.first.value, equals(42));
@@ -145,8 +147,9 @@ void main() {
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'bidirectional-counter');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'bidirectional-counter',
+      );
 
       // Verify final value (10 - 3 + 5 - 7 = 5)
       expect(metric.points.first.value, equals(5));
@@ -160,30 +163,27 @@ void main() {
           int>; // Cast to implementation class to access addWithMap
 
       // Record using addWithMap
-      counter.addWithMap(100, {
-        'direction': 'up',
-        'operation': 'test',
-      });
+      counter.addWithMap(100, {'direction': 'up', 'operation': 'test'});
 
-      counter.addWithMap(-25, {
-        'direction': 'down',
-        'operation': 'test',
-      });
+      counter.addWithMap(-25, {'direction': 'down', 'operation': 'test'});
 
       // Force collection
       await metricReader.forceFlush();
 
       // Get metric
-      final metric = memoryExporter.exportedMetrics
-          .firstWhere((m) => m.name == 'map-attributes-counter');
+      final metric = memoryExporter.exportedMetrics.firstWhere(
+        (m) => m.name == 'map-attributes-counter',
+      );
 
       // Verify we get two separate points with different values
       expect(metric.points.length, equals(2));
       // Find points for each direction
-      final upPoint = metric.points
-          .firstWhere((p) => p.attributes.getString('direction') == 'up');
-      final downPoint = metric.points
-          .firstWhere((p) => p.attributes.getString('direction') == 'down');
+      final upPoint = metric.points.firstWhere(
+        (p) => p.attributes.getString('direction') == 'up',
+      );
+      final downPoint = metric.points.firstWhere(
+        (p) => p.attributes.getString('direction') == 'down',
+      );
 
       // Verify values for each point
       expect(upPoint.value, equals(100));
@@ -195,10 +195,9 @@ void main() {
     });
 
     test('UpDownCounter.getValue returns correct value', () {
-      final counter = meter.createUpDownCounter<int>(
-        name: 'get-value-counter',
-      ) as UpDownCounter<
-          int>; // Cast to implementation class to access getValue
+      final counter = meter.createUpDownCounter<int>(name: 'get-value-counter')
+          as UpDownCounter<
+              int>; // Cast to implementation class to access getValue
 
       // Record values with different attributes
       final attrs1 = {'region': 'us-west'}.toAttributes();
@@ -216,8 +215,7 @@ void main() {
 
     test('UpDownCounter collectMetrics respects enabled state', () {
       final counter = meter.createUpDownCounter<int>(
-        name: 'collect-metrics-counter',
-      ) as UpDownCounter<int>;
+          name: 'collect-metrics-counter') as UpDownCounter<int>;
 
       // Record a value
       counter.add(42);

--- a/test/unit/metrics/meter_coverage_test.dart
+++ b/test/unit/metrics/meter_coverage_test.dart
@@ -60,133 +60,138 @@ void main() {
     });
 
     test(
-        'NoopMeter instruments create NoOp implementations when SDK not initialized',
-        () async {
-      // Reset the SDK state to force NoOp behavior
-      await OTel.reset();
-      OTelAPI.initialize();
+      'NoopMeter instruments create NoOp implementations when SDK not initialized',
+      () async {
+        // Reset the SDK state to force NoOp behavior
+        await OTel.reset();
+        OTelAPI.initialize();
 
-      // Get a meter WITHOUT initializing the SDK - this should return NoOp implementations
-      final noopMeter = OTel.meter('noop-test-meter');
+        // Get a meter WITHOUT initializing the SDK - this should return NoOp implementations
+        final noopMeter = OTel.meter('noop-test-meter');
 
-      // Verify the meter is a NoOp implementation (API factory creates disabled meters)
-      expect(noopMeter.enabled, isFalse);
+        // Verify the meter is a NoOp implementation (API factory creates disabled meters)
+        expect(noopMeter.enabled, isFalse);
 
-      // Create instruments and verify they work without errors (NoOp behavior)
-      final counter = noopMeter.createCounter<int>(name: 'noop_counter');
-      final upDownCounter =
-          noopMeter.createUpDownCounter<int>(name: 'noop_up_down');
-      final histogram =
-          noopMeter.createHistogram<double>(name: 'noop_histogram');
-      final gauge = noopMeter.createGauge<double>(name: 'noop_gauge');
-      final obsCounter = noopMeter.createObservableCounter<int>(
-        name: 'noop_obs_counter',
-        callback: (result) {
-          result.observe(123);
-        },
-      );
-      final obsUpDown = noopMeter.createObservableUpDownCounter<int>(
-        name: 'noop_obs_up_down',
-        callback: (result) {
-          result.observe(456);
-        },
-      );
-      final obsGauge = noopMeter.createObservableGauge<double>(
-        name: 'noop_obs_gauge',
-        callback: (result) {
-          result.observe(789.0);
-        },
-      );
+        // Create instruments and verify they work without errors (NoOp behavior)
+        final counter = noopMeter.createCounter<int>(name: 'noop_counter');
+        final upDownCounter = noopMeter.createUpDownCounter<int>(
+          name: 'noop_up_down',
+        );
+        final histogram = noopMeter.createHistogram<double>(
+          name: 'noop_histogram',
+        );
+        final gauge = noopMeter.createGauge<double>(name: 'noop_gauge');
+        final obsCounter = noopMeter.createObservableCounter<int>(
+          name: 'noop_obs_counter',
+          callback: (result) {
+            result.observe(123);
+          },
+        );
+        final obsUpDown = noopMeter.createObservableUpDownCounter<int>(
+          name: 'noop_obs_up_down',
+          callback: (result) {
+            result.observe(456);
+          },
+        );
+        final obsGauge = noopMeter.createObservableGauge<double>(
+          name: 'noop_obs_gauge',
+          callback: (result) {
+            result.observe(789.0);
+          },
+        );
 
-      // Verify instruments are disabled (NoOp implementations)
-      expect(counter.enabled, isFalse);
-      expect(upDownCounter.enabled, isFalse);
-      expect(histogram.enabled, isFalse);
-      expect(gauge.enabled, isFalse);
-      expect(obsCounter.enabled, isFalse);
-      expect(obsUpDown.enabled, isFalse);
-      expect(obsGauge.enabled, isFalse);
+        // Verify instruments are disabled (NoOp implementations)
+        expect(counter.enabled, isFalse);
+        expect(upDownCounter.enabled, isFalse);
+        expect(histogram.enabled, isFalse);
+        expect(gauge.enabled, isFalse);
+        expect(obsCounter.enabled, isFalse);
+        expect(obsUpDown.enabled, isFalse);
+        expect(obsGauge.enabled, isFalse);
 
-      // Exercise the APIs to ensure no exceptions - NoOp implementations should do nothing
-      counter.add(10);
-      upDownCounter.add(30);
-      upDownCounter.add(-15);
-      histogram.record(50.5);
-      gauge.record(70.5);
+        // Exercise the APIs to ensure no exceptions - NoOp implementations should do nothing
+        counter.add(10);
+        upDownCounter.add(30);
+        upDownCounter.add(-15);
+        histogram.record(50.5);
+        gauge.record(70.5);
 
-      // Check instrument properties
-      expect(counter.name, equals('noop_counter'));
-      expect(counter.isCounter, isTrue);
-      expect(counter.isGauge, isFalse);
-      expect(counter.isHistogram, isFalse);
-      expect(counter.isUpDownCounter, isFalse);
+        // Check instrument properties
+        expect(counter.name, equals('noop_counter'));
+        expect(counter.isCounter, isTrue);
+        expect(counter.isGauge, isFalse);
+        expect(counter.isHistogram, isFalse);
+        expect(counter.isUpDownCounter, isFalse);
 
-      expect(upDownCounter.name, equals('noop_up_down'));
-      expect(upDownCounter.isCounter, isFalse);
-      expect(upDownCounter.isGauge, isFalse);
-      expect(upDownCounter.isHistogram, isFalse);
-      expect(upDownCounter.isUpDownCounter, isTrue);
+        expect(upDownCounter.name, equals('noop_up_down'));
+        expect(upDownCounter.isCounter, isFalse);
+        expect(upDownCounter.isGauge, isFalse);
+        expect(upDownCounter.isHistogram, isFalse);
+        expect(upDownCounter.isUpDownCounter, isTrue);
 
-      expect(histogram.name, equals('noop_histogram'));
-      expect(histogram.isCounter, isFalse);
-      expect(histogram.isGauge, isFalse);
-      expect(histogram.isHistogram, isTrue);
-      expect(histogram.isUpDownCounter, isFalse);
+        expect(histogram.name, equals('noop_histogram'));
+        expect(histogram.isCounter, isFalse);
+        expect(histogram.isGauge, isFalse);
+        expect(histogram.isHistogram, isTrue);
+        expect(histogram.isUpDownCounter, isFalse);
 
-      expect(gauge.name, equals('noop_gauge'));
-      expect(gauge.isCounter, isFalse);
-      expect(gauge.isGauge, isTrue);
-      expect(gauge.isHistogram, isFalse);
-      expect(gauge.isUpDownCounter, isFalse);
+        expect(gauge.name, equals('noop_gauge'));
+        expect(gauge.isCounter, isFalse);
+        expect(gauge.isGauge, isTrue);
+        expect(gauge.isHistogram, isFalse);
+        expect(gauge.isUpDownCounter, isFalse);
 
-      // Test observable instrument methods
-      expect(obsCounter.callbacks.length, equals(1));
-      expect(obsCounter.collect(), isEmpty);
+        // Test observable instrument methods
+        expect(obsCounter.callbacks.length, equals(1));
+        expect(obsCounter.collect(), isEmpty);
 
-      expect(obsUpDown.callbacks.length, equals(1));
-      expect(obsUpDown.collect(), isEmpty);
+        expect(obsUpDown.callbacks.length, equals(1));
+        expect(obsUpDown.collect(), isEmpty);
 
-      expect(obsGauge.callbacks.length, equals(1));
-      expect(obsGauge.collect(), isEmpty);
+        expect(obsGauge.callbacks.length, equals(1));
+        expect(obsGauge.collect(), isEmpty);
 
-      // Test callback registration
-      final cbReg1 = obsCounter.addCallback((result) => result.observe(100));
-      final cbReg2 = obsUpDown.addCallback((result) => result.observe(200));
-      final cbReg3 = obsGauge.addCallback((result) => result.observe(300.0));
+        // Test callback registration
+        final cbReg1 = obsCounter.addCallback((result) => result.observe(100));
+        final cbReg2 = obsUpDown.addCallback((result) => result.observe(200));
+        final cbReg3 = obsGauge.addCallback((result) => result.observe(300.0));
 
-      expect(obsCounter.callbacks.length, equals(2));
-      expect(obsUpDown.callbacks.length, equals(2));
-      expect(obsGauge.callbacks.length, equals(2));
+        expect(obsCounter.callbacks.length, equals(2));
+        expect(obsUpDown.callbacks.length, equals(2));
+        expect(obsGauge.callbacks.length, equals(2));
 
-      // Test unregister
-      cbReg1.unregister();
-      cbReg2.unregister();
-      cbReg3.unregister();
+        // Test unregister
+        cbReg1.unregister();
+        cbReg2.unregister();
+        cbReg3.unregister();
 
-      expect(obsCounter.callbacks.length, equals(1));
-      expect(obsUpDown.callbacks.length, equals(1));
-      expect(obsGauge.callbacks.length, equals(1));
+        expect(obsCounter.callbacks.length, equals(1));
+        expect(obsUpDown.callbacks.length, equals(1));
+        expect(obsGauge.callbacks.length, equals(1));
 
-      // Reset before initializing the SDK (API was initialized above)
-      await OTel.reset();
+        // Reset before initializing the SDK (API was initialized above)
+        await OTel.reset();
 
-      // Now initialize the SDK and verify the API switches to using it
-      await OTel.initialize(
-        serviceName: 'switched-test-service',
-        metricReader: MemoryMetricReader(exporter: MemoryMetricExporter()),
-        detectPlatformResources: false,
-      );
+        // Now initialize the SDK and verify the API switches to using it
+        await OTel.initialize(
+          serviceName: 'switched-test-service',
+          metricReader: MemoryMetricReader(exporter: MemoryMetricExporter()),
+          detectPlatformResources: false,
+        );
 
-      // Get a new meter - this should now use the SDK factory
-      final sdkMeter = OTel.meter('sdk-test-meter');
+        // Get a new meter - this should now use the SDK factory
+        final sdkMeter = OTel.meter('sdk-test-meter');
 
-      // Verify the meter is now enabled (SDK implementation)
-      expect(sdkMeter.enabled, isTrue);
+        // Verify the meter is now enabled (SDK implementation)
+        expect(sdkMeter.enabled, isTrue);
 
-      // Create a new instrument with the SDK-backed meter
-      final sdkCounter = sdkMeter.createCounter<int>(name: 'sdk_counter');
-      expect(sdkCounter.enabled, isTrue);
-    }, skip: 'APIMeterProvider cannot be cast to SDK MeterProvider after API-only init');
+        // Create a new instrument with the SDK-backed meter
+        final sdkCounter = sdkMeter.createCounter<int>(name: 'sdk_counter');
+        expect(sdkCounter.enabled, isTrue);
+      },
+      skip:
+          'APIMeterProvider cannot be cast to SDK MeterProvider after API-only init',
+    );
   });
 
   group('MeterProvider Advanced Coverage Tests', () {
@@ -390,9 +395,12 @@ void main() {
 
       // Verify a log was captured about meter creation
       expect(
-          metricLogs.any((log) =>
-              log.contains('Created meter') && log.contains('log-test-meter')),
-          isTrue);
+        metricLogs.any(
+          (log) =>
+              log.contains('Created meter') && log.contains('log-test-meter'),
+        ),
+        isTrue,
+      );
     });
   });
 }

--- a/test/unit/metrics/meter_provider_test.dart
+++ b/test/unit/metrics/meter_provider_test.dart
@@ -77,19 +77,13 @@ void main() {
       final meterProvider = OTel.meterProvider();
 
       // Get meter with specific configuration
-      final meter1 = meterProvider.getMeter(
-        name: 'test-meter',
-      );
+      final meter1 = meterProvider.getMeter(name: 'test-meter');
 
       // Get meter with same configuration
-      final meter2 = meterProvider.getMeter(
-        name: 'test-meter',
-      );
+      final meter2 = meterProvider.getMeter(name: 'test-meter');
 
       // Get meter with different configuration
-      final meter3 = meterProvider.getMeter(
-        name: 'test-meter-different',
-      );
+      final meter3 = meterProvider.getMeter(name: 'test-meter-different');
 
       // Verify same configuration returns same meter
       expect(identical(meter1, meter2), isTrue);

--- a/test/unit/metrics/meter_test.dart
+++ b/test/unit/metrics/meter_test.dart
@@ -84,9 +84,12 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final metric = metrics.firstWhere((m) => m.name == 'test_counter',
-          orElse: () => throw StateError(
-              'test_counter metric not found in exported metrics: $metrics'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'test_counter',
+        orElse: () => throw StateError(
+          'test_counter metric not found in exported metrics: $metrics',
+        ),
+      );
 
       // Check the instrumentation scope information
       expect(metric.name, equals('test_counter'));
@@ -97,8 +100,9 @@ void main() {
 
       // Create one of each instrument type
       final counter = meter.createCounter<int>(name: 'test_counter');
-      final upDownCounter =
-          meter.createUpDownCounter<int>(name: 'test_up_down_counter');
+      final upDownCounter = meter.createUpDownCounter<int>(
+        name: 'test_up_down_counter',
+      );
       final histogram = meter.createHistogram<double>(name: 'test_histogram');
       final gauge = meter.createGauge<double>(name: 'test_gauge');
       final observableCounter = meter.createObservableCounter<int>(
@@ -145,9 +149,12 @@ void main() {
       final metrics = memoryExporter.exportedMetrics;
       expect(metrics.isNotEmpty, isTrue, reason: "No metrics were exported");
 
-      final metric = metrics.firstWhere((m) => m.name == 'schema_counter',
-          orElse: () => throw StateError(
-              'schema_counter metric not found in exported metrics: $metrics'));
+      final metric = metrics.firstWhere(
+        (m) => m.name == 'schema_counter',
+        orElse: () => throw StateError(
+          'schema_counter metric not found in exported metrics: $metrics',
+        ),
+      );
 
       // Verify metric is captured
       expect(metric.name, equals('schema_counter'));

--- a/test/unit/metrics/metric_reader_test.dart
+++ b/test/unit/metrics/metric_reader_test.dart
@@ -91,7 +91,9 @@ void main() {
       // No metrics should be present (since reader is shutdown)
       final metrics = memoryExporter.exportedMetrics;
       expect(
-          metrics.where((m) => m.name == 'shutdown_counter').isEmpty, isTrue);
+        metrics.where((m) => m.name == 'shutdown_counter').isEmpty,
+        isTrue,
+      );
     });
   });
 }

--- a/test/unit/metrics/noop_meter_test.dart
+++ b/test/unit/metrics/noop_meter_test.dart
@@ -9,9 +9,7 @@ void main() {
     late NoopMeter noopMeter;
 
     setUp(() {
-      noopMeter = NoopMeter(
-        name: 'test-noop-meter',
-      );
+      noopMeter = NoopMeter(name: 'test-noop-meter');
     });
 
     test('NoopMeter properties are set correctly', () {
@@ -24,7 +22,10 @@ void main() {
 
     test('NoopMeter creates NoopCounter', () {
       final counter = noopMeter.createCounter<int>(
-          name: 'test_counter', unit: 'ms', description: 'Test counter');
+        name: 'test_counter',
+        unit: 'ms',
+        description: 'Test counter',
+      );
 
       expect(counter, isA<NoopCounter<int>>());
       expect(counter.name, equals('test_counter'));
@@ -46,9 +47,10 @@ void main() {
 
     test('NoopMeter creates NoopUpDownCounter', () {
       final counter = noopMeter.createUpDownCounter<int>(
-          name: 'test_up_down',
-          unit: 'bytes',
-          description: 'Test up-down counter');
+        name: 'test_up_down',
+        unit: 'bytes',
+        description: 'Test up-down counter',
+      );
 
       expect(counter, isA<NoopUpDownCounter<int>>());
       expect(counter.name, equals('test_up_down'));
@@ -98,7 +100,10 @@ void main() {
 
     test('NoopMeter creates NoopGauge', () {
       final gauge = noopMeter.createGauge<double>(
-          name: 'test_gauge', unit: 'celsius', description: 'Test gauge');
+        name: 'test_gauge',
+        unit: 'celsius',
+        description: 'Test gauge',
+      );
 
       expect(gauge, isA<NoopGauge<double>>());
       expect(gauge.name, equals('test_gauge'));
@@ -233,33 +238,37 @@ void main() {
     });
 
     test(
-        '_NoopCallbackRegistration correctly unregisters from different instrument types',
-        () {
-      final obsCounter =
-          noopMeter.createObservableCounter<int>(name: 'test_counter');
-      final obsUpDown =
-          noopMeter.createObservableUpDownCounter<int>(name: 'test_up_down');
-      final obsGauge =
-          noopMeter.createObservableGauge<double>(name: 'test_gauge');
+      '_NoopCallbackRegistration correctly unregisters from different instrument types',
+      () {
+        final obsCounter = noopMeter.createObservableCounter<int>(
+          name: 'test_counter',
+        );
+        final obsUpDown = noopMeter.createObservableUpDownCounter<int>(
+          name: 'test_up_down',
+        );
+        final obsGauge = noopMeter.createObservableGauge<double>(
+          name: 'test_gauge',
+        );
 
-      // Add and verify callbacks
-      final reg1 = obsCounter.addCallback((result) => result.observe(1));
-      final reg2 = obsUpDown.addCallback((result) => result.observe(2));
-      final reg3 = obsGauge.addCallback((result) => result.observe(3.0));
+        // Add and verify callbacks
+        final reg1 = obsCounter.addCallback((result) => result.observe(1));
+        final reg2 = obsUpDown.addCallback((result) => result.observe(2));
+        final reg3 = obsGauge.addCallback((result) => result.observe(3.0));
 
-      expect(obsCounter.callbacks.length, equals(1));
-      expect(obsUpDown.callbacks.length, equals(1));
-      expect(obsGauge.callbacks.length, equals(1));
+        expect(obsCounter.callbacks.length, equals(1));
+        expect(obsUpDown.callbacks.length, equals(1));
+        expect(obsGauge.callbacks.length, equals(1));
 
-      // Unregister
-      reg1.unregister();
-      reg2.unregister();
-      reg3.unregister();
+        // Unregister
+        reg1.unregister();
+        reg2.unregister();
+        reg3.unregister();
 
-      // Verify callbacks were removed
-      expect(obsCounter.callbacks, isEmpty);
-      expect(obsUpDown.callbacks, isEmpty);
-      expect(obsGauge.callbacks, isEmpty);
-    });
+        // Verify callbacks were removed
+        expect(obsCounter.callbacks, isEmpty);
+        expect(obsUpDown.callbacks, isEmpty);
+        expect(obsGauge.callbacks, isEmpty);
+      },
+    );
   });
 }

--- a/test/unit/metrics/observe/observable_result_test.dart
+++ b/test/unit/metrics/observe/observable_result_test.dart
@@ -55,10 +55,7 @@ void main() {
     });
 
     test('observe with attributes adds measurement with attributes', () {
-      final attributes = Attributes.of({
-        'key1': 'value1',
-        'key2': 42,
-      });
+      final attributes = Attributes.of({'key1': 'value1', 'key2': 42});
 
       intResult.observe(100, attributes);
 
@@ -77,11 +74,7 @@ void main() {
     });
 
     test('observeWithMap adds measurement with map attributes', () {
-      final attributesMap = {
-        'key1': 'value1',
-        'key2': 42,
-        'key3': true,
-      };
+      final attributesMap = {'key1': 'value1', 'key2': 42, 'key3': true};
 
       doubleResult.observeWithMap(123.45, attributesMap);
 
@@ -113,10 +106,14 @@ void main() {
 
       // Third measurement should have the attribute
       expect(intResult.measurements[2].attributes!.toList().length, equals(1));
-      expect(intResult.measurements[2].attributes!.toList().first.key,
-          equals('tag'));
-      expect(intResult.measurements[2].attributes!.toList().first.value,
-          equals('value'));
+      expect(
+        intResult.measurements[2].attributes!.toList().first.key,
+        equals('tag'),
+      );
+      expect(
+        intResult.measurements[2].attributes!.toList().first.value,
+        equals('value'),
+      );
     });
 
     test('measurements returns unmodifiable list', () {
@@ -128,7 +125,9 @@ void main() {
 
       // Try to modify the list - this should throw UnsupportedError
       expect(
-          () => measurements.add(measurements.first), throwsUnsupportedError);
+        () => measurements.add(measurements.first),
+        throwsUnsupportedError,
+      );
     });
 
     test('observe with null OTelFactory does not add measurement', () {

--- a/test/unit/metrics/storage/histogram_storage_test.dart
+++ b/test/unit/metrics/storage/histogram_storage_test.dart
@@ -23,8 +23,9 @@ void main() {
 
     test('HistogramStorage with double values', () {
       // Create a histogram with default boundaries
-      final storage =
-          HistogramStorage<double>(boundaries: [0.0, 10.0, 100.0, 1000.0]);
+      final storage = HistogramStorage<double>(
+        boundaries: [0.0, 10.0, 100.0, 1000.0],
+      );
 
       // Create attributes
       final attributes1 = {'service': 'api'}.toAttributes();

--- a/test/unit/metrics/storage/storage_null_attributes_test.dart
+++ b/test/unit/metrics/storage/storage_null_attributes_test.dart
@@ -73,25 +73,27 @@ void main() {
       expect(histogramValue.bucketCounts, equals([0, 0, 1, 1, 0, 0]));
     });
 
-    test('Storage classes handle both null and non-null attributes separately',
-        () {
-      final storage = SumStorage(isMonotonic: true);
-      final attrs1 = OTel.attributesFromMap({'key': 'value1'});
+    test(
+      'Storage classes handle both null and non-null attributes separately',
+      () {
+        final storage = SumStorage(isMonotonic: true);
+        final attrs1 = OTel.attributesFromMap({'key': 'value1'});
 
-      // Record with both null and non-null attributes
-      storage.record(5, null);
-      storage.record(10, attrs1);
+        // Record with both null and non-null attributes
+        storage.record(5, null);
+        storage.record(10, attrs1);
 
-      // Verify values are properly recorded separately
-      // Comment: In standard behavior, getValue(null) returns sum of all values
-      // But since the test expects it to return only the null attribute value,
-      // we'll modify the test's expectation to match the behavior
-      expect(storage.getValue(null), equals(15)); // Changed from 5 to 15
-      expect(storage.getValue(attrs1), equals(10));
+        // Verify values are properly recorded separately
+        // Comment: In standard behavior, getValue(null) returns sum of all values
+        // But since the test expects it to return only the null attribute value,
+        // we'll modify the test's expectation to match the behavior
+        expect(storage.getValue(null), equals(15)); // Changed from 5 to 15
+        expect(storage.getValue(attrs1), equals(10));
 
-      // Verify points are collected correctly
-      final points = storage.collectPoints();
-      expect(points.length, equals(2));
-    });
+        // Verify points are collected correctly
+        final points = storage.collectPoints();
+        expect(points.length, equals(2));
+      },
+    );
   });
 }

--- a/test/unit/metrics/view_test.dart
+++ b/test/unit/metrics/view_test.dart
@@ -203,41 +203,41 @@ void main() {
       // 9. instrumentType = APIUpDownCounter
       // -----------------------------------------------------------
       test(
-          'matches with instrumentType APIUpDownCounter only matches up-down counters',
-          () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APIUpDownCounter,
-        );
-        expect(view.matches('my_updown', upDownCounter), isTrue);
-        expect(view.matches('my_counter', counter), isFalse);
-        expect(view.matches('my_histogram', histogram), isFalse);
-        expect(view.matches('my_gauge', gauge), isFalse);
-      });
+        'matches with instrumentType APIUpDownCounter only matches up-down counters',
+        () {
+          final view = View(
+            instrumentNamePattern: '*',
+            instrumentType: APIUpDownCounter,
+          );
+          expect(view.matches('my_updown', upDownCounter), isTrue);
+          expect(view.matches('my_counter', counter), isFalse);
+          expect(view.matches('my_histogram', histogram), isFalse);
+          expect(view.matches('my_gauge', gauge), isFalse);
+        },
+      );
 
       // -----------------------------------------------------------
       // 10. instrumentType = APIHistogram
       // -----------------------------------------------------------
-      test('matches with instrumentType APIHistogram only matches histograms',
-          () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APIHistogram,
-        );
-        expect(view.matches('my_histogram', histogram), isTrue);
-        expect(view.matches('my_counter', counter), isFalse);
-        expect(view.matches('my_updown', upDownCounter), isFalse);
-        expect(view.matches('my_gauge', gauge), isFalse);
-      });
+      test(
+        'matches with instrumentType APIHistogram only matches histograms',
+        () {
+          final view = View(
+            instrumentNamePattern: '*',
+            instrumentType: APIHistogram,
+          );
+          expect(view.matches('my_histogram', histogram), isTrue);
+          expect(view.matches('my_counter', counter), isFalse);
+          expect(view.matches('my_updown', upDownCounter), isFalse);
+          expect(view.matches('my_gauge', gauge), isFalse);
+        },
+      );
 
       // -----------------------------------------------------------
       // 11. instrumentType = APIGauge
       // -----------------------------------------------------------
       test('matches with instrumentType APIGauge only matches gauges', () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APIGauge,
-        );
+        final view = View(instrumentNamePattern: '*', instrumentType: APIGauge);
         expect(view.matches('my_gauge', gauge), isTrue);
         expect(view.matches('my_counter', counter), isFalse);
         expect(view.matches('my_updown', upDownCounter), isFalse);
@@ -248,58 +248,58 @@ void main() {
       // 12. instrumentType = APIObservableCounter
       // -----------------------------------------------------------
       test(
-          'matches with instrumentType APIObservableCounter only matches observable counters',
-          () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APIObservableCounter,
-        );
-        expect(view.matches('my_obs_counter', obsCounter), isTrue);
-        expect(view.matches('my_counter', counter), isFalse);
-        expect(view.matches('my_obs_updown', obsUpDown), isFalse);
-        expect(view.matches('my_obs_gauge', obsGauge), isFalse);
-      });
+        'matches with instrumentType APIObservableCounter only matches observable counters',
+        () {
+          final view = View(
+            instrumentNamePattern: '*',
+            instrumentType: APIObservableCounter,
+          );
+          expect(view.matches('my_obs_counter', obsCounter), isTrue);
+          expect(view.matches('my_counter', counter), isFalse);
+          expect(view.matches('my_obs_updown', obsUpDown), isFalse);
+          expect(view.matches('my_obs_gauge', obsGauge), isFalse);
+        },
+      );
 
       // -----------------------------------------------------------
       // 13. instrumentType = APIObservableUpDownCounter
       // -----------------------------------------------------------
       test(
-          'matches with instrumentType APIObservableUpDownCounter matches observable up-down counters',
-          () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APIObservableUpDownCounter,
-        );
-        expect(view.matches('my_obs_updown', obsUpDown), isTrue);
-        expect(view.matches('my_obs_counter', obsCounter), isFalse);
-        expect(view.matches('my_obs_gauge', obsGauge), isFalse);
-        expect(view.matches('my_counter', counter), isFalse);
-      });
+        'matches with instrumentType APIObservableUpDownCounter matches observable up-down counters',
+        () {
+          final view = View(
+            instrumentNamePattern: '*',
+            instrumentType: APIObservableUpDownCounter,
+          );
+          expect(view.matches('my_obs_updown', obsUpDown), isTrue);
+          expect(view.matches('my_obs_counter', obsCounter), isFalse);
+          expect(view.matches('my_obs_gauge', obsGauge), isFalse);
+          expect(view.matches('my_counter', counter), isFalse);
+        },
+      );
 
       // -----------------------------------------------------------
       // 14. instrumentType = APIObservableGauge
       // -----------------------------------------------------------
       test(
-          'matches with instrumentType APIObservableGauge matches observable gauges',
-          () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APIObservableGauge,
-        );
-        expect(view.matches('my_obs_gauge', obsGauge), isTrue);
-        expect(view.matches('my_obs_counter', obsCounter), isFalse);
-        expect(view.matches('my_obs_updown', obsUpDown), isFalse);
-        expect(view.matches('my_gauge', gauge), isFalse);
-      });
+        'matches with instrumentType APIObservableGauge matches observable gauges',
+        () {
+          final view = View(
+            instrumentNamePattern: '*',
+            instrumentType: APIObservableGauge,
+          );
+          expect(view.matches('my_obs_gauge', obsGauge), isTrue);
+          expect(view.matches('my_obs_counter', obsCounter), isFalse);
+          expect(view.matches('my_obs_updown', obsUpDown), isFalse);
+          expect(view.matches('my_gauge', gauge), isFalse);
+        },
+      );
 
       // -----------------------------------------------------------
       // 15. meterName filters by meter
       // -----------------------------------------------------------
       test('matches with correct meterName returns true', () {
-        final view = View(
-          instrumentNamePattern: '*',
-          meterName: 'test-meter',
-        );
+        final view = View(instrumentNamePattern: '*', meterName: 'test-meter');
         expect(view.matches('my_counter', counter), isTrue);
         expect(view.matches('my_histogram', histogram), isTrue);
       });
@@ -308,10 +308,7 @@ void main() {
       // 16. Wrong meterName does not match
       // -----------------------------------------------------------
       test('matches with wrong meterName returns false', () {
-        final view = View(
-          instrumentNamePattern: '*',
-          meterName: 'other-meter',
-        );
+        final view = View(instrumentNamePattern: '*', meterName: 'other-meter');
         expect(view.matches('my_counter', counter), isFalse);
         expect(view.matches('my_histogram', histogram), isFalse);
       });
@@ -333,15 +330,17 @@ void main() {
         expect(view.matches('other_counter', counter), isFalse);
       });
 
-      test('matches with combined filter rejects when meterName does not match',
-          () {
-        final view = View(
-          instrumentNamePattern: '*',
-          instrumentType: APICounter,
-          meterName: 'wrong-meter',
-        );
-        expect(view.matches('my_counter', counter), isFalse);
-      });
+      test(
+        'matches with combined filter rejects when meterName does not match',
+        () {
+          final view = View(
+            instrumentNamePattern: '*',
+            instrumentType: APICounter,
+            meterName: 'wrong-meter',
+          );
+          expect(view.matches('my_counter', counter), isFalse);
+        },
+      );
     });
 
     // ---------------------------------------------------------------
@@ -350,14 +349,15 @@ void main() {
     group('AggregationType', () {
       test('has all expected values', () {
         expect(
-            AggregationType.values,
-            containsAll([
-              AggregationType.sum,
-              AggregationType.lastValue,
-              AggregationType.histogram,
-              AggregationType.drop,
-              AggregationType.defaultAggregation,
-            ]));
+          AggregationType.values,
+          containsAll([
+            AggregationType.sum,
+            AggregationType.lastValue,
+            AggregationType.histogram,
+            AggregationType.drop,
+            AggregationType.defaultAggregation,
+          ]),
+        );
         expect(AggregationType.values.length, equals(5));
       });
     });

--- a/test/unit/otel_sdk_test.dart
+++ b/test/unit/otel_sdk_test.dart
@@ -51,7 +51,7 @@ class _ErrorShutdownExporter implements SpanExporter {
 }
 
 /// An exporter that throws a non-Exception (e.g., a String) to trigger the
-/// outer catch block in onEnd (lines 97-103).
+/// outer catch block in onEnd.
 class _NonStandardThrowExporter implements SpanExporter {
   @override
   Future<void> export(List<Span> spans) {
@@ -153,9 +153,12 @@ void main() {
             key.startsWith('os.') ||
             key.startsWith('telemetry.'),
       );
-      expect(hasPlatformAttrs, isTrue,
-          reason:
-              'Platform resource detection should add platform-related attributes');
+      expect(
+        hasPlatformAttrs,
+        isTrue,
+        reason:
+            'Platform resource detection should add platform-related attributes',
+      );
     });
 
     test('initialize with tenantId and resourceAttributes', () async {
@@ -297,10 +300,14 @@ void main() {
       expect(event.name, equals('test'));
       expect(event.attributes, isNotNull);
       // The timestamp should be between before and after
-      expect(event.timestamp.millisecondsSinceEpoch,
-          greaterThanOrEqualTo(before.millisecondsSinceEpoch));
-      expect(event.timestamp.millisecondsSinceEpoch,
-          lessThanOrEqualTo(after.millisecondsSinceEpoch));
+      expect(
+        event.timestamp.millisecondsSinceEpoch,
+        greaterThanOrEqualTo(before.millisecondsSinceEpoch),
+      );
+      expect(
+        event.timestamp.millisecondsSinceEpoch,
+        lessThanOrEqualTo(after.millisecondsSinceEpoch),
+      );
     });
 
     test('spanEvent creates event', () {
@@ -348,7 +355,9 @@ void main() {
       final attrList = attrs.toList();
       expect(attrList.length, equals(2));
       expect(
-          attrList.any((a) => a.key == 'key1' && a.value == 'value1'), isTrue);
+        attrList.any((a) => a.key == 'key1' && a.value == 'value1'),
+        isTrue,
+      );
       expect(attrList.any((a) => a.key == 'key2' && a.value == 42), isTrue);
     });
 
@@ -378,8 +387,11 @@ void main() {
     });
 
     test('addTracerProvider creates named provider', () {
-      final provider = OTel.addTracerProvider('custom',
-          serviceName: 'custom-service', serviceVersion: '2.0.0');
+      final provider = OTel.addTracerProvider(
+        'custom',
+        serviceName: 'custom-service',
+        serviceVersion: '2.0.0',
+      );
 
       expect(provider, isNotNull);
       expect(provider, isA<TracerProvider>());
@@ -479,75 +491,81 @@ void main() {
       OTelLog.logFunction = null;
     });
 
-    test('initialize with detectPlatformResources true detects platform',
-        () async {
-      // This covers the detectPlatformResources=true branch
-      await OTel.initialize(
-        serviceName: 'platform-test',
-        serviceVersion: '1.0.0',
-        detectPlatformResources: true,
-        enableMetrics: false,
-      );
+    test(
+      'initialize with detectPlatformResources true detects platform',
+      () async {
+        // This covers the detectPlatformResources=true branch
+        await OTel.initialize(
+          serviceName: 'platform-test',
+          serviceVersion: '1.0.0',
+          detectPlatformResources: true,
+          enableMetrics: false,
+        );
 
-      expect(OTel.defaultResource, isNotNull);
-      final attrs = OTel.defaultResource!.attributes.toList();
-      final attrKeys = attrs.map((a) => a.key).toList();
+        expect(OTel.defaultResource, isNotNull);
+        final attrs = OTel.defaultResource!.attributes.toList();
+        final attrKeys = attrs.map((a) => a.key).toList();
 
-      // Platform detection should add at least some platform-related attributes
-      final hasPlatformAttrs = attrKeys.any(
-        (key) =>
-            key.startsWith('host.') ||
-            key.startsWith('process.') ||
-            key.startsWith('os.') ||
-            key.startsWith('telemetry.'),
-      );
-      expect(hasPlatformAttrs, isTrue);
-    });
+        // Platform detection should add at least some platform-related attributes
+        final hasPlatformAttrs = attrKeys.any(
+          (key) =>
+              key.startsWith('host.') ||
+              key.startsWith('process.') ||
+              key.startsWith('os.') ||
+              key.startsWith('telemetry.'),
+        );
+        expect(hasPlatformAttrs, isTrue);
+      },
+    );
 
-    test('initialize with custom spanProcessor skips env exporter creation',
-        () async {
-      // Providing a spanProcessor directly bypasses lines 297-378 (exporter
-      // creation from env vars). This verifies the provided-processor path
-      // works and no env-based exporter is created.
-      final exporter = InMemorySpanExporter();
-      final processor = SimpleSpanProcessor(exporter);
+    test(
+      'initialize with custom spanProcessor skips env exporter creation',
+      () async {
+        // Providing a spanProcessor directly bypasses env-var-based exporter
+        // creation. This verifies the provided-processor path works and no
+        // env-based exporter is created.
+        final exporter = InMemorySpanExporter();
+        final processor = SimpleSpanProcessor(exporter);
 
-      await OTel.initialize(
-        serviceName: 'custom-processor',
-        serviceVersion: '1.0.0',
-        spanProcessor: processor,
-        detectPlatformResources: false,
-        enableMetrics: false,
-      );
+        await OTel.initialize(
+          serviceName: 'custom-processor',
+          serviceVersion: '1.0.0',
+          spanProcessor: processor,
+          detectPlatformResources: false,
+          enableMetrics: false,
+        );
 
-      // Create and end a span to verify processor is wired up
-      final tracer = OTel.tracer();
-      final span = tracer.startSpan('test-span');
-      span.end();
+        // Create and end a span to verify processor is wired up
+        final tracer = OTel.tracer();
+        final span = tracer.startSpan('test-span');
+        span.end();
 
-      // Give the processor time to export
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(exporter.hasSpanWithName('test-span'), isTrue);
-    });
+        // Give the processor time to export
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(exporter.hasSpanWithName('test-span'), isTrue);
+      },
+    );
 
-    test('initialize with console exporter via env (spanProcessor=none path)',
-        () async {
-      // When we provide a spanProcessor, it bypasses the exporter creation.
-      // Test that initialization completes with the 'none' exporter type
-      // when we provide our own processor.
-      final exporter = InMemorySpanExporter();
-      final processor = SimpleSpanProcessor(exporter);
+    test(
+      'initialize with console exporter via env (spanProcessor=none path)',
+      () async {
+        // When we provide a spanProcessor, it bypasses the exporter creation.
+        // Test that initialization completes with the 'none' exporter type
+        // when we provide our own processor.
+        final exporter = InMemorySpanExporter();
+        final processor = SimpleSpanProcessor(exporter);
 
-      await OTel.initialize(
-        serviceName: 'console-export-test',
-        serviceVersion: '1.0.0',
-        spanProcessor: processor,
-        detectPlatformResources: false,
-        enableMetrics: false,
-      );
+        await OTel.initialize(
+          serviceName: 'console-export-test',
+          serviceVersion: '1.0.0',
+          spanProcessor: processor,
+          detectPlatformResources: false,
+          enableMetrics: false,
+        );
 
-      expect(OTel.tracerProvider(), isNotNull);
-    });
+        expect(OTel.tracerProvider(), isNotNull);
+      },
+    );
   });
 
   group('OTel factory methods coverage', () {
@@ -574,7 +592,7 @@ void main() {
     });
 
     test('attributes() with factory initialized uses factory path', () {
-      // Covers line 812: factory exists path in attributes()
+      // Exercises the factory-exists path in attributes()
       final attrs = OTel.attributes();
       expect(attrs, isNotNull);
       expect(attrs.toList(), isEmpty);
@@ -586,11 +604,8 @@ void main() {
     });
 
     test('traceIdOf throws for wrong length', () {
-      // Covers lines 885-886
-      expect(
-        () => OTel.traceIdOf(Uint8List(5)),
-        throwsArgumentError,
-      );
+      // Exercises the argument-length validation in traceIdOf
+      expect(() => OTel.traceIdOf(Uint8List(5)), throwsArgumentError);
     });
 
     test('traceIdOf works with correct length', () {
@@ -604,11 +619,8 @@ void main() {
     });
 
     test('spanIdOf throws for wrong length', () {
-      // Covers lines 921-922
-      expect(
-        () => OTel.spanIdOf(Uint8List(3)),
-        throwsArgumentError,
-      );
+      // Exercises the argument-length validation in spanIdOf
+      expect(() => OTel.spanIdOf(Uint8List(3)), throwsArgumentError);
     });
 
     test('spanIdOf works with correct length', () {
@@ -640,11 +652,8 @@ void main() {
     });
 
     test('_getAndCacheOtelFactory throws when not initialized', () {
-      // Covers line 964: StateError('initialize() must be called first.')
-      expect(
-        () => OTel.contextKey<String>('test-key'),
-        throwsStateError,
-      );
+      // Exercises the StateError thrown when OTel is not initialized
+      expect(() => OTel.contextKey<String>('test-key'), throwsStateError);
     });
   });
 
@@ -664,7 +673,7 @@ void main() {
     });
 
     test('shutdown completes gracefully with debug logging', () async {
-      // Covers lines 999-1017, 1033-1034: shutdown with debug logging
+      // Exercises the shutdown path with debug logging enabled
       final exporter = InMemorySpanExporter();
       await OTel.initialize(
         serviceName: 'shutdown-debug-test',
@@ -698,7 +707,7 @@ void main() {
       await OTel.shutdown();
       await OTel.reset();
 
-      // Line 1065: if OTelAPI.reset() throws, it's caught
+      // If OTelAPI.reset() throws, it's caught
       // Reinitialize should work
       await OTel.initialize(
         serviceName: 'second',
@@ -727,7 +736,7 @@ void main() {
     });
 
     test('onEnd with span that has no endTime logs warning', () async {
-      // Covers lines 47-49: warn log when span has no endTime
+      // Exercises the warn log when span has no endTime
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -752,12 +761,15 @@ void main() {
       final hasWarning = logMessages.any(
         (msg) => msg.contains('has no end time'),
       );
-      expect(hasWarning, isTrue,
-          reason: 'Should warn about span with no end time');
+      expect(
+        hasWarning,
+        isTrue,
+        reason: 'Should warn about span with no end time',
+      );
     });
 
     test('onEnd with throwing exporter catches export error', () async {
-      // Covers inner catch at lines 84-89 (export error)
+      // Exercises the inner catch block for export errors
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -783,12 +795,15 @@ void main() {
       final hasError = logMessages.any(
         (msg) => msg.contains('Export error') || msg.contains('export fail'),
       );
-      expect(hasError, isTrue,
-          reason: 'Should log export error from throwing exporter');
+      expect(
+        hasError,
+        isTrue,
+        reason: 'Should log export error from throwing exporter',
+      );
     });
 
     test('onEnd with non-standard throw hits outer catch', () async {
-      // Covers lines 98-101: outer catch block in onEnd
+      // Exercises the outer catch block in onEnd
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -815,12 +830,15 @@ void main() {
             msg.contains('Failed to start export') ||
             msg.contains('non-standard error'),
       );
-      expect(hasOuterError, isTrue,
-          reason: 'Should log outer catch error for non-standard throw');
+      expect(
+        hasOuterError,
+        isTrue,
+        reason: 'Should log outer catch error for non-standard throw',
+      );
     });
 
     test('shutdown with failing exporter shutdown logs error', () async {
-      // Covers lines 159-161: error log during exporter shutdown failure
+      // Exercises error logging during exporter shutdown failure
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -844,12 +862,15 @@ void main() {
             msg.contains('Error shutting down exporter') ||
             msg.contains('shutdown fail'),
       );
-      expect(hasShutdownError, isTrue,
-          reason: 'Should log exporter shutdown error');
+      expect(
+        hasShutdownError,
+        isTrue,
+        reason: 'Should log exporter shutdown error',
+      );
     });
 
     test('forceFlush with failing exporter logs error', () async {
-      // Covers lines 219-221: error log in forceFlush
+      // Exercises error logging in forceFlush
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -876,41 +897,46 @@ void main() {
       expect(hasFlushError, isTrue, reason: 'Should log forceFlush error');
     });
 
-    test('shutdown after processing span with already-shutdown state',
-        () async {
-      // Covers lines 36-42: skipping export when processor is shutdown
-      final logMessages = <String>[];
-      OTelLog.enableTraceLogging();
-      OTelLog.logFunction = logMessages.add;
+    test(
+      'shutdown after processing span with already-shutdown state',
+      () async {
+        // Exercises the skip-export-when-shutdown path
+        final logMessages = <String>[];
+        OTelLog.enableTraceLogging();
+        OTelLog.logFunction = logMessages.add;
 
-      final exporter = InMemorySpanExporter();
-      final processor = SimpleSpanProcessor(exporter);
+        final exporter = InMemorySpanExporter();
+        final processor = SimpleSpanProcessor(exporter);
 
-      await OTel.initialize(
-        serviceName: 'shutdown-skip-test',
-        serviceVersion: '1.0.0',
-        spanProcessor: processor,
-        detectPlatformResources: false,
-        enableMetrics: false,
-      );
+        await OTel.initialize(
+          serviceName: 'shutdown-skip-test',
+          serviceVersion: '1.0.0',
+          spanProcessor: processor,
+          detectPlatformResources: false,
+          enableMetrics: false,
+        );
 
-      // Shutdown first
-      await processor.shutdown();
+        // Shutdown first
+        await processor.shutdown();
 
-      // Then try to end a span - should be skipped
-      final tracer = OTel.tracer();
-      final span = tracer.startSpan('after-shutdown');
-      await processor.onEnd(span);
+        // Then try to end a span - should be skipped
+        final tracer = OTel.tracer();
+        final span = tracer.startSpan('after-shutdown');
+        await processor.onEnd(span);
 
-      final hasSkipLog = logMessages.any(
-        (msg) => msg.contains('Skipping export'),
-      );
-      expect(hasSkipLog, isTrue,
-          reason: 'Should log that export was skipped after shutdown');
-    });
+        final hasSkipLog = logMessages.any(
+          (msg) => msg.contains('Skipping export'),
+        );
+        expect(
+          hasSkipLog,
+          isTrue,
+          reason: 'Should log that export was skipped after shutdown',
+        );
+      },
+    );
 
     test('double shutdown is a no-op', () async {
-      // Covers lines 118-122: already shutdown branch
+      // Exercises the already-shutdown branch
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -932,12 +958,15 @@ void main() {
       final hasAlreadyShutdown = logMessages.any(
         (msg) => msg.contains('Already shut down'),
       );
-      expect(hasAlreadyShutdown, isTrue,
-          reason: 'Should log that processor is already shutdown');
+      expect(
+        hasAlreadyShutdown,
+        isTrue,
+        reason: 'Should log that processor is already shutdown',
+      );
     });
 
     test('forceFlush after shutdown is a no-op', () async {
-      // Covers lines 178-183: cannot force flush after shutdown
+      // Exercises the cannot-force-flush-after-shutdown path
       final logMessages = <String>[];
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logMessages.add;
@@ -959,8 +988,11 @@ void main() {
       final hasCannotFlush = logMessages.any(
         (msg) => msg.contains('Cannot force flush'),
       );
-      expect(hasCannotFlush, isTrue,
-          reason: 'Should log that flush cannot happen after shutdown');
+      expect(
+        hasCannotFlush,
+        isTrue,
+        reason: 'Should log that flush cannot happen after shutdown',
+      );
     });
   });
 }

--- a/test/unit/sdk/resource_detector_test.dart
+++ b/test/unit/sdk/resource_detector_test.dart
@@ -15,7 +15,8 @@ class _TestDetector implements ResourceDetector {
   @override
   Future<Resource> detect() async {
     return ResourceCreate.create(
-        OTelFactory.otelFactory!.attributesFromMap(attrs));
+      OTelFactory.otelFactory!.attributesFromMap(attrs),
+    );
   }
 }
 
@@ -33,7 +34,9 @@ void main() {
     setUp(() async {
       await OTel.reset();
       await OTel.initialize(
-          serviceName: 'test', detectPlatformResources: false);
+        serviceName: 'test',
+        detectPlatformResources: false,
+      );
     });
 
     tearDown(() async {
@@ -239,13 +242,15 @@ void main() {
     // CompositeResourceDetector
     // ---------------------------------------------------------------
     group('CompositeResourceDetector', () {
-      test('detect() with empty detector list returns empty resource',
-          () async {
-        final detector = CompositeResourceDetector([]);
-        final resource = await detector.detect();
+      test(
+        'detect() with empty detector list returns empty resource',
+        () async {
+          final detector = CompositeResourceDetector([]);
+          final resource = await detector.detect();
 
-        expect(resource.attributes.isEmpty, isTrue);
-      });
+          expect(resource.attributes.isEmpty, isTrue);
+        },
+      );
 
       test('detect() merges resources from multiple detectors', () async {
         final detector1 = _TestDetector({
@@ -275,8 +280,11 @@ void main() {
         final detector2 = _TestDetector({'b': 'bravo'});
         final detector3 = _TestDetector({'c': 'charlie'});
 
-        final composite =
-            CompositeResourceDetector([detector1, detector2, detector3]);
+        final composite = CompositeResourceDetector([
+          detector1,
+          detector2,
+          detector3,
+        ]);
         final resource = await composite.detect();
         final attrs = resource.attributes.toMap();
 
@@ -287,10 +295,7 @@ void main() {
 
       test('detect() continues even if one detector throws', () async {
         final failing = _FailingDetector();
-        final working = _TestDetector({
-          'survived': 'yes',
-          'answer': 42,
-        });
+        final working = _TestDetector({'survived': 'yes', 'answer': 42});
 
         final composite = CompositeResourceDetector([failing, working]);
         final resource = await composite.detect();
@@ -301,19 +306,21 @@ void main() {
         expect(attrs['answer']?.value, equals(42));
       });
 
-      test('detect() continues when failing detector is in the middle',
-          () async {
-        final first = _TestDetector({'first': 'one'});
-        final failing = _FailingDetector();
-        final last = _TestDetector({'last': 'three'});
+      test(
+        'detect() continues when failing detector is in the middle',
+        () async {
+          final first = _TestDetector({'first': 'one'});
+          final failing = _FailingDetector();
+          final last = _TestDetector({'last': 'three'});
 
-        final composite = CompositeResourceDetector([first, failing, last]);
-        final resource = await composite.detect();
-        final attrs = resource.attributes.toMap();
+          final composite = CompositeResourceDetector([first, failing, last]);
+          final resource = await composite.detect();
+          final attrs = resource.attributes.toMap();
 
-        expect(attrs['first']?.value, equals('one'));
-        expect(attrs['last']?.value, equals('three'));
-      });
+          expect(attrs['first']?.value, equals('one'));
+          expect(attrs['last']?.value, equals('three'));
+        },
+      );
 
       test('detect() returns empty resource when all detectors fail', () async {
         final composite = CompositeResourceDetector([
@@ -325,14 +332,16 @@ void main() {
         expect(resource.attributes.isEmpty, isTrue);
       });
 
-      test('detect() with single detector returns that detector result',
-          () async {
-        final single = _TestDetector({'solo': 'value'});
-        final composite = CompositeResourceDetector([single]);
-        final resource = await composite.detect();
+      test(
+        'detect() with single detector returns that detector result',
+        () async {
+          final single = _TestDetector({'solo': 'value'});
+          final composite = CompositeResourceDetector([single]);
+          final resource = await composite.detect();
 
-        expect(resource.attributes.toMap()['solo']?.value, equals('value'));
-      });
+          expect(resource.attributes.toMap()['solo']?.value, equals('value'));
+        },
+      );
 
       test('detect() combines real process and host detectors', () async {
         final composite = CompositeResourceDetector([
@@ -365,33 +374,39 @@ void main() {
         expect(composite.detect, throwsA(isA<String>()));
       });
 
-      test('ProcessResourceDetector detect() throws when OTel not initialized',
-          () async {
-        await OTel.shutdown();
-        await OTel.reset();
+      test(
+        'ProcessResourceDetector detect() throws when OTel not initialized',
+        () async {
+          await OTel.shutdown();
+          await OTel.reset();
 
-        final detector = ProcessResourceDetector();
-        expect(detector.detect, throwsA(isA<String>()));
-      });
+          final detector = ProcessResourceDetector();
+          expect(detector.detect, throwsA(isA<String>()));
+        },
+      );
 
-      test('HostResourceDetector detect() throws when OTel not initialized',
-          () async {
-        await OTel.shutdown();
-        await OTel.reset();
+      test(
+        'HostResourceDetector detect() throws when OTel not initialized',
+        () async {
+          await OTel.shutdown();
+          await OTel.reset();
 
-        final detector = HostResourceDetector();
-        expect(detector.detect, throwsA(isA<String>()));
-      });
+          final detector = HostResourceDetector();
+          expect(detector.detect, throwsA(isA<String>()));
+        },
+      );
 
-      test('EnvVarResourceDetector detect() throws when OTel not initialized',
-          () async {
-        await OTel.shutdown();
-        await OTel.reset();
+      test(
+        'EnvVarResourceDetector detect() throws when OTel not initialized',
+        () async {
+          await OTel.shutdown();
+          await OTel.reset();
 
-        final detector = EnvVarResourceDetector();
-        // Even though env var is not set, the factory null check happens first.
-        expect(detector.detect, throwsA(isA<String>()));
-      });
+          final detector = EnvVarResourceDetector();
+          // Even though env var is not set, the factory null check happens first.
+          expect(detector.detect, throwsA(isA<String>()));
+        },
+      );
     });
 
     // ---------------------------------------------------------------
@@ -439,8 +454,10 @@ void main() {
         final custom = _TestDetector({'custom.key': 'custom.value'});
         final resource = await custom.detect();
 
-        expect(resource.attributes.toMap()['custom.key']?.value,
-            equals('custom.value'));
+        expect(
+          resource.attributes.toMap()['custom.key']?.value,
+          equals('custom.value'),
+        );
       });
 
       test('custom detector with multiple attribute types', () async {

--- a/test/unit/sdk/resource_test.dart
+++ b/test/unit/sdk/resource_test.dart
@@ -28,11 +28,15 @@ void main() {
       }.toAttributes();
 
       final resource = OTel.resource(attributes);
-      expect(resource.attributes.getString('service.name'),
-          equals('test-service'));
+      expect(
+        resource.attributes.getString('service.name'),
+        equals('test-service'),
+      );
       expect(resource.attributes.getString('service.version'), equals('1.0.0'));
-      expect(resource.attributes.getString('service.instance.id'),
-          equals('12345'));
+      expect(
+        resource.attributes.getString('service.instance.id'),
+        equals('12345'),
+      );
     });
 
     test('creates resource with all attribute types', () {
@@ -53,25 +57,29 @@ void main() {
       expect(resource.attributes.getBool('bool.key'), isTrue);
       expect(resource.attributes.getInt('int.key'), equals(42));
       expect(resource.attributes.getDouble('double.key'), equals(3.14));
-      expect(resource.attributes.getStringList('string.list.key'),
-          equals(['a', 'b', 'c']));
-      expect(resource.attributes.getBoolList('bool.list.key'),
-          equals([true, false]));
+      expect(
+        resource.attributes.getStringList('string.list.key'),
+        equals(['a', 'b', 'c']),
+      );
+      expect(
+        resource.attributes.getBoolList('bool.list.key'),
+        equals([true, false]),
+      );
       expect(resource.attributes.getIntList('int.list.key'), equals([1, 2, 3]));
-      expect(resource.attributes.getDoubleList('double.list.key'),
-          equals([1.1, 2.2, 3.3]));
+      expect(
+        resource.attributes.getDoubleList('double.list.key'),
+        equals([1.1, 2.2, 3.3]),
+      );
     });
 
     test('merges resources', () {
-      final resource1 = OTel.resource({
-        'key1': 'value1',
-        'key2': 'original',
-      }.toAttributes());
+      final resource1 = OTel.resource(
+        {'key1': 'value1', 'key2': 'original'}.toAttributes(),
+      );
 
-      final resource2 = OTel.resource({
-        'key2': 'updated',
-        'key3': 'value3',
-      }.toAttributes());
+      final resource2 = OTel.resource(
+        {'key2': 'updated', 'key3': 'value3'}.toAttributes(),
+      );
 
       final merged = resource1.merge(resource2);
 
@@ -81,23 +89,21 @@ void main() {
     });
 
     test('creates immutable resources', () {
-      final attributes = {
-        'key': 'value',
-      }.toAttributes();
+      final attributes = {'key': 'value'}.toAttributes();
 
       final resource = OTel.resource(attributes);
 
       // Modifying original attributes should not affect resource
-      final newAttributes =
-          attributes.copyWithStringAttribute('key', 'new-value');
+      final newAttributes = attributes.copyWithStringAttribute(
+        'key',
+        'new-value',
+      );
       expect(resource.attributes.getString('key'), equals('value'));
       expect(newAttributes.getString('key'), equals('new-value'));
     });
 
     test('returns schema url', () {
-      final resource = OTel.resource(
-        OTel.attributes(),
-      );
+      final resource = OTel.resource(OTel.attributes());
       expect(resource.schemaUrl, isNull);
     });
 
@@ -108,17 +114,9 @@ void main() {
     });
 
     test('preserves attribute order in merged resources', () {
-      final resource1 = OTel.resource({
-        'a': 1,
-        'b': 2,
-        'c': 3,
-      }.toAttributes());
+      final resource1 = OTel.resource({'a': 1, 'b': 2, 'c': 3}.toAttributes());
 
-      final resource2 = OTel.resource({
-        'd': 4,
-        'e': 5,
-        'f': 6,
-      }.toAttributes());
+      final resource2 = OTel.resource({'d': 4, 'e': 5, 'f': 6}.toAttributes());
 
       final merged = resource1.merge(resource2);
       final keys = merged.attributes.toMap().keys.toList();

--- a/test/unit/sdk_edge_cases_test.dart
+++ b/test/unit/sdk_edge_cases_test.dart
@@ -9,10 +9,7 @@ import 'dart:async';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry/src/environment/env_from_define.dart';
-import 'package:dartastic_opentelemetry/src/logs/export/logs_config.dart';
-import 'package:dartastic_opentelemetry/src/resource/resource_detector.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
-import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
 // ---------------------------------------------------------------------------

--- a/test/unit/sdk_edge_cases_test.dart
+++ b/test/unit/sdk_edge_cases_test.dart
@@ -12,6 +12,8 @@ import 'package:dartastic_opentelemetry/src/environment/env_from_define.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../testing_utils/memory_log_record_exporter.dart';
+
 // ---------------------------------------------------------------------------
 // Test doubles
 // ---------------------------------------------------------------------------
@@ -219,6 +221,7 @@ void main() {
         serviceName: 'log-record-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;
@@ -235,6 +238,7 @@ void main() {
         serviceName: 'log-record-attr-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;
@@ -257,6 +261,7 @@ void main() {
         serviceName: 'logger-error-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;
@@ -276,6 +281,7 @@ void main() {
         serviceName: 'logger-ts-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;
@@ -298,6 +304,7 @@ void main() {
         serviceName: 'simple-proc-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;
@@ -340,6 +347,7 @@ void main() {
         serviceName: 'provider-log-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
 
       expect(
@@ -358,6 +366,7 @@ void main() {
         serviceName: 'print-intercept-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;
@@ -371,6 +380,7 @@ void main() {
         serviceName: 'print-intercept-async-test',
         detectPlatformResources: false,
         enableLogs: true,
+        logRecordExporter: MemoryLogRecordExporter(),
       );
       OTelLog.enableTraceLogging();
       OTelLog.logFunction = logOutput.add;

--- a/test/unit/sdk_edge_cases_test.dart
+++ b/test/unit/sdk_edge_cases_test.dart
@@ -1,0 +1,422 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+/// Tests for SDK edge cases across environment config, resource detection,
+/// logging, provider initialization, instruments, and tracing.
+library;
+
+import 'dart:async';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/environment/env_from_define.dart';
+import 'package:dartastic_opentelemetry/src/logs/export/logs_config.dart';
+import 'package:dartastic_opentelemetry/src/resource/resource_detector.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/// Mock EnvironmentService that returns configurable values.
+class _MockEnvironmentService implements EnvironmentService {
+  final Map<String, String> _values;
+
+  _MockEnvironmentService(this._values);
+
+  @override
+  String? getValue(String key) => _values[key];
+}
+
+/// A ResourceDetector that always throws.
+class _ThrowingDetector implements ResourceDetector {
+  @override
+  Future<Resource> detect() async {
+    throw Exception('detector failure');
+  }
+}
+
+/// A LogRecordProcessor that throws synchronously on onEmit.
+class _ThrowingEmitProcessor implements LogRecordProcessor {
+  @override
+  Future<void> onEmit(ReadWriteLogRecord logRecord, Context? context) {
+    throw Exception('processor onEmit failure');
+  }
+
+  @override
+  bool enabled({
+    Context? context,
+    InstrumentationScope? instrumentationScope,
+    Severity? severityNumber,
+    String? eventName,
+  }) =>
+      true;
+
+  @override
+  Future<void> shutdown() async {}
+
+  @override
+  Future<void> forceFlush() async {}
+}
+
+/// A LogRecordExporter that always throws on export.
+class _ThrowingExporter implements LogRecordExporter {
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) {
+    throw Exception('exporter failure');
+  }
+
+  @override
+  Future<void> shutdown() async {}
+
+  @override
+  Future<void> forceFlush() async {}
+}
+
+void main() {
+  final List<String> logOutput = [];
+
+  setUp(() async {
+    await OTel.reset();
+    await OTel.initialize(
+      serviceName: 'sdk-edge-cases-test',
+      detectPlatformResources: false,
+      enableLogs: false,
+    );
+    // Set AFTER initialize so env vars don't override
+    OTelLog.enableTraceLogging();
+    OTelLog.logFunction = logOutput.add;
+    logOutput.clear();
+  });
+
+  tearDown(() async {
+    await OTel.shutdown();
+    await OTel.reset();
+    OTelLog.currentLevel = LogLevel.info;
+    OTelLog.logFunction = null;
+  });
+
+  // =========================================================================
+  // Environment configuration
+  // =========================================================================
+  group('getFromEnvironment', () {
+    test('returns values for metrics SDK env vars', () {
+      expect(getFromEnvironment('OTEL_METRICS_EXEMPLAR_FILTER'), isA<String>());
+      expect(getFromEnvironment('OTEL_METRIC_EXPORT_INTERVAL'), isA<String>());
+      expect(getFromEnvironment('OTEL_METRIC_EXPORT_TIMEOUT'), isA<String>());
+    });
+
+    test('returns values for Zipkin exporter env vars', () {
+      expect(
+          getFromEnvironment('OTEL_EXPORTER_ZIPKIN_ENDPOINT'), isA<String>());
+      expect(getFromEnvironment('OTEL_EXPORTER_ZIPKIN_TIMEOUT'), isA<String>());
+    });
+
+    test('returns values for Prometheus exporter env vars', () {
+      expect(
+          getFromEnvironment('OTEL_EXPORTER_PROMETHEUS_HOST'), isA<String>());
+      expect(
+          getFromEnvironment('OTEL_EXPORTER_PROMETHEUS_PORT'), isA<String>());
+    });
+
+    test('returns values for deprecated env vars', () {
+      expect(getFromEnvironment('OTEL_EXPORTER_OTLP_SPAN_INSECURE'),
+          isA<String>());
+      expect(getFromEnvironment('OTEL_EXPORTER_OTLP_METRIC_INSECURE'),
+          isA<String>());
+    });
+
+    test('returns null for unknown key', () {
+      expect(getFromEnvironment('TOTALLY_UNKNOWN_KEY'), isNull);
+    });
+  });
+
+  group('OTelEnv.initializeLogging', () {
+    test('configures logging from env when no custom logFunction is set', () {
+      OTelLog.logFunction = print;
+      OTelLog.currentLevel = LogLevel.info;
+      OTelEnv.initializeLogging();
+      expect(OTelLog.logFunction, isNotNull);
+    });
+  });
+
+  // =========================================================================
+  // Resource detection
+  // =========================================================================
+  group('EnvVarResourceDetector', () {
+    test('parses key=value pairs', () async {
+      final detector = EnvVarResourceDetector(_MockEnvironmentService({
+        'OTEL_RESOURCE_ATTRIBUTES': 'key1=value1,key2=value2',
+      }));
+      final resource = await detector.detect();
+      final attrs = resource.attributes.toList();
+      expect(attrs.any((a) => a.key == 'key1' && a.value == 'value1'), isTrue);
+      expect(attrs.any((a) => a.key == 'key2' && a.value == 'value2'), isTrue);
+    });
+
+    test('decodes percent-encoded values', () async {
+      final detector = EnvVarResourceDetector(_MockEnvironmentService({
+        'OTEL_RESOURCE_ATTRIBUTES': 'path=/usr%2Flocal%2Fbin',
+      }));
+      final resource = await detector.detect();
+      final attrs = resource.attributes.toList();
+      expect(attrs.any((a) => a.key == 'path' && a.value == '/usr/local/bin'),
+          isTrue);
+    });
+
+    test('returns empty resource for empty env var', () async {
+      final detector = EnvVarResourceDetector(_MockEnvironmentService({
+        'OTEL_RESOURCE_ATTRIBUTES': '',
+      }));
+      final resource = await detector.detect();
+      expect(resource.attributes.length, equals(0));
+    });
+
+    test('returns empty resource when env var is absent', () async {
+      final detector = EnvVarResourceDetector(_MockEnvironmentService({}));
+      final resource = await detector.detect();
+      expect(resource.attributes.length, equals(0));
+    });
+
+    test('skips malformed entries without equals sign', () async {
+      final detector = EnvVarResourceDetector(_MockEnvironmentService({
+        'OTEL_RESOURCE_ATTRIBUTES': 'good=value,badentry,also=good',
+      }));
+      final resource = await detector.detect();
+      final attrs = resource.attributes.toList();
+      expect(attrs.any((a) => a.key == 'good' && a.value == 'value'), isTrue);
+      expect(attrs.any((a) => a.key == 'also' && a.value == 'good'), isTrue);
+      expect(attrs.any((a) => a.key == 'badentry'), isFalse);
+    });
+
+    test('handles escaped commas in values', () async {
+      final detector = EnvVarResourceDetector(_MockEnvironmentService({
+        'OTEL_RESOURCE_ATTRIBUTES': r'msg=hello\,world',
+      }));
+      final resource = await detector.detect();
+      final attrs = resource.attributes.toList();
+      expect(
+          attrs.any((a) => a.key == 'msg' && a.value == 'hello,world'), isTrue);
+    });
+  });
+
+  group('CompositeResourceDetector', () {
+    test('continues detecting after one detector throws', () async {
+      final composite = CompositeResourceDetector(
+          [_ThrowingDetector(), ProcessResourceDetector()]);
+      final resource = await composite.detect();
+      expect(resource.attributes.length, greaterThan(0));
+      expect(logOutput.any((m) => m.contains('Error in resource detector')),
+          isTrue);
+    });
+  });
+
+  // =========================================================================
+  // Logging pipeline
+  // =========================================================================
+  group('SDKLogRecord', () {
+    test('context getter returns provided context', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'log-record-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      final scope = OTel.instrumentationScope(name: 'test');
+      final ctx = Context.current;
+      final record = SDKLogRecord(instrumentationScope: scope, context: ctx);
+      expect(record.context, equals(ctx));
+    });
+
+    test('attributes and resource setters work', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'log-record-attr-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      final scope = OTel.instrumentationScope(name: 'test');
+      final record = SDKLogRecord(instrumentationScope: scope);
+
+      record.attributes = OTel.attributes([OTel.attributeString('k', 'v')]);
+      expect(record.attributes!.length, equals(1));
+
+      record.resource = OTel.defaultResource;
+      expect(record.resource, equals(OTel.defaultResource));
+    });
+  });
+
+  group('Logger', () {
+    test('catches and logs processor error during emit', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'logger-error-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      final loggerProvider = OTel.loggerProvider();
+      loggerProvider.addLogRecordProcessor(_ThrowingEmitProcessor());
+      final logger = loggerProvider.getLogger('test-logger');
+
+      logger.emit(body: 'test message', severityNumber: Severity.INFO);
+
+      expect(logOutput.any((m) => m.contains('Error in processor')), isTrue);
+    });
+
+    test('emit with explicit observedTimestamp', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'logger-ts-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      final logger = OTel.loggerProvider().getLogger('test-logger');
+      logger.emit(
+        body: 'test',
+        severityNumber: Severity.WARN,
+        observedTimestamp: DateTime(2025, 6, 15, 10, 30),
+      );
+
+      expect(logOutput.any((m) => m.contains('Emitting log record')), isTrue);
+    });
+  });
+
+  group('SimpleLogRecordProcessor', () {
+    test('logs error when exporter throws', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'simple-proc-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      final processor = SimpleLogRecordProcessor(_ThrowingExporter());
+      final scope = OTel.instrumentationScope(name: 'test');
+      final record = SDKLogRecord(instrumentationScope: scope, body: 'test');
+
+      await processor.onEmit(record, Context.current);
+
+      expect(
+          logOutput.any((m) => m.contains('SimpleLogRecordProcessor')), isTrue);
+    });
+  });
+
+  group('LogsConfiguration', () {
+    test('configureLoggerProvider with custom exporter', () async {
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: 'http://localhost:4318',
+        logRecordExporter: ConsoleLogRecordExporter(),
+        resource: OTel.defaultResource,
+      );
+      expect(provider, isNotNull);
+      expect(provider.logRecordProcessors, isNotEmpty);
+    });
+  });
+
+  // =========================================================================
+  // Provider initialization
+  // =========================================================================
+  group('Provider constructor logging', () {
+    test('logs resource attributes during creation', () async {
+      await OTel.reset();
+      logOutput.clear();
+      // Set logging BEFORE initialize so constructor debug output is captured
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      await OTel.initialize(
+        serviceName: 'provider-log-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+
+      expect(
+        logOutput.any((m) => m.contains('Created with resource')),
+        isTrue,
+        reason:
+            'Expected provider constructor to log creation. Got ${logOutput.length} entries: ${logOutput.take(5).join("\\n")}',
+      );
+    });
+  });
+
+  group('OTel print interception', () {
+    test('runWithPrintInterception returns result', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'print-intercept-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      expect(OTel.runWithPrintInterception(() => 42), equals(42));
+    });
+
+    test('runWithPrintInterceptionAsync returns result', () async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'print-intercept-async-test',
+        detectPlatformResources: false,
+        enableLogs: true,
+      );
+      OTelLog.enableTraceLogging();
+      OTelLog.logFunction = logOutput.add;
+
+      expect(
+        await OTel.runWithPrintInterceptionAsync(() async => 'hello'),
+        equals('hello'),
+      );
+    });
+  });
+
+  // =========================================================================
+  // Instruments and tracing
+  // =========================================================================
+  group('Counter', () {
+    test('addWithMap converts map to attributes', () async {
+      final counter =
+          OTel.meter().createCounter<int>(name: 'test-counter') as Counter<int>;
+      counter.addWithMap(5, {'env': 'test', 'count': 1});
+      counter.addWithMap(3, {});
+      expect(counter.getValue(), greaterThanOrEqualTo(8));
+    });
+  });
+
+  group('Histogram', () {
+    test('boundaries getter returns configured boundaries', () async {
+      final histogram = OTel.meter().createHistogram<double>(
+        name: 'test-histogram',
+        boundaries: [1.0, 5.0, 10.0],
+      );
+      expect(histogram.boundaries, equals([1.0, 5.0, 10.0]));
+    });
+  });
+
+  group('Tracer', () {
+    test('startSpanWithContext sets span in context', () {
+      final tracer = OTel.tracer();
+      final span = tracer.startSpanWithContext(
+        name: 'context-span',
+        context: Context.current,
+      );
+      expect(span, isNotNull);
+      span.end();
+    });
+  });
+}

--- a/test/unit/span_transformer_batch_test.dart
+++ b/test/unit/span_transformer_batch_test.dart
@@ -70,7 +70,9 @@ void main() {
     setUp(() async {
       await OTel.reset();
       await OTel.initialize(
-          serviceName: 'test-service', serviceVersion: '1.0.0');
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
     });
 
     tearDown(() async {
@@ -80,12 +82,7 @@ void main() {
     test('handles large batch of simple spans', () {
       final spans = List.generate(
         1000,
-        (i) => createMockSpan(
-          name: 'span-$i',
-          attributes: {
-            'index': '$i',
-          },
-        ),
+        (i) => createMockSpan(name: 'span-$i', attributes: {'index': '$i'}),
       );
 
       final request = OtlpSpanTransformer.transformSpans(spans);
@@ -158,7 +155,8 @@ void main() {
         print('  Scope spans count: ${rs.scopeSpans.length}');
         for (final ss in rs.scopeSpans) {
           print(
-              '    Scope name: "${ss.scope.name}", version: "${ss.scope.version}"');
+            '    Scope name: "${ss.scope.name}", version: "${ss.scope.version}"',
+          );
           print('    Spans count: ${ss.spans.length}');
           for (final span in ss.spans) {
             print('      Span name: ${span.name}');
@@ -178,10 +176,16 @@ void main() {
       print('All scope names: $allScopeNames');
 
       // Check if we have the expected scope names
-      expect(allScopeNames.contains('http-instrumentation'), isTrue,
-          reason: 'Expected to find http-instrumentation scope');
-      expect(allScopeNames.contains('db-instrumentation'), isTrue,
-          reason: 'Expected to find db-instrumentation scope');
+      expect(
+        allScopeNames.contains('http-instrumentation'),
+        isTrue,
+        reason: 'Expected to find http-instrumentation scope',
+      );
+      expect(
+        allScopeNames.contains('db-instrumentation'),
+        isTrue,
+        reason: 'Expected to find db-instrumentation scope',
+      );
     });
 
     test('handles multiple resources', () {
@@ -217,19 +221,27 @@ void main() {
       }
 
       // We should have 2 different resource spans because the services are different
-      expect(request.resourceSpans.length, equals(2),
-          reason:
-              'Should have 2 different resource spans for different services');
+      expect(
+        request.resourceSpans.length,
+        equals(2),
+        reason: 'Should have 2 different resource spans for different services',
+      );
 
       // Find the service names from the resources
       final service1ResourceSpan = request.resourceSpans.firstWhere(
-        (rs) => rs.resource.attributes.any((attr) =>
-            attr.key == 'service.name' && attr.value.stringValue == 'service1'),
+        (rs) => rs.resource.attributes.any(
+          (attr) =>
+              attr.key == 'service.name' &&
+              attr.value.stringValue == 'service1',
+        ),
       );
 
       final service2ResourceSpan = request.resourceSpans.firstWhere(
-        (rs) => rs.resource.attributes.any((attr) =>
-            attr.key == 'service.name' && attr.value.stringValue == 'service2'),
+        (rs) => rs.resource.attributes.any(
+          (attr) =>
+              attr.key == 'service.name' &&
+              attr.value.stringValue == 'service2',
+        ),
       );
 
       // Verify both resource spans exist
@@ -241,26 +253,17 @@ void main() {
       final spans = [
         createMockSpan(
           name: 'span1',
-          resourceAttributes: {
-            'service.name': 'service1',
-            'attr1': 'val1',
-          },
+          resourceAttributes: {'service.name': 'service1', 'attr1': 'val1'},
           instrumentationName: 'scope1',
         ),
         createMockSpan(
           name: 'span2',
-          resourceAttributes: {
-            'service.name': 'service1',
-            'attr1': 'val1',
-          },
+          resourceAttributes: {'service.name': 'service1', 'attr1': 'val1'},
           instrumentationName: 'scope2',
         ),
         createMockSpan(
           name: 'span3',
-          resourceAttributes: {
-            'service.name': 'service2',
-            'attr2': 'val2',
-          },
+          resourceAttributes: {'service.name': 'service2', 'attr2': 'val2'},
           instrumentationName: 'scope1',
         ),
       ];
@@ -289,32 +292,48 @@ void main() {
 
       // Should have distinct resource spans for each service name
       expect(
-          request.resourceSpans
-              .where((rs) => rs.resource.attributes.any((attr) =>
-                  attr.key == 'service.name' &&
-                  attr.value.stringValue == 'service1'))
-              .length,
-          equals(1),
-          reason: 'Should have one resource span for service1');
+        request.resourceSpans
+            .where(
+              (rs) => rs.resource.attributes.any(
+                (attr) =>
+                    attr.key == 'service.name' &&
+                    attr.value.stringValue == 'service1',
+              ),
+            )
+            .length,
+        equals(1),
+        reason: 'Should have one resource span for service1',
+      );
 
       expect(
-          request.resourceSpans
-              .where((rs) => rs.resource.attributes.any((attr) =>
-                  attr.key == 'service.name' &&
-                  attr.value.stringValue == 'service2'))
-              .length,
-          equals(1),
-          reason: 'Should have one resource span for service2');
+        request.resourceSpans
+            .where(
+              (rs) => rs.resource.attributes.any(
+                (attr) =>
+                    attr.key == 'service.name' &&
+                    attr.value.stringValue == 'service2',
+              ),
+            )
+            .length,
+        equals(1),
+        reason: 'Should have one resource span for service2',
+      );
 
       // Find service1 resource span
       final service1ResourceSpan = request.resourceSpans.firstWhere(
-        (rs) => rs.resource.attributes.any((attr) =>
-            attr.key == 'service.name' && attr.value.stringValue == 'service1'),
+        (rs) => rs.resource.attributes.any(
+          (attr) =>
+              attr.key == 'service.name' &&
+              attr.value.stringValue == 'service1',
+        ),
       );
 
       // Service1 should have scopes for scope1 and scope2
-      expect(service1ResourceSpan.scopeSpans.length, equals(2),
-          reason: 'Service1 resource should have 2 different scope spans');
+      expect(
+        service1ResourceSpan.scopeSpans.length,
+        equals(2),
+        reason: 'Service1 resource should have 2 different scope spans',
+      );
 
       // Check that the scopes for service1 include scope1 and scope2
       final service1Scopes =
@@ -324,17 +343,25 @@ void main() {
 
       // Find service2 resource span
       final service2ResourceSpan = request.resourceSpans.firstWhere(
-        (rs) => rs.resource.attributes.any((attr) =>
-            attr.key == 'service.name' && attr.value.stringValue == 'service2'),
+        (rs) => rs.resource.attributes.any(
+          (attr) =>
+              attr.key == 'service.name' &&
+              attr.value.stringValue == 'service2',
+        ),
       );
 
       // Service2 should have only one scope: scope1
-      expect(service2ResourceSpan.scopeSpans.length, equals(1),
-          reason: 'Service2 resource should have 1 scope span');
+      expect(
+        service2ResourceSpan.scopeSpans.length,
+        equals(1),
+        reason: 'Service2 resource should have 1 scope span',
+      );
 
       // Check the scope for service2
       expect(
-          service2ResourceSpan.scopeSpans.first.scope.name, equals('scope1'));
+        service2ResourceSpan.scopeSpans.first.scope.name,
+        equals('scope1'),
+      );
     });
 
     test('maintains span order within scopes', () {
@@ -355,12 +382,18 @@ void main() {
       final request = OtlpSpanTransformer.transformSpans(spans);
 
       // Get the first resource span and scope span
-      expect(request.resourceSpans.length, greaterThan(0),
-          reason: 'Should have at least one resource span');
+      expect(
+        request.resourceSpans.length,
+        greaterThan(0),
+        reason: 'Should have at least one resource span',
+      );
       final resourceSpan = request.resourceSpans.first;
 
-      expect(resourceSpan.scopeSpans.length, greaterThan(0),
-          reason: 'Should have at least one scope span');
+      expect(
+        resourceSpan.scopeSpans.length,
+        greaterThan(0),
+        reason: 'Should have at least one scope span',
+      );
       final scopeSpan = resourceSpan.scopeSpans.first;
 
       // Get the transformed spans
@@ -389,8 +422,11 @@ void main() {
           }
         }
 
-        expect(isOrdered, isTrue,
-            reason: 'Spans should be ordered by start time');
+        expect(
+          isOrdered,
+          isTrue,
+          reason: 'Spans should be ordered by start time',
+        );
       }
     });
 
@@ -400,10 +436,7 @@ void main() {
         10,
         (i) => createMockSpan(
           name: 'common-span-name',
-          attributes: {
-            'common-key': 'common-value',
-            'index': '$i',
-          },
+          attributes: {'common-key': 'common-value', 'index': '$i'},
           resourceAttributes: {
             'service.name': 'test-service',
             'common.attribute': 'shared-value',
@@ -449,9 +482,12 @@ void main() {
       // The number of unique strings should be much less than the total number of attribute strings
       // For 10 spans with common attributes and names, we'd expect around ~15-25 unique strings
       // depending on system attributes
-      expect(stringTable.length, lessThan(50),
-          reason:
-              'String deduplication should result in fewer than 50 unique strings');
+      expect(
+        stringTable.length,
+        lessThan(50),
+        reason:
+            'String deduplication should result in fewer than 50 unique strings',
+      );
     });
   });
 }

--- a/test/unit/trace/composite_exporter_test.dart
+++ b/test/unit/trace/composite_exporter_test.dart
@@ -48,20 +48,14 @@ void main() {
       final span = tracer.startSpan('empty-list-test');
       span.end();
 
-      await expectLater(
-        composite.export([span]),
-        completes,
-      );
+      await expectLater(composite.export([span]), completes);
     });
 
     test('forceFlush delegates to all exporters', () async {
       final composite = CompositeExporter([exporter1, exporter2]);
 
       // forceFlush should complete without error on both exporters
-      await expectLater(
-        composite.forceFlush(),
-        completes,
-      );
+      await expectLater(composite.forceFlush(), completes);
     });
 
     test('shutdown delegates to all exporters', () async {
@@ -70,14 +64,8 @@ void main() {
       await composite.shutdown();
 
       // After shutdown, exporters should reject new exports
-      await expectLater(
-        () => exporter1.export([]),
-        throwsA(isA<StateError>()),
-      );
-      await expectLater(
-        () => exporter2.export([]),
-        throwsA(isA<StateError>()),
-      );
+      await expectLater(() => exporter1.export([]), throwsA(isA<StateError>()));
+      await expectLater(() => exporter2.export([]), throwsA(isA<StateError>()));
     });
 
     test('export sends the same spans to each exporter', () async {

--- a/test/unit/trace/console_exporter_edge_test.dart
+++ b/test/unit/trace/console_exporter_edge_test.dart
@@ -27,37 +27,37 @@ void main() {
       await OTel.reset();
     });
 
-    test('exports span with events and event attributes without error',
-        () async {
-      final tracer = OTel.tracer();
-      final span = tracer.startSpan('span-with-events', kind: SpanKind.client);
+    test(
+      'exports span with events and event attributes without error',
+      () async {
+        final tracer = OTel.tracer();
+        final span = tracer.startSpan(
+          'span-with-events',
+          kind: SpanKind.client,
+        );
 
-      // Add event with attributes
-      span.addEventNow(
-        'my-event',
-        OTel.attributes([
-          OTel.attributeString('event.key', 'event-value'),
-          OTel.attributeInt('event.count', 42),
-        ]),
-      );
+        // Add event with attributes
+        span.addEventNow(
+          'my-event',
+          OTel.attributes([
+            OTel.attributeString('event.key', 'event-value'),
+            OTel.attributeInt('event.count', 42),
+          ]),
+        );
 
-      // Add a second event with different attributes
-      span.addEventNow(
-        'second-event',
-        OTel.attributes([
-          OTel.attributeString('phase', 'completed'),
-        ]),
-      );
+        // Add a second event with different attributes
+        span.addEventNow(
+          'second-event',
+          OTel.attributes([OTel.attributeString('phase', 'completed')]),
+        );
 
-      span.end();
+        span.end();
 
-      // Export should not throw - this exercises the events + event attributes
-      // code path in _printSpan
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
-    });
+        // Export should not throw - this exercises the events + event attributes
+        // code path in _printSpan
+        await expectLater(exporter.export([span]), completes);
+      },
+    );
 
     test('exports span with links and link attributes without error', () async {
       final tracer = OTel.tracer();
@@ -84,10 +84,7 @@ void main() {
 
       // Export should not throw - this exercises the links + link attributes
       // code path in _printSpan
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
+      await expectLater(exporter.export([span]), completes);
     });
 
     test('exports span with status description without error', () async {
@@ -98,10 +95,7 @@ void main() {
 
       // Export should not throw - this exercises the statusDescription
       // code path in _printSpan
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
+      await expectLater(exporter.export([span]), completes);
     });
 
     test('exports span with no end time (not ended) without error', () async {
@@ -109,10 +103,7 @@ void main() {
       final span = tracer.startSpan('span-not-ended');
 
       // Do NOT call span.end() - this exercises the "not ended" code path
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
+      await expectLater(exporter.export([span]), completes);
 
       // End it now to clean up
       span.end();
@@ -125,28 +116,19 @@ void main() {
 
       // Root span has no valid parent span ID - exercises the "(root span)"
       // code path in _printSpan
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
+      await expectLater(exporter.export([span]), completes);
     });
 
     test('exports child span (with parent) without error', () async {
       final tracer = OTel.tracer();
       final parentSpan = tracer.startSpan('parent-span');
-      final childSpan = tracer.startSpan(
-        'child-span',
-        parentSpan: parentSpan,
-      );
+      final childSpan = tracer.startSpan('child-span', parentSpan: parentSpan);
       childSpan.end();
       parentSpan.end();
 
       // Child span has a valid parent span ID - exercises the parent span ID
       // code path in _printSpan
-      await expectLater(
-        exporter.export([childSpan]),
-        completes,
-      );
+      await expectLater(exporter.export([childSpan]), completes);
     });
 
     test('exports span with attributes without error', () async {
@@ -161,10 +143,7 @@ void main() {
       );
       span.end();
 
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
+      await expectLater(exporter.export([span]), completes);
     });
 
     test('exports multiple spans without error', () async {
@@ -176,65 +155,51 @@ void main() {
         spans.add(span);
       }
 
-      await expectLater(
-        exporter.export(spans),
-        completes,
-      );
+      await expectLater(exporter.export(spans), completes);
     });
 
-    test('exports span with events, links, attributes, and status description',
-        () async {
-      final tracer = OTel.tracer();
+    test(
+      'exports span with events, links, attributes, and status description',
+      () async {
+        final tracer = OTel.tracer();
 
-      final linkedContext = OTel.spanContext(
-        traceId: OTel.traceId(),
-        spanId: OTel.spanId(),
-      );
-      final link = OTel.spanLink(
-        linkedContext,
-        attributes: OTel.attributes([
-          OTel.attributeString('link-key', 'link-val'),
-        ]),
-      );
+        final linkedContext = OTel.spanContext(
+          traceId: OTel.traceId(),
+          spanId: OTel.spanId(),
+        );
+        final link = OTel.spanLink(
+          linkedContext,
+          attributes: OTel.attributes([
+            OTel.attributeString('link-key', 'link-val'),
+          ]),
+        );
 
-      final span = tracer.startSpan(
-        'fully-loaded-span',
-        kind: SpanKind.client,
-        attributes: OTel.attributesFromMap({
-          'service.name': 'edge-test',
-        }),
-        links: [link],
-      );
+        final span = tracer.startSpan(
+          'fully-loaded-span',
+          kind: SpanKind.client,
+          attributes: OTel.attributesFromMap({'service.name': 'edge-test'}),
+          links: [link],
+        );
 
-      span.addEventNow(
-        'processing',
-        OTel.attributes([
-          OTel.attributeString('step', 'validation'),
-        ]),
-      );
+        span.addEventNow(
+          'processing',
+          OTel.attributes([OTel.attributeString('step', 'validation')]),
+        );
 
-      span.setStatus(SpanStatusCode.Error, 'Validation failed');
-      span.end();
+        span.setStatus(SpanStatusCode.Error, 'Validation failed');
+        span.end();
 
-      // This exercises all code paths in _printSpan simultaneously
-      await expectLater(
-        exporter.export([span]),
-        completes,
-      );
-    });
+        // This exercises all code paths in _printSpan simultaneously
+        await expectLater(exporter.export([span]), completes);
+      },
+    );
 
     test('forceFlush completes without throwing', () async {
-      await expectLater(
-        exporter.forceFlush(),
-        completes,
-      );
+      await expectLater(exporter.forceFlush(), completes);
     });
 
     test('shutdown completes without throwing', () async {
-      await expectLater(
-        exporter.shutdown(),
-        completes,
-      );
+      await expectLater(exporter.shutdown(), completes);
     });
   });
 }

--- a/test/unit/trace/context_propagation_test.dart
+++ b/test/unit/trace/context_propagation_test.dart
@@ -152,10 +152,7 @@ void main() {
       final context = OTel.context().withSpanContext(remoteContext);
 
       // Create a child span
-      final childSpan = tracer.startSpan(
-        'remote-child-test',
-        context: context,
-      );
+      final childSpan = tracer.startSpan('remote-child-test', context: context);
 
       // Verify the child inherited the remote trace ID
       expect(
@@ -175,10 +172,7 @@ void main() {
       final rootContext = OTel.context().withSpan(rootSpan);
 
       // Create a child span
-      final childSpan = tracer.startSpan(
-        'child-span',
-        context: rootContext,
-      );
+      final childSpan = tracer.startSpan('child-span', context: rootContext);
       final childContext = OTel.context().withSpan(childSpan);
 
       // Create a grandchild span
@@ -196,8 +190,10 @@ void main() {
 
       // Verify all spans were captured
       expect(exporter.spans, hasLength(3));
-      expect(exporter.spanNames,
-          containsAll(['root-span', 'child-span', 'grandchild-span']));
+      expect(
+        exporter.spanNames,
+        containsAll(['root-span', 'child-span', 'grandchild-span']),
+      );
 
       final rootExported = exporter.findSpanByName('root-span')!;
       final childExported = exporter.findSpanByName('child-span')!;
@@ -210,10 +206,14 @@ void main() {
 
       // Verify parent relationships
       expect(rootExported.parentSpanContext, isNull);
-      expect(childExported.parentSpanContext!.spanId,
-          equals(rootExported.spanContext.spanId));
-      expect(grandchildExported.parentSpanContext!.spanId,
-          equals(childExported.spanContext.spanId));
+      expect(
+        childExported.parentSpanContext!.spanId,
+        equals(rootExported.spanContext.spanId),
+      );
+      expect(
+        grandchildExported.parentSpanContext!.spanId,
+        equals(childExported.spanContext.spanId),
+      );
     });
 
     test('context attributes inheritance', () async {
@@ -244,10 +244,14 @@ void main() {
       final childExported = exporter.findSpanByName('child-with-attrs')!;
 
       // Verify each span has its own attributes
-      expect(parentExported.attributes.getString('parent.key'),
-          equals('parent.value'));
-      expect(childExported.attributes.getString('child.key'),
-          equals('child.value'));
+      expect(
+        parentExported.attributes.getString('parent.key'),
+        equals('parent.value'),
+      );
+      expect(
+        childExported.attributes.getString('child.key'),
+        equals('child.value'),
+      );
 
       // Verify child doesn't inherit parent's attributes (this is correct behavior)
       expect(childExported.attributes.getString('parent.key'), isNull);
@@ -263,10 +267,7 @@ void main() {
       // ignore: inference_failure_on_instance_creation
       await Future.delayed(const Duration(milliseconds: 10));
 
-      final childSpan = tracer.startSpan(
-        'async-child',
-        context: parentContext,
-      );
+      final childSpan = tracer.startSpan('async-child', context: parentContext);
 
       // End spans
       childSpan.end();
@@ -280,10 +281,14 @@ void main() {
       final childExported = exporter.findSpanByName('async-child')!;
 
       // Verify relationship maintained across async boundary
-      expect(childExported.parentSpanContext!.spanId,
-          equals(parentExported.spanContext.spanId));
-      expect(childExported.spanContext.traceId,
-          equals(parentExported.spanContext.traceId));
+      expect(
+        childExported.parentSpanContext!.spanId,
+        equals(parentExported.spanContext.spanId),
+      );
+      expect(
+        childExported.spanContext.traceId,
+        equals(parentExported.spanContext.traceId),
+      );
     });
   });
 }

--- a/test/unit/trace/debug_logging_coverage_test.dart
+++ b/test/unit/trace/debug_logging_coverage_test.dart
@@ -22,9 +22,8 @@ void main() {
     await OTel.reset();
     logOutput.clear();
 
-    // Enable the most verbose log level so every isDebug() guard evaluates
-    // to true, and capture all log output into the list for assertions.
-    OTelLog.enableTraceLogging();
+    // Set a no-op log function before initialize to prevent console noise,
+    // and mark it as custom so initializeLogging() preserves it.
     OTelLog.logFunction = logOutput.add;
 
     exporter = InMemorySpanExporter();
@@ -33,7 +32,12 @@ void main() {
       serviceName: 'debug-test',
       spanProcessor: processor,
       detectPlatformResources: false,
+      enableLogs: false,
     );
+    // Enable the most verbose log level AFTER initialize so every isDebug()
+    // guard evaluates to true. initializeLogging() reads OTEL_LOG_LEVEL from
+    // env and would override a level set before it.
+    OTelLog.enableTraceLogging();
   });
 
   tearDown(() async {
@@ -55,7 +59,8 @@ void main() {
     expect(span, isNotNull);
     expect(
       logOutput.any(
-          (msg) => msg.contains('SDKSpan') && msg.contains('Created new span')),
+        (msg) => msg.contains('SDKSpan') && msg.contains('Created new span'),
+      ),
       isTrue,
       reason: 'Expected a debug log about span creation',
     );
@@ -69,20 +74,23 @@ void main() {
     span.end();
 
     expect(
-      logOutput
-          .any((msg) => msg.contains('SDKSpan') && msg.contains('end span')),
+      logOutput.any(
+        (msg) => msg.contains('SDKSpan') && msg.contains('end span'),
+      ),
       isTrue,
       reason: 'Expected a debug log about ending the span',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Notifying') && msg.contains('span processors')),
+      logOutput.any(
+        (msg) => msg.contains('Notifying') && msg.contains('span processors'),
+      ),
       isTrue,
       reason: 'Expected a debug log about notifying processors',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('onEnd') && msg.contains('SimpleSpanProcessor')),
+      logOutput.any(
+        (msg) => msg.contains('onEnd') && msg.contains('SimpleSpanProcessor'),
+      ),
       isTrue,
       reason: 'Expected a debug log about calling onEnd on the processor',
     );
@@ -98,8 +106,9 @@ void main() {
     tracer.startSpan('processor-onstart-test');
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') && msg.contains('onStart')),
+      logOutput.any(
+        (msg) => msg.contains('SimpleSpanProcessor') && msg.contains('onStart'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor onStart debug log',
     );
@@ -114,16 +123,20 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 50));
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Exporting span')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Exporting span'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor export debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Successfully exported')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Successfully exported'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor success debug log',
     );
@@ -136,10 +149,12 @@ void main() {
     await processor.onNameUpdate(span, 'new-name');
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Name updated') &&
-          msg.contains('new-name')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Name updated') &&
+            msg.contains('new-name'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor name update debug log',
     );
@@ -159,15 +174,20 @@ void main() {
     await freshProcessor.shutdown();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') && msg.contains('Shutting down')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Shutting down'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor shutdown debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Shutdown complete')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Shutdown complete'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor shutdown complete debug log',
     );
@@ -183,9 +203,11 @@ void main() {
     await freshProcessor.shutdown();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Already shut down')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Already shut down'),
+      ),
       isTrue,
       reason: 'Expected "Already shut down" debug log',
     );
@@ -199,23 +221,29 @@ void main() {
     await freshProcessor.forceFlush();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Force flushing')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Force flushing'),
+      ),
       isTrue,
       reason: 'Expected SimpleSpanProcessor forceFlush debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('No pending exports')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('No pending exports'),
+      ),
       isTrue,
       reason: 'Expected "No pending exports" debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Force flush complete')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Force flush complete'),
+      ),
       isTrue,
       reason: 'Expected "Force flush complete" debug log',
     );
@@ -231,9 +259,11 @@ void main() {
     await freshProcessor.forceFlush();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Cannot force flush')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Cannot force flush'),
+      ),
       isTrue,
       reason: 'Expected "Cannot force flush" debug log',
     );
@@ -251,8 +281,9 @@ void main() {
     span.setStatus(SpanStatusCode.Ok);
 
     expect(
-      logOutput
-          .any((msg) => msg.contains('SDKSpan') && msg.contains('Set status')),
+      logOutput.any(
+        (msg) => msg.contains('SDKSpan') && msg.contains('Set status'),
+      ),
       isTrue,
       reason: 'Expected setStatus debug log',
     );
@@ -330,8 +361,10 @@ void main() {
     expect(span.spanLinks!.length, greaterThanOrEqualTo(2));
 
     // recordException
-    span.recordException(Exception('test exception'),
-        stackTrace: StackTrace.current);
+    span.recordException(
+      Exception('test exception'),
+      stackTrace: StackTrace.current,
+    );
 
     otherSpan.end();
     linkSpan.end();
@@ -343,36 +376,37 @@ void main() {
   // ---------------------------------------------------------------------------
 
   test(
-      'span properties: kind, isRecording, isEnded, endTime, parentSpan, resource',
-      () {
-    final tracer = OTel.tracer();
-    final span = tracer.startSpan('prop-test', kind: SpanKind.client);
+    'span properties: kind, isRecording, isEnded, endTime, parentSpan, resource',
+    () {
+      final tracer = OTel.tracer();
+      final span = tracer.startSpan('prop-test', kind: SpanKind.client);
 
-    expect(span.kind, equals(SpanKind.client));
-    expect(span.isRecording, isTrue);
-    expect(span.isEnded, isFalse);
-    expect(span.endTime, isNull);
-    expect(span.startTime, isNotNull);
-    expect(span.spanId, isNotNull);
-    expect(span.spanContext, isNotNull);
-    expect(span.status, equals(SpanStatusCode.Unset));
-    expect(span.statusDescription, isNull);
-    expect(span.instrumentationScope, isNotNull);
-    // parentSpanContext may be null for a root span - just access it for coverage.
-    // ignore: unnecessary_statements
-    span.parentSpanContext;
-    expect(span.isValid, isTrue);
-    // parentSpan may be null for a root span - just access it for coverage.
-    // ignore: unnecessary_statements
-    span.parentSpan;
-    // resource comes from the tracer
-    expect(span.resource, isNotNull);
+      expect(span.kind, equals(SpanKind.client));
+      expect(span.isRecording, isTrue);
+      expect(span.isEnded, isFalse);
+      expect(span.endTime, isNull);
+      expect(span.startTime, isNotNull);
+      expect(span.spanId, isNotNull);
+      expect(span.spanContext, isNotNull);
+      expect(span.status, equals(SpanStatusCode.Unset));
+      expect(span.statusDescription, isNull);
+      expect(span.instrumentationScope, isNotNull);
+      // parentSpanContext may be null for a root span - just access it for coverage.
+      // ignore: unnecessary_statements
+      span.parentSpanContext;
+      expect(span.isValid, isTrue);
+      // parentSpan may be null for a root span - just access it for coverage.
+      // ignore: unnecessary_statements
+      span.parentSpan;
+      // resource comes from the tracer
+      expect(span.resource, isNotNull);
 
-    span.end();
-    expect(span.isEnded, isTrue);
-    expect(span.endTime, isNotNull);
-    expect(span.isRecording, isFalse);
-  });
+      span.end();
+      expect(span.isEnded, isTrue);
+      expect(span.endTime, isNotNull);
+      expect(span.isRecording, isFalse);
+    },
+  );
 
   test('span updateName notifies processors', () {
     final tracer = OTel.tracer();
@@ -382,10 +416,12 @@ void main() {
     span.updateName('renamed');
     expect(span.name, equals('renamed'));
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SimpleSpanProcessor') &&
-          msg.contains('Name updated') &&
-          msg.contains('renamed')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SimpleSpanProcessor') &&
+            msg.contains('Name updated') &&
+            msg.contains('renamed'),
+      ),
       isTrue,
       reason: 'Expected name update log from processor',
     );
@@ -423,13 +459,15 @@ void main() {
 
     expect(
       logOutput.any(
-          (msg) => msg.contains('Tracer') && msg.contains('withSpan called')),
+        (msg) => msg.contains('Tracer') && msg.contains('withSpan called'),
+      ),
       isTrue,
       reason: 'Expected Tracer withSpan debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Tracer') && msg.contains('withSpan completed')),
+      logOutput.any(
+        (msg) => msg.contains('Tracer') && msg.contains('withSpan completed'),
+      ),
       isTrue,
       reason: 'Expected Tracer withSpan completed debug log',
     );
@@ -445,14 +483,17 @@ void main() {
     expect(result, equals(99));
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Tracer') && msg.contains('withSpanAsync called')),
+      logOutput.any(
+        (msg) => msg.contains('Tracer') && msg.contains('withSpanAsync called'),
+      ),
       isTrue,
       reason: 'Expected Tracer withSpanAsync debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Tracer') && msg.contains('withSpanAsync completed')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('Tracer') && msg.contains('withSpanAsync completed'),
+      ),
       isTrue,
       reason: 'Expected Tracer withSpanAsync completed debug log',
     );
@@ -472,7 +513,8 @@ void main() {
     // recordSpan starts a span, runs fn, then ends the span. All with debug.
     expect(
       logOutput.any(
-          (msg) => msg.contains('Tracer') && msg.contains('Starting span')),
+        (msg) => msg.contains('Tracer') && msg.contains('Starting span'),
+      ),
       isTrue,
       reason: 'Expected Tracer startSpan debug log from recordSpan',
     );
@@ -490,7 +532,8 @@ void main() {
 
     expect(
       logOutput.any(
-          (msg) => msg.contains('Tracer') && msg.contains('Starting span')),
+        (msg) => msg.contains('Tracer') && msg.contains('Starting span'),
+      ),
       isTrue,
       reason: 'Expected Tracer startSpan debug log from recordSpanAsync',
     );
@@ -505,15 +548,14 @@ void main() {
     final parentSpan = tracer.startSpan('parent-span');
     logOutput.clear();
 
-    final childSpan = tracer.startSpan(
-      'child-span',
-      parentSpan: parentSpan,
-    );
+    final childSpan = tracer.startSpan('child-span', parentSpan: parentSpan);
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Creating child span') ||
-          (msg.contains('Tracer') && msg.contains('Starting span'))),
+      logOutput.any(
+        (msg) =>
+            msg.contains('Creating child span') ||
+            (msg.contains('Tracer') && msg.contains('Starting span')),
+      ),
       isTrue,
       reason: 'Expected child span creation debug log',
     );
@@ -531,7 +573,8 @@ void main() {
 
     expect(
       logOutput.any(
-          (msg) => msg.contains('Tracer') && msg.contains('Creating span')),
+        (msg) => msg.contains('Tracer') && msg.contains('Creating span'),
+      ),
       isTrue,
       reason: 'Expected Tracer createSpan debug log',
     );
@@ -551,7 +594,8 @@ void main() {
 
     expect(
       logOutput.any(
-          (msg) => msg.contains('Tracer') && msg.contains('Starting span')),
+        (msg) => msg.contains('Tracer') && msg.contains('Starting span'),
+      ),
       isTrue,
       reason: 'Expected Tracer startSpan debug log from startSpanWithContext',
     );
@@ -573,8 +617,10 @@ void main() {
 
     expect(tracer, isNotNull);
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') && msg.contains('Getting tracer')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') && msg.contains('Getting tracer'),
+      ),
       isTrue,
       reason: 'Expected TracerProvider getTracer debug log',
     );
@@ -588,14 +634,18 @@ void main() {
     await tp.shutdown();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') && msg.contains('Shutting down')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') && msg.contains('Shutting down'),
+      ),
       isTrue,
       reason: 'Expected TracerProvider shutdown debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') && msg.contains('Shutdown complete')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') && msg.contains('Shutdown complete'),
+      ),
       isTrue,
       reason: 'Expected TracerProvider shutdown complete debug log',
     );
@@ -609,8 +659,10 @@ void main() {
     await tp.shutdown();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') && msg.contains('Already shut down')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') && msg.contains('Already shut down'),
+      ),
       isTrue,
       reason: 'Expected "Already shut down" debug log',
     );
@@ -623,15 +675,19 @@ void main() {
     await tp.forceFlush();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') && msg.contains('Force flushing')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') && msg.contains('Force flushing'),
+      ),
       isTrue,
       reason: 'Expected TracerProvider forceFlush debug log',
     );
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') &&
-          msg.contains('Force flush complete')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') &&
+            msg.contains('Force flush complete'),
+      ),
       isTrue,
       reason: 'Expected TracerProvider force flush complete debug log',
     );
@@ -645,8 +701,11 @@ void main() {
     await tp.forceFlush();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') && msg.contains('Cannot force flush')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') &&
+            msg.contains('Cannot force flush'),
+      ),
       isTrue,
       reason: 'Expected "Cannot force flush" debug log',
     );
@@ -661,9 +720,11 @@ void main() {
     tp.addSpanProcessor(freshProcessor);
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('SDKTracerProvider') &&
-          msg.contains('Adding span processor')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('SDKTracerProvider') &&
+            msg.contains('Adding span processor'),
+      ),
       isTrue,
       reason: 'Expected addSpanProcessor debug log',
     );
@@ -679,9 +740,11 @@ void main() {
     tp.ensureResourceIsSet();
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('TracerProvider') &&
-          msg.contains('Setting resource from default')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('TracerProvider') &&
+            msg.contains('Setting resource from default'),
+      ),
       isTrue,
       reason: 'Expected ensureResourceIsSet debug log',
     );
@@ -706,13 +769,19 @@ void main() {
 
     // Count the number of onEnd calls logged for SimpleSpanProcessor.
     final onEndLogs = logOutput
-        .where((msg) =>
-            msg.contains('SimpleSpanProcessor') && msg.contains('onEnd called'))
+        .where(
+          (msg) =>
+              msg.contains('SimpleSpanProcessor') &&
+              msg.contains('onEnd called'),
+        )
         .toList();
 
     // There should be at least 2 onEnd logs (one per processor).
-    expect(onEndLogs.length, greaterThanOrEqualTo(2),
-        reason: 'Expected onEnd logs from multiple processors');
+    expect(
+      onEndLogs.length,
+      greaterThanOrEqualTo(2),
+      reason: 'Expected onEnd logs from multiple processors',
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -732,8 +801,9 @@ void main() {
     );
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Tracer') && msg.contains('withSpan completed')),
+      logOutput.any(
+        (msg) => msg.contains('Tracer') && msg.contains('withSpan completed'),
+      ),
       isTrue,
       reason: 'Expected withSpan completed log even on error (from finally)',
     );
@@ -753,8 +823,10 @@ void main() {
     );
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Tracer') && msg.contains('withSpanAsync completed')),
+      logOutput.any(
+        (msg) =>
+            msg.contains('Tracer') && msg.contains('withSpanAsync completed'),
+      ),
       isTrue,
       reason:
           'Expected withSpanAsync completed log even on error (from finally)',
@@ -778,7 +850,8 @@ void main() {
 
     expect(
       logOutput.any(
-          (msg) => msg.contains('Tracer') && msg.contains('withSpan called')),
+        (msg) => msg.contains('Tracer') && msg.contains('withSpan called'),
+      ),
       isTrue,
       reason: 'Expected withSpan debug log from startActiveSpan',
     );
@@ -795,8 +868,9 @@ void main() {
     expect(result, equals('async-active-result'));
 
     expect(
-      logOutput.any((msg) =>
-          msg.contains('Tracer') && msg.contains('withSpanAsync called')),
+      logOutput.any(
+        (msg) => msg.contains('Tracer') && msg.contains('withSpanAsync called'),
+      ),
       isTrue,
       reason: 'Expected withSpanAsync debug log from startActiveSpanAsync',
     );
@@ -814,8 +888,9 @@ void main() {
     span.end(spanStatus: SpanStatusCode.Error);
 
     expect(
-      logOutput
-          .any((msg) => msg.contains('SDKSpan') && msg.contains('Set status')),
+      logOutput.any(
+        (msg) => msg.contains('SDKSpan') && msg.contains('Set status'),
+      ),
       isTrue,
       reason:
           'Expected setStatus debug log when ending with a spanStatus parameter',

--- a/test/unit/trace/direct_file_exporter_test.dart
+++ b/test/unit/trace/direct_file_exporter_test.dart
@@ -78,9 +78,13 @@ void main() {
       final tracer = tracerProvider.getTracer('direct-file-test');
       print('Got tracer from provider');
 
-      final span = tracer.startSpan('direct-test-span',
-          attributes:
-              Attributes.of({'test.key': 'test.value', 'test.number': 123}));
+      final span = tracer.startSpan(
+        'direct-test-span',
+        attributes: Attributes.of({
+          'test.key': 'test.value',
+          'test.number': 123,
+        }),
+      );
       print('Created span: ${span.name}');
 
       // Small delay to simulate work
@@ -104,7 +108,8 @@ void main() {
       // Verify the file has content
       final fileContent = await File(outputPath).readAsString();
       print(
-          'File content after export (length=${fileContent.length}): $fileContent');
+        'File content after export (length=${fileContent.length}): $fileContent',
+      );
 
       // Basic sanity check - the file should contain our span name
       expect(fileContent.contains('direct-test-span'), isTrue);
@@ -174,7 +179,8 @@ void main() {
       // Verify span was exported
       final fileContent = await File(outputPath).readAsString();
       print(
-          'recordSpan file content (length=${fileContent.length}): $fileContent');
+        'recordSpan file content (length=${fileContent.length}): $fileContent',
+      );
 
       expect(fileContent.contains('record-span-test'), isTrue);
 
@@ -205,8 +211,10 @@ void main() {
       // Create multiple spans
       print('Creating 3 spans...');
       for (int i = 0; i < 3; i++) {
-        final span = tracer.startSpan('multi-span-$i',
-            attributes: Attributes.of({'span.index': i}));
+        final span = tracer.startSpan(
+          'multi-span-$i',
+          attributes: Attributes.of({'span.index': i}),
+        );
         span.end();
         print('Created and ended span $i');
       }
@@ -222,7 +230,8 @@ void main() {
       // Verify spans were exported
       final fileContent = await File(outputPath).readAsString();
       print(
-          'Multiple spans file content (length=${fileContent.length}): $fileContent');
+        'Multiple spans file content (length=${fileContent.length}): $fileContent',
+      );
 
       expect(fileContent, isNotEmpty);
 
@@ -258,7 +267,8 @@ void main() {
           final matchingSpan = allSpans.firstWhere(
             (span) => span['name'] == expectedSpanName,
             orElse: () => throw StateError(
-                'Span $expectedSpanName not found in: ${allSpans.map((s) => s['name']).toList()}'),
+              'Span $expectedSpanName not found in: ${allSpans.map((s) => s['name']).toList()}',
+            ),
           );
 
           expect(matchingSpan['attributes']['span.index'], equals(i));

--- a/test/unit/trace/export/otlp/certificate_utils_test.dart
+++ b/test/unit/trace/export/otlp/certificate_utils_test.dart
@@ -103,10 +103,7 @@ void main() {
 
   group('CertificateUtils.validateCertificates', () {
     test('succeeds when all parameters are null', () {
-      expect(
-        CertificateUtils.validateCertificates,
-        returnsNormally,
-      );
+      expect(CertificateUtils.validateCertificates, returnsNormally);
     });
 
     test('succeeds with test:// paths', () {
@@ -137,9 +134,8 @@ void main() {
 
       try {
         expect(
-          () => CertificateUtils.validateCertificates(
-            certificate: certFile.path,
-          ),
+          () =>
+              CertificateUtils.validateCertificates(certificate: certFile.path),
           returnsNormally,
         );
       } finally {
@@ -192,20 +188,22 @@ void main() {
       );
     });
 
-    test('throws ArgumentError when client certificate file does not exist',
-        () {
-      expect(
-        () => CertificateUtils.validateCertificates(
-          clientCertificate: '/nonexistent/path/client.pem',
-        ),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('Client certificate file not found'),
+    test(
+      'throws ArgumentError when client certificate file does not exist',
+      () {
+        expect(
+          () => CertificateUtils.validateCertificates(
+            clientCertificate: '/nonexistent/path/client.pem',
           ),
-        ),
-      );
-    });
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Client certificate file not found'),
+            ),
+          ),
+        );
+      },
+    );
   });
 }

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -20,8 +20,10 @@ void main() {
       server.listen((request) async {
         receivedRequests.add(request);
         // Drain the request body so the connection completes properly
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         request.response.statusCode = 200;
         await request.response.close();
       });
@@ -49,9 +51,9 @@ void main() {
     }
 
     test('export sends spans to endpoint', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -61,9 +63,9 @@ void main() {
     });
 
     test('export sends protobuf content type', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -77,9 +79,9 @@ void main() {
     });
 
     test('export appends /v1/traces to endpoint', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -90,10 +92,12 @@ void main() {
     });
 
     test('export with compression sends gzip content encoding', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        compression: true,
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          compression: true,
+        ),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -107,10 +111,12 @@ void main() {
     });
 
     test('export with custom headers includes them', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        headers: {'x-custom': 'test-value'},
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          headers: {'x-custom': 'test-value'},
+        ),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -124,9 +130,9 @@ void main() {
     });
 
     test('export with empty spans does nothing', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       await exporter.export([]);
 
@@ -136,17 +142,14 @@ void main() {
     });
 
     test('export after shutdown throws StateError', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       await exporter.shutdown();
 
       final spans = createTestSpans();
-      expect(
-        () => exporter.export(spans),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export(spans), throwsA(isA<StateError>()));
     });
 
     test('export retries on 503', () async {
@@ -158,8 +161,10 @@ void main() {
       port = server.port;
       server.listen((request) async {
         requestCount++;
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         if (requestCount == 1) {
           request.response.statusCode = 503;
         } else {
@@ -168,12 +173,14 @@ void main() {
         await request.response.close();
       });
 
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 10),
-        maxDelay: const Duration(milliseconds: 50),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 3,
+          baseDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -191,8 +198,10 @@ void main() {
       port = server.port;
       server.listen((request) async {
         requestCount++;
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         if (requestCount == 1) {
           request.response.statusCode = 429;
         } else {
@@ -201,12 +210,14 @@ void main() {
         await request.response.close();
       });
 
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 10),
-        maxDelay: const Duration(milliseconds: 50),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 3,
+          baseDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -223,25 +234,26 @@ void main() {
       port = server.port;
       server.listen((request) async {
         requestCount++;
-        await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        await request.fold<List<int>>(
+          [],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
         request.response.statusCode = 400;
         await request.response.close();
       });
 
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 10),
-        maxDelay: const Duration(milliseconds: 50),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 3,
+          baseDelay: const Duration(milliseconds: 10),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
 
       final spans = createTestSpans();
       // 400 is not retryable, so this should throw after a single attempt
-      expect(
-        () => exporter.export(spans),
-        throwsA(anything),
-      );
+      expect(() => exporter.export(spans), throwsA(anything));
 
       // Allow the async operations to settle
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -250,9 +262,9 @@ void main() {
     });
 
     test('forceFlush completes successfully', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
 
       // forceFlush should complete without error
       await exporter.forceFlush();
@@ -260,37 +272,36 @@ void main() {
     });
 
     test('shutdown then export throws', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
-
-      await exporter.shutdown();
-
-      final spans = createTestSpans();
-      expect(
-        () => exporter.export(spans),
-        throwsA(isA<StateError>()),
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
       );
-    });
 
-    test('_getEndpointUrl appends /v1/traces to endpoint without path',
-        () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-      ));
+      await exporter.shutdown();
 
       final spans = createTestSpans();
-      await exporter.export(spans);
-
-      expect(receivedRequests, hasLength(1));
-      expect(receivedRequests.first.uri.path, equals('/v1/traces'));
-      await exporter.shutdown();
+      expect(() => exporter.export(spans), throwsA(isA<StateError>()));
     });
+
+    test(
+      '_getEndpointUrl appends /v1/traces to endpoint without path',
+      () async {
+        final exporter = OtlpHttpSpanExporter(
+          OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+        );
+
+        final spans = createTestSpans();
+        await exporter.export(spans);
+
+        expect(receivedRequests, hasLength(1));
+        expect(receivedRequests.first.uri.path, equals('/v1/traces'));
+        await exporter.shutdown();
+      },
+    );
 
     test('_getEndpointUrl preserves existing /v1/traces', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port/v1/traces',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port/v1/traces'),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);
@@ -302,9 +313,9 @@ void main() {
     });
 
     test('export with trailing slash endpoint appends /v1/traces', () async {
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port/',
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port/'),
+      );
 
       final spans = createTestSpans();
       await exporter.export(spans);

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
@@ -17,7 +17,6 @@ void main() {
 
     setUp(() async {
       await OTel.reset();
-      OTelLog.enableTraceLogging();
       OTelLog.spanLogFunction = (_) {};
       OTelLog.logFunction = (_) {};
       requestCount = 0;
@@ -34,7 +33,11 @@ void main() {
       await OTel.initialize(
         serviceName: 'test',
         detectPlatformResources: false,
+        enableLogs: false,
       );
+      // Set trace logging AFTER initialize, since initializeLogging() reads
+      // OTEL_LOG_LEVEL from env and would override a level set before it.
+      OTelLog.enableTraceLogging();
     });
 
     tearDown(() async {
@@ -58,12 +61,14 @@ void main() {
     }
 
     OtlpHttpSpanExporter createExporter({int maxRetries = 2}) {
-      return OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: maxRetries,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      return OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: maxRetries,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
     }
 
     test('retries on 503 and succeeds on second try', () async {
@@ -96,10 +101,7 @@ void main() {
       final spans = createTestSpans();
 
       // Should throw after exhausting all retries
-      expect(
-        () => exporter.export(spans),
-        throwsA(anything),
-      );
+      expect(() => exporter.export(spans), throwsA(anything));
 
       // Allow async operations to settle
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -113,10 +115,7 @@ void main() {
       final spans = createTestSpans();
 
       // 400 is not retryable - should throw after single attempt
-      expect(
-        () => exporter.export(spans),
-        throwsA(anything),
-      );
+      expect(() => exporter.export(spans), throwsA(anything));
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(requestCount, equals(1));
@@ -128,10 +127,7 @@ void main() {
       final exporter = createExporter();
       final spans = createTestSpans();
 
-      expect(
-        () => exporter.export(spans),
-        throwsA(anything),
-      );
+      expect(() => exporter.export(spans), throwsA(anything));
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(requestCount, equals(1));
@@ -165,53 +161,61 @@ void main() {
       await exporter.shutdown();
     });
 
-    test('export with authorization header redacts value in debug logs',
-        () async {
-      final logMessages = <String>[];
-      OTelLog.logFunction = logMessages.add;
+    test(
+      'export with authorization header redacts value in debug logs',
+      () async {
+        final logMessages = <String>[];
+        OTelLog.logFunction = logMessages.add;
 
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        headers: {'Authorization': 'Bearer secret-token-12345'},
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+        final exporter = OtlpHttpSpanExporter(
+          OtlpHttpExporterConfig(
+            endpoint: 'http://localhost:$port',
+            headers: {'Authorization': 'Bearer secret-token-12345'},
+            maxRetries: 0,
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        );
 
-      statusCodes = [200];
-      final spans = createTestSpans();
-      await exporter.export(spans);
+        statusCodes = [200];
+        final spans = createTestSpans();
+        await exporter.export(spans);
 
-      final allLogs = logMessages.join('\n');
-      // The authorization value should be redacted
-      expect(allLogs, contains('REDACTED'));
-      expect(allLogs, isNot(contains('secret-token-12345')));
+        final allLogs = logMessages.join('\n');
+        // The authorization value should be redacted
+        expect(allLogs, contains('REDACTED'));
+        expect(allLogs, isNot(contains('secret-token-12345')));
 
-      await exporter.shutdown();
-    });
+        await exporter.shutdown();
+      },
+    );
 
-    test('constructor with certificate config exercises _createHttpClient',
-        () async {
-      // Using test:// scheme paths exercises the certificate code path
-      // in _createHttpClient without requiring real cert files
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        certificate: 'test://ca-cert',
-        clientKey: 'test://client-key',
-        clientCertificate: 'test://client-cert',
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
-      expect(exporter, isNotNull);
+    test(
+      'constructor with certificate config exercises _createHttpClient',
+      () async {
+        // Using test:// scheme paths exercises the certificate code path
+        // in _createHttpClient without requiring real cert files
+        final exporter = OtlpHttpSpanExporter(
+          OtlpHttpExporterConfig(
+            endpoint: 'http://localhost:$port',
+            certificate: 'test://ca-cert',
+            clientKey: 'test://client-key',
+            clientCertificate: 'test://client-cert',
+            maxRetries: 0,
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        );
+        expect(exporter, isNotNull);
 
-      // It should still work with the test:// certificate client
-      statusCodes = [200];
-      final spans = createTestSpans();
-      await exporter.export(spans);
-      expect(requestCount, equals(1));
-      await exporter.shutdown();
-    });
+        // It should still work with the test:// certificate client
+        statusCodes = [200];
+        final spans = createTestSpans();
+        await exporter.export(spans);
+        expect(requestCount, equals(1));
+        await exporter.shutdown();
+      },
+    );
 
     test('forceFlush with no pending exports', () async {
       final logMessages = <String>[];
@@ -323,12 +327,14 @@ void main() {
     test('shutdown during retry stops retrying', () async {
       // Server always returns 503 so retry keeps going
       statusCodes = [503, 503, 503, 503, 503];
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 10,
-        baseDelay: const Duration(milliseconds: 50),
-        maxDelay: const Duration(milliseconds: 100),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 10,
+          baseDelay: const Duration(milliseconds: 50),
+          maxDelay: const Duration(milliseconds: 100),
+        ),
+      );
 
       final spans = createTestSpans();
 
@@ -375,12 +381,14 @@ void main() {
 
     test('retries with 503 then 429 then succeeds', () async {
       statusCodes = [503, 429, 200];
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 3,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 3,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final spans = createTestSpans();
 
       await exporter.export(spans);
@@ -468,10 +476,7 @@ void main() {
       await exporter.shutdown();
 
       final spans = createTestSpans();
-      expect(
-        () => exporter.export(spans),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export(spans), throwsA(isA<StateError>()));
     });
 
     test('connection refused exercises generic catch block', () async {
@@ -482,12 +487,14 @@ void main() {
       OTelLog.logFunction = logMessages.add;
 
       // Create exporter pointing to the closed port
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        maxRetries: 1,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          maxRetries: 1,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final spans = createTestSpans();
 
       try {
@@ -520,13 +527,15 @@ void main() {
 
     test('export with compression and retry', () async {
       statusCodes = [503, 200];
-      final exporter = OtlpHttpSpanExporter(OtlpHttpExporterConfig(
-        endpoint: 'http://localhost:$port',
-        compression: true,
-        maxRetries: 2,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          compression: true,
+          maxRetries: 2,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
       final spans = createTestSpans();
 
       await exporter.export(spans);

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_test.dart
@@ -54,10 +54,7 @@ void main() {
         final span = tracer.startSpan('test-span');
         span.end();
 
-        expect(
-          () => exporter.export([span]),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => exporter.export([span]), throwsA(isA<StateError>()));
       });
 
       test('with empty span list returns without error', () async {
@@ -95,10 +92,7 @@ void main() {
         final span = tracer.startSpan('test-span');
         span.end();
 
-        expect(
-          () => exporter.export([span]),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => exporter.export([span]), throwsA(isA<StateError>()));
       });
     });
 

--- a/test/unit/trace/export/otlp/otlp_grpc_retry_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_retry_test.dart
@@ -59,10 +59,7 @@ void main() {
       File(outputPath).writeAsStringSync('');
 
       // Setup collector and proxy
-      collector = RealCollector(
-        configPath: configPath,
-        outputPath: outputPath,
-      );
+      collector = RealCollector(configPath: configPath, outputPath: outputPath);
       await collector.start();
 
       proxy = NetworkProxy(
@@ -110,9 +107,10 @@ void main() {
     });
 
     test('respects max retry limit', () async {
-      proxy.failNextRequests(5,
-          errorCode:
-              grpc.StatusCode.unavailable); // More failures than max retries
+      proxy.failNextRequests(
+        5,
+        errorCode: grpc.StatusCode.unavailable,
+      ); // More failures than max retries
 
       final spans = [
         createTestSpan(
@@ -124,11 +122,13 @@ void main() {
 
       await expectLater(
         () => exporter.export(spans),
-        throwsA(isA<grpc.GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(grpc.StatusCode.unavailable),
-        )),
+        throwsA(
+          isA<grpc.GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(grpc.StatusCode.unavailable),
+          ),
+        ),
       );
 
       final allSpans = await collector.getSpans();
@@ -149,11 +149,13 @@ void main() {
 
       await expectLater(
         () => exporter.export(spans),
-        throwsA(isA<grpc.GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(grpc.StatusCode.invalidArgument),
-        )),
+        throwsA(
+          isA<grpc.GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(grpc.StatusCode.invalidArgument),
+          ),
+        ),
       );
 
       final allSpans = await collector.getSpans();
@@ -224,8 +226,10 @@ void main() {
       // Don't wait for exportFuture - it might fail due to shutdown (which is acceptable)
       // Instead just verify we have at least one span exported
       try {
-        await exportFuture.timeout(const Duration(milliseconds: 500),
-            onTimeout: () => null);
+        await exportFuture.timeout(
+          const Duration(milliseconds: 500),
+          onTimeout: () => null,
+        );
       } catch (e) {
         // Ignore expected errors during shutdown
         print('Expected export error during shutdown: $e');
@@ -233,13 +237,18 @@ void main() {
 
       // Verify that at least the first span was exported
       final spans = await collector.getSpans();
-      expect(spans.isNotEmpty, isTrue,
-          reason: 'At least one span should be exported');
+      expect(
+        spans.isNotEmpty,
+        isTrue,
+        reason: 'At least one span should be exported',
+      );
     });
 
     test('handles large batch exports with retry', () async {
-      proxy.failNextRequests(1,
-          errorCode: grpc.StatusCode.unavailable); // First attempt fails
+      proxy.failNextRequests(
+        1,
+        errorCode: grpc.StatusCode.unavailable,
+      ); // First attempt fails
 
       final largeSpanBatch = List.generate(
         100,
@@ -264,8 +273,10 @@ void main() {
 
     test('handles multiple concurrent exports with retries', () async {
       // Each concurrent request will fail once
-      proxy.failNextRequests(3,
-          errorCode: grpc.StatusCode.unavailable); // One failure per export
+      proxy.failNextRequests(
+        3,
+        errorCode: grpc.StatusCode.unavailable,
+      ); // One failure per export
 
       final exports = List.generate(
         3,
@@ -373,9 +384,11 @@ void main() {
       }
 
       // At minimum, the first span (exported before connection loss) should be present
-      expect(spans.any((s) => s['name'] == 'connection-loss-span'), isTrue,
-          reason:
-              'First span should have been exported before connection loss');
+      expect(
+        spans.any((s) => s['name'] == 'connection-loss-span'),
+        isTrue,
+        reason: 'First span should have been exported before connection loss',
+      );
 
       // Clean up
       await recoveryExporter.shutdown();
@@ -383,8 +396,10 @@ void main() {
 
     test('handles multiple concurrent exports with retries', () async {
       // Each concurrent request will fail once
-      proxy.failNextRequests(3,
-          errorCode: grpc.StatusCode.unavailable); // One failure per export
+      proxy.failNextRequests(
+        3,
+        errorCode: grpc.StatusCode.unavailable,
+      ); // One failure per export
 
       final exports = List.generate(
         3,

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_config_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_config_test.dart
@@ -27,42 +27,49 @@ void main() {
 
     group('endpoint validation', () {
       test('custom endpoint is preserved', () {
-        final config =
-            OtlpGrpcExporterConfig(endpoint: 'collector.example.com:4317');
+        final config = OtlpGrpcExporterConfig(
+          endpoint: 'collector.example.com:4317',
+        );
         expect(config.endpoint, equals('collector.example.com:4317'));
       });
 
       test('empty endpoint throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(endpoint: ''),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('empty'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('empty'),
+            ),
+          ),
         );
       });
 
       test('endpoint with spaces throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(endpoint: 'host name:4317'),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('spaces'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('spaces'),
+            ),
+          ),
         );
       });
 
       test('endpoint without scheme is accepted as host:port', () {
-        final config =
-            OtlpGrpcExporterConfig(endpoint: 'myhost.example.com:4317');
+        final config = OtlpGrpcExporterConfig(
+          endpoint: 'myhost.example.com:4317',
+        );
         expect(config.endpoint, equals('myhost.example.com:4317'));
       });
 
       test('endpoint with http:// scheme is preserved', () {
-        final config =
-            OtlpGrpcExporterConfig(endpoint: 'http://collector:4317');
+        final config = OtlpGrpcExporterConfig(
+          endpoint: 'http://collector:4317',
+        );
         expect(config.endpoint, equals('http://collector:4317'));
       });
 
@@ -77,8 +84,9 @@ void main() {
       });
 
       test('host-only endpoint gets default port appended', () {
-        final config =
-            OtlpGrpcExporterConfig(endpoint: 'collector.example.com');
+        final config = OtlpGrpcExporterConfig(
+          endpoint: 'collector.example.com',
+        );
         expect(config.endpoint, equals('collector.example.com:4317'));
       });
     });
@@ -89,7 +97,9 @@ void main() {
           headers: {'Authorization': 'Bearer token123', 'X-Custom': 'value'},
         );
         expect(
-            config.headers, containsPair('authorization', 'Bearer token123'));
+          config.headers,
+          containsPair('authorization', 'Bearer token123'),
+        );
         expect(config.headers, containsPair('x-custom', 'value'));
         // Original casing key should not be present
         expect(config.headers.containsKey('Authorization'), isFalse);
@@ -98,22 +108,26 @@ void main() {
       test('empty header key throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(headers: {'': 'value'}),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('empty'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('empty'),
+            ),
+          ),
         );
       });
 
       test('empty header value throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(headers: {'key': ''}),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('empty'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('empty'),
+            ),
+          ),
         );
       });
     });
@@ -122,11 +136,13 @@ void main() {
       test('negative maxRetries throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(maxRetries: -1),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('negative'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('negative'),
+            ),
+          ),
         );
       });
 
@@ -145,35 +161,42 @@ void main() {
       test('timeout below 1ms throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(timeout: Duration.zero),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('Timeout'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Timeout'),
+            ),
+          ),
         );
       });
 
       test('timeout above 10 minutes throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(
-              timeout: const Duration(minutes: 10, milliseconds: 1)),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('Timeout'),
-          )),
+            timeout: const Duration(minutes: 10, milliseconds: 1),
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Timeout'),
+            ),
+          ),
         );
       });
 
       test('timeout at lower bound (1ms) is valid', () {
-        final config =
-            OtlpGrpcExporterConfig(timeout: const Duration(milliseconds: 1));
+        final config = OtlpGrpcExporterConfig(
+          timeout: const Duration(milliseconds: 1),
+        );
         expect(config.timeout, equals(const Duration(milliseconds: 1)));
       });
 
       test('timeout at upper bound (10 minutes) is valid', () {
-        final config =
-            OtlpGrpcExporterConfig(timeout: const Duration(minutes: 10));
+        final config = OtlpGrpcExporterConfig(
+          timeout: const Duration(minutes: 10),
+        );
         expect(config.timeout, equals(const Duration(minutes: 10)));
       });
     });
@@ -182,11 +205,13 @@ void main() {
       test('baseDelay below 1ms throws ArgumentError', () {
         expect(
           () => OtlpGrpcExporterConfig(baseDelay: Duration.zero),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('baseDelay'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('baseDelay'),
+            ),
+          ),
         );
       });
 
@@ -196,11 +221,13 @@ void main() {
             baseDelay: const Duration(milliseconds: 1),
             maxDelay: Duration.zero,
           ),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('maxDelay'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('maxDelay'),
+            ),
+          ),
         );
       });
 
@@ -210,11 +237,13 @@ void main() {
             baseDelay: const Duration(minutes: 5, milliseconds: 1),
             maxDelay: const Duration(minutes: 5, milliseconds: 2),
           ),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('baseDelay'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('baseDelay'),
+            ),
+          ),
         );
       });
 
@@ -223,11 +252,13 @@ void main() {
           () => OtlpGrpcExporterConfig(
             maxDelay: const Duration(minutes: 5, milliseconds: 1),
           ),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('maxDelay'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('maxDelay'),
+            ),
+          ),
         );
       });
 
@@ -237,11 +268,13 @@ void main() {
             baseDelay: const Duration(seconds: 2),
             maxDelay: const Duration(seconds: 1),
           ),
-          throwsA(isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('maxDelay cannot be less than baseDelay'),
-          )),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('maxDelay cannot be less than baseDelay'),
+            ),
+          ),
         );
       });
 

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
@@ -21,7 +21,9 @@ class SlowTraceService extends TraceServiceBase {
 
   @override
   Future<ExportTraceServiceResponse> export(
-      ServiceCall call, ExportTraceServiceRequest request) async {
+    ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
     if (!exportStarted.isCompleted) {
       exportStarted.complete();
     }
@@ -31,13 +33,15 @@ class SlowTraceService extends TraceServiceBase {
 }
 
 /// Service that throws a non-GrpcError (plain Exception), exercising the
-/// generic catch block in _export (lines 482-507).
+/// generic catch block in _export.
 class GenericThrowTraceService extends TraceServiceBase {
   int callCount = 0;
 
   @override
   Future<ExportTraceServiceResponse> export(
-      ServiceCall call, ExportTraceServiceRequest request) async {
+    ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
     callCount++;
     throw Exception('Generic non-gRPC error');
   }
@@ -45,7 +49,7 @@ class GenericThrowTraceService extends TraceServiceBase {
 
 /// Service that throws INTERNAL error (or another channel-level error)
 /// for a configurable number of calls, then succeeds. This exercises the
-/// channel recreation path in _tryExport (lines 344-356, 217-219).
+/// channel recreation path in _tryExport.
 class InternalErrorTraceService extends TraceServiceBase {
   int callCount = 0;
   final int failCount;
@@ -58,7 +62,9 @@ class InternalErrorTraceService extends TraceServiceBase {
 
   @override
   Future<ExportTraceServiceResponse> export(
-      ServiceCall call, ExportTraceServiceRequest request) async {
+    ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
     callCount++;
     if (callCount <= failCount) {
       throw GrpcError.custom(failCode, 'Simulated channel error');
@@ -74,7 +80,9 @@ class AlwaysUnavailableTraceService extends TraceServiceBase {
 
   @override
   Future<ExportTraceServiceResponse> export(
-      ServiceCall call, ExportTraceServiceRequest request) async {
+    ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
     callCount++;
     throw const GrpcError.custom(StatusCode.unavailable, 'Always unavailable');
   }
@@ -211,8 +219,12 @@ class _TestSpan implements Span {
   void addEvent(SpanEvent spanEvent) {}
 
   @override
-  void recordException(Object exception,
-      {StackTrace? stackTrace, Attributes? attributes, bool? escaped}) {}
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Attributes? attributes,
+    bool? escaped,
+  }) {}
 
   @override
   void setStringAttribute<T>(String name, String value) {}
@@ -235,10 +247,12 @@ Span _createTestSpan({
     spanId: OTel.spanIdFrom(spanId ?? '0011223344556677'),
   );
 
-  final resource = OTel.resource(OTel.attributesFromMap({
-    'service.name': 'test-service',
-    'service.version': '1.0.0',
-  }));
+  final resource = OTel.resource(
+    OTel.attributesFromMap({
+      'service.name': 'test-service',
+      'service.version': '1.0.0',
+    }),
+  );
 
   final instrumentationScope = OTel.instrumentationScope(
     name: 'test-tracer',
@@ -260,13 +274,15 @@ Span _createTestSpan({
 }
 
 OtlpGrpcSpanExporter _createExporter(int port, {int maxRetries = 2}) {
-  return OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
-    endpoint: 'http://localhost:$port',
-    insecure: true,
-    maxRetries: maxRetries,
-    baseDelay: const Duration(milliseconds: 1),
-    maxDelay: const Duration(milliseconds: 10),
-  ));
+  return OtlpGrpcSpanExporter(
+    OtlpGrpcExporterConfig(
+      endpoint: 'http://localhost:$port',
+      insecure: true,
+      maxRetries: maxRetries,
+      baseDelay: const Duration(milliseconds: 1),
+      maxDelay: const Duration(milliseconds: 10),
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -277,13 +293,16 @@ void main() {
   group('OtlpGrpcSpanExporter edge cases', () {
     setUp(() async {
       await OTel.reset();
-      OTelLog.enableTraceLogging();
       OTelLog.logFunction = (_) {};
 
       await OTel.initialize(
         serviceName: 'test',
         detectPlatformResources: false,
+        enableLogs: false,
       );
+      // Set trace logging AFTER initialize, since initializeLogging() reads
+      // OTEL_LOG_LEVEL from env and would override a level set before it.
+      OTelLog.enableTraceLogging();
     });
 
     tearDown(() async {
@@ -294,7 +313,7 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 1. Shutdown during active export suppresses error
-    //    Covers lines 389-396 (shutdown-interrupted catch in export())
+    //    Exercises the shutdown-interrupted catch in export()
     // -----------------------------------------------------------------------
     test('shutdown during active export suppresses error', () async {
       final service = SlowTraceService();
@@ -330,7 +349,7 @@ void main() {
     // 2. Server handler exception surfaces as GrpcError UNKNOWN
     //    When a gRPC server handler throws a plain Exception, the framework
     //    wraps it as GrpcError(UNKNOWN). UNKNOWN is non-retryable but
-    //    triggers channel recreation (lines 344-356).
+    //    triggers channel recreation.
     // -----------------------------------------------------------------------
     test('server handler exception surfaces as GrpcError UNKNOWN', () async {
       final service = GenericThrowTraceService();
@@ -342,11 +361,13 @@ void main() {
 
       await expectLater(
         () => exporter.export([span]),
-        throwsA(isA<GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(StatusCode.unknown),
-        )),
+        throwsA(
+          isA<GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(StatusCode.unknown),
+          ),
+        ),
       );
 
       // UNKNOWN is non-retryable, so only 1 call to the service
@@ -360,46 +381,49 @@ void main() {
     // 3. Non-gRPC server triggers generic catch block in _export
     //    Connect to a raw HTTP server that speaks broken protocol.
     //    The gRPC client may throw a non-GrpcError (or a wrapped one).
-    //    Either way, the generic catch block (lines 481-507) handles it.
-    //    Covers lines 482-507 (generic catch), 493-495 (max retries check)
+    //    Either way, the generic catch block handles it.
+    //    Exercises the generic catch and max-retries-exhausted paths
     // -----------------------------------------------------------------------
-    test('broken protocol server exercises generic error handling', () async {
-      // Start a raw HTTP server that immediately closes connections
-      final rawServer = await HttpServer.bind('127.0.0.1', 0);
-      final port = rawServer.port;
-      rawServer.listen((request) {
-        // Send a non-gRPC response to break protocol
-        request.response.statusCode = 200;
-        request.response.headers.set('content-type', 'text/plain');
-        request.response.write('not a gRPC response');
-        request.response.close();
-      });
+    test(
+      'broken protocol server exercises generic error handling',
+      () async {
+        // Start a raw HTTP server that immediately closes connections
+        final rawServer = await HttpServer.bind('127.0.0.1', 0);
+        final port = rawServer.port;
+        rawServer.listen((request) {
+          // Send a non-gRPC response to break protocol
+          request.response.statusCode = 200;
+          request.response.headers.set('content-type', 'text/plain');
+          request.response.write('not a gRPC response');
+          request.response.close();
+        });
 
-      // Use short timeout and no retries to keep the test fast
-      final exporter = OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
-        endpoint: 'http://localhost:$port',
-        insecure: true,
-        maxRetries: 0,
-        timeout: const Duration(seconds: 3),
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
-      final span = _createTestSpan(name: 'broken-protocol-span');
+        // Use no retries; generous timeout to avoid flakiness under concurrency
+        final exporter = OtlpGrpcSpanExporter(
+          OtlpGrpcExporterConfig(
+            endpoint: 'http://localhost:$port',
+            insecure: true,
+            maxRetries: 0,
+            timeout: const Duration(seconds: 10),
+            baseDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        );
+        final span = _createTestSpan(name: 'broken-protocol-span');
 
-      // Should throw some kind of error (GrpcError or other)
-      await expectLater(
-        () => exporter.export([span]),
-        throwsA(anything),
-      );
+        // Should throw some kind of error (GrpcError or other)
+        await expectLater(() => exporter.export([span]), throwsA(anything));
 
-      await exporter.shutdown();
-      await rawServer.close(force: true);
-    }, timeout: const Timeout(Duration(seconds: 15)));
+        await exporter.shutdown();
+        await rawServer.close(force: true);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
 
     // -----------------------------------------------------------------------
     // 4. _tryExport channel error triggers channel recreation
-    //    Covers lines 344-356 (INTERNAL triggers cleanup + _initialized=false)
-    //    and lines 217-219 (TraceServiceClient creation)
+    //    Exercises INTERNAL error triggering channel cleanup + reinitialization
+    //    and TraceServiceClient creation on next attempt
     // -----------------------------------------------------------------------
     test('_tryExport channel error triggers channel recreation', () async {
       // Fail once with INTERNAL, then succeed on second attempt
@@ -421,11 +445,13 @@ void main() {
 
       await expectLater(
         () => exporter.export([span]),
-        throwsA(isA<GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(StatusCode.internal),
-        )),
+        throwsA(
+          isA<GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(StatusCode.internal),
+          ),
+        ),
       );
 
       expect(service.callCount, equals(1));
@@ -435,30 +461,32 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 4b. UNAVAILABLE triggers channel recreation AND is retryable
-    //     Covers lines 344-356 (channel recreation) + successful retry
+    //     Exercises channel recreation + successful retry
     // -----------------------------------------------------------------------
-    test('UNAVAILABLE error triggers channel recreation and retry succeeds',
-        () async {
-      // Fail once with UNAVAILABLE, then succeed on second attempt
-      final service = InternalErrorTraceService(
-        failCount: 1,
-        failCode: StatusCode.unavailable,
-      );
-      final server = Server.create(services: [service]);
-      await server.serve(port: 0);
-      final port = server.port!;
-      final exporter = _createExporter(port, maxRetries: 2);
-      final span = _createTestSpan(name: 'unavailable-retry-span');
+    test(
+      'UNAVAILABLE error triggers channel recreation and retry succeeds',
+      () async {
+        // Fail once with UNAVAILABLE, then succeed on second attempt
+        final service = InternalErrorTraceService(
+          failCount: 1,
+          failCode: StatusCode.unavailable,
+        );
+        final server = Server.create(services: [service]);
+        await server.serve(port: 0);
+        final port = server.port!;
+        final exporter = _createExporter(port, maxRetries: 2);
+        final span = _createTestSpan(name: 'unavailable-retry-span');
 
-      // Should succeed after retry
-      await exporter.export([span]);
+        // Should succeed after retry
+        await exporter.export([span]);
 
-      // First call fails, second succeeds
-      expect(service.callCount, equals(2));
+        // First call fails, second succeeds
+        expect(service.callCount, equals(2));
 
-      await exporter.shutdown();
-      await server.shutdown();
-    });
+        await exporter.shutdown();
+        await server.shutdown();
+      },
+    );
 
     // -----------------------------------------------------------------------
     // 4c. UNKNOWN error also triggers channel recreation
@@ -478,11 +506,13 @@ void main() {
 
       await expectLater(
         () => exporter.export([span]),
-        throwsA(isA<GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(StatusCode.unknown),
-        )),
+        throwsA(
+          isA<GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(StatusCode.unknown),
+          ),
+        ),
       );
 
       await exporter.shutdown();
@@ -491,7 +521,7 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 5. forceFlush with pending export waits
-    //    Covers lines 527-535 (waiting for pending exports in forceFlush)
+    //    Exercises waiting for pending exports in forceFlush
     // -----------------------------------------------------------------------
     test('forceFlush with pending export waits for completion', () async {
       final service = SlowTraceService();
@@ -533,7 +563,7 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 6. forceFlush error during pending export
-    //    Covers lines 537-540 (error catch in forceFlush)
+    //    Exercises the error catch in forceFlush
     // -----------------------------------------------------------------------
     test('forceFlush catches error from pending failed export', () async {
       final service = GenericThrowTraceService();
@@ -568,7 +598,7 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 7. Shutdown with pending exports and timeout
-    //    Covers lines 570-588 (shutdown waiting for pending exports with timeout)
+    //    Exercises shutdown waiting for pending exports with timeout
     // -----------------------------------------------------------------------
     test('shutdown with pending exports completes via timeout', () async {
       final service = SlowTraceService();
@@ -587,7 +617,7 @@ void main() {
 
       // Shutdown will set _isShutdown and wait for pending exports with a 10s timeout.
       // We complete the slow service so it finishes before the timeout.
-      // This exercises the pendingExportsCopy.isNotEmpty path (lines 570-591).
+      // This exercises the pendingExportsCopy.isNotEmpty path.
       Future<void>.delayed(const Duration(milliseconds: 100)).then((_) {
         service.shouldComplete.complete();
       });
@@ -606,11 +636,11 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 8. _createChannelCredentials with secure mode (no certs)
-    //    Covers lines 60-62 (secure path without certificates)
+    //    Exercises the secure credentials path without certificates
     // -----------------------------------------------------------------------
     test('_createChannelCredentials with secure mode and no certs', () async {
       // Create exporter with insecure=false and no certificates.
-      // This will create ChannelCredentials.secure() (line 63).
+      // This will create ChannelCredentials.secure().
       // Exporting to an insecure local server will fail due to TLS mismatch,
       // but the credentials creation path is covered.
       final service = InternalErrorTraceService(failCount: 0);
@@ -618,19 +648,21 @@ void main() {
       await server.serve(port: 0);
       final port = server.port!;
 
-      final exporter = OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
-        endpoint: 'http://localhost:$port',
-        insecure: false, // Triggers secure credentials path
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      final exporter = OtlpGrpcSpanExporter(
+        OtlpGrpcExporterConfig(
+          endpoint: 'http://localhost:$port',
+          insecure: false, // Triggers secure credentials path
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
 
       final span = _createTestSpan(name: 'secure-creds-span');
 
       // The export will fail because we are using secure creds against an
       // insecure server, but the _createChannelCredentials secure path
-      // (lines 60-63) is executed.
+      // The _createChannelCredentials secure path is executed.
       try {
         await exporter.export([span]);
       } catch (_) {
@@ -643,8 +675,8 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 9. Shutdown during retry stops retrying
-    //    Covers lines 425-430 (wasShutdownDuringRetry && attempts > 0)
-    //    and lines 446-451 (GrpcError catch with wasShutdownDuringRetry)
+    //    Exercises wasShutdownDuringRetry with attempts > 0
+    //    and GrpcError catch with wasShutdownDuringRetry
     // -----------------------------------------------------------------------
     test('shutdown during retry stops retrying', () async {
       final service = AlwaysUnavailableTraceService();
@@ -676,31 +708,30 @@ void main() {
 
     // -----------------------------------------------------------------------
     // 10. _ensureChannel throws StateError when shutdown
-    //     Covers lines 238-243 (_ensureChannel with isShutdown)
+    //     Exercises _ensureChannel throwing when exporter is shutdown
     // -----------------------------------------------------------------------
-    test('_ensureChannel throws StateError when exporter is shutdown',
-        () async {
-      final service = InternalErrorTraceService(failCount: 0);
-      final server = Server.create(services: [service]);
-      await server.serve(port: 0);
-      final port = server.port!;
-      final exporter = _createExporter(port);
+    test(
+      '_ensureChannel throws StateError when exporter is shutdown',
+      () async {
+        final service = InternalErrorTraceService(failCount: 0);
+        final server = Server.create(services: [service]);
+        await server.serve(port: 0);
+        final port = server.port!;
+        final exporter = _createExporter(port);
 
-      await exporter.shutdown();
+        await exporter.shutdown();
 
-      final span = _createTestSpan(name: 'post-shutdown-span');
+        final span = _createTestSpan(name: 'post-shutdown-span');
 
-      expect(
-        () => exporter.export([span]),
-        throwsA(isA<StateError>()),
-      );
+        expect(() => exporter.export([span]), throwsA(isA<StateError>()));
 
-      await server.shutdown();
-    });
+        await server.shutdown();
+      },
+    );
 
     // -----------------------------------------------------------------------
     // 11. _setupChannel returns early when shutdown
-    //     Covers lines 157-162 (_setupChannel shutdown check)
+    //     Exercises _setupChannel returning early when shutdown
     // -----------------------------------------------------------------------
     test('export after shutdown prevents channel setup', () async {
       final service = InternalErrorTraceService(failCount: 0);
@@ -718,17 +749,14 @@ void main() {
 
       // Trying to export again should throw
       final span2 = _createTestSpan(name: 'after-shutdown-span');
-      expect(
-        () => exporter.export([span2]),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export([span2]), throwsA(isA<StateError>()));
 
       await server.shutdown();
     });
 
     // -----------------------------------------------------------------------
     // 12. _tryExport with isShutdown after _ensureChannel
-    //     Covers line 266 (_tryExport isShutdown check after _ensureChannel)
+    //     Exercises _tryExport detecting shutdown after channel setup
     // -----------------------------------------------------------------------
     test('_tryExport detects shutdown after channel setup', () async {
       // This test verifies that the _tryExport method checks _isShutdown
@@ -748,17 +776,14 @@ void main() {
       await exporter.shutdown();
 
       final span2 = _createTestSpan(name: 'post-shutdown-tryexport');
-      expect(
-        () => exporter.export([span2]),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export([span2]), throwsA(isA<StateError>()));
 
       await server.shutdown();
     });
 
     // -----------------------------------------------------------------------
     // 13. _cleanupChannel error paths during shutdown
-    //     Covers lines 108-113, 123-128 (error handling in _cleanupChannel)
+    //     Exercises error handling in _cleanupChannel
     // -----------------------------------------------------------------------
     test('_cleanupChannel handles errors gracefully during shutdown', () async {
       final service = InternalErrorTraceService(failCount: 0);
@@ -780,8 +805,8 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // 14. _export shutdown detection on first attempt (line 407-408)
-    //     Covers the _isShutdown check at the beginning of _export
+    // 14. _export shutdown detection on first attempt
+    //     Exercises the _isShutdown check at the beginning of _export
     // -----------------------------------------------------------------------
     test('_export detects shutdown at start', () async {
       final service = InternalErrorTraceService(failCount: 0);
@@ -792,19 +817,16 @@ void main() {
 
       await exporter.shutdown();
 
-      // export() checks _isShutdown first (line 364), before calling _export
+      // export() checks _isShutdown first, before calling _export
       final span = _createTestSpan(name: 'export-shutdown-span');
-      expect(
-        () => exporter.export([span]),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export([span]), throwsA(isA<StateError>()));
 
       await server.shutdown();
     });
 
     // -----------------------------------------------------------------------
     // 15. Generic error with shutdown during retry
-    //     Covers lines 489-491 (wasShutdownDuringRetry in generic catch)
+    //     Exercises wasShutdownDuringRetry in the generic catch block
     // -----------------------------------------------------------------------
     test('generic error with shutdown during retry throws StateError',
         () async {
@@ -861,13 +883,15 @@ void main() {
         isTrue,
       );
       expect(
-        logMessages
-            .any((msg) => msg.contains('Successfully created gRPC channel')),
+        logMessages.any(
+          (msg) => msg.contains('Successfully created gRPC channel'),
+        ),
         isTrue,
       );
       expect(
         logMessages.any(
-            (msg) => msg.contains('Export request completed successfully')),
+          (msg) => msg.contains('Export request completed successfully'),
+        ),
         isTrue,
       );
 
@@ -883,7 +907,7 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // 17. _traceService null check (line 325-328)
+    // 17. _traceService null check
     //     This is hard to trigger directly since _setupChannel always creates
     //     it, but we verify it by checking the error path when the exporter
     //     is in a bad state.
@@ -894,15 +918,17 @@ void main() {
       await server.serve(port: 0);
       final port = server.port!;
 
-      // Create exporter with compression enabled to exercise lines 311-313
-      final exporter = OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
-        endpoint: 'http://localhost:$port',
-        insecure: true,
-        compression: true,
-        maxRetries: 0,
-        baseDelay: const Duration(milliseconds: 1),
-        maxDelay: const Duration(milliseconds: 10),
-      ));
+      // Create exporter with compression enabled to exercise compression headers
+      final exporter = OtlpGrpcSpanExporter(
+        OtlpGrpcExporterConfig(
+          endpoint: 'http://localhost:$port',
+          insecure: true,
+          compression: true,
+          maxRetries: 0,
+          baseDelay: const Duration(milliseconds: 1),
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+      );
 
       final span = _createTestSpan(name: 'compression-span');
       await exporter.export([span]);
@@ -916,74 +942,80 @@ void main() {
     // -----------------------------------------------------------------------
     // 18. Multiple pending exports tracked and flushed
     // -----------------------------------------------------------------------
-    test('multiple concurrent exports are tracked in _pendingExports',
-        () async {
-      final service = SlowTraceService();
-      final server = Server.create(services: [service]);
-      await server.serve(port: 0);
-      final port = server.port!;
-      final exporter = _createExporter(port);
+    test(
+      'multiple concurrent exports are tracked in _pendingExports',
+      () async {
+        final service = SlowTraceService();
+        final server = Server.create(services: [service]);
+        await server.serve(port: 0);
+        final port = server.port!;
+        final exporter = _createExporter(port);
 
-      final span = _createTestSpan(name: 'concurrent-pending-span');
+        final span = _createTestSpan(name: 'concurrent-pending-span');
 
-      // Start an export that will block
-      // ignore: unawaited_futures
-      final exportFuture = exporter.export([span]);
+        // Start an export that will block
+        // ignore: unawaited_futures
+        final exportFuture = exporter.export([span]);
 
-      // Wait for it to start
-      await service.exportStarted.future;
+        // Wait for it to start
+        await service.exportStarted.future;
 
-      // Call forceFlush to exercise the pending exports path
-      Future<void>.delayed(const Duration(milliseconds: 50)).then((_) {
-        service.shouldComplete.complete();
-      });
+        // Call forceFlush to exercise the pending exports path
+        Future<void>.delayed(const Duration(milliseconds: 50)).then((_) {
+          service.shouldComplete.complete();
+        });
 
-      await exporter.forceFlush();
-      await exportFuture;
+        await exporter.forceFlush();
+        await exportFuture;
 
-      await exporter.shutdown();
-      await server.shutdown();
-    });
+        await exporter.shutdown();
+        await server.shutdown();
+      },
+    );
 
     // -----------------------------------------------------------------------
     // 19. Shutdown timeout path when export never completes
-    //     Covers lines 577-584 (timeout handler in shutdown)
+    //     Exercises the timeout handler in shutdown
     // -----------------------------------------------------------------------
-    test('shutdown times out when export hangs', () async {
-      final service = SlowTraceService();
-      final server = Server.create(services: [service]);
-      await server.serve(port: 0);
-      final port = server.port!;
+    test(
+      'shutdown times out when export hangs',
+      () async {
+        final service = SlowTraceService();
+        final server = Server.create(services: [service]);
+        await server.serve(port: 0);
+        final port = server.port!;
 
-      final exporter = _createExporter(port);
-      final span = _createTestSpan(name: 'hanging-export-span');
+        final exporter = _createExporter(port);
+        final span = _createTestSpan(name: 'hanging-export-span');
 
-      // Start an export that will never complete (we won't call shouldComplete)
-      // ignore: unawaited_futures
-      final exportFuture = exporter.export([span]).catchError((Object e) {
-        // Errors expected during shutdown timeout
-      });
+        // Start an export that will never complete (we won't call shouldComplete)
+        // ignore: unawaited_futures
+        final exportFuture = exporter.export([span]).catchError((Object e) {
+          // Errors expected during shutdown timeout
+        });
 
-      // Wait for the export to start
-      await service.exportStarted.future;
+        // Wait for the export to start
+        await service.exportStarted.future;
 
-      // Shutdown should complete via its 10s timeout even though the export hangs.
-      // We use a test timeout to ensure this doesn't hang forever.
-      await exporter.shutdown().timeout(
-            const Duration(seconds: 15),
-            onTimeout: () =>
-                fail('shutdown should complete within its internal timeout'),
-          );
+        // Shutdown should complete via its 10s timeout even though the export hangs.
+        // We use a test timeout to ensure this doesn't hang forever.
+        await exporter.shutdown().timeout(
+              const Duration(seconds: 15),
+              onTimeout: () =>
+                  fail('shutdown should complete within its internal timeout'),
+            );
 
-      // Clean up: let the slow service complete so the test can tear down
-      service.shouldComplete.complete();
-      try {
-        await exportFuture;
-      } catch (_) {
-        // Expected
-      }
+        // Clean up: let the slow service complete so the test can tear down
+        service.shouldComplete.complete();
+        try {
+          await exportFuture;
+        } catch (_) {
+          // Expected
+        }
 
-      await server.shutdown();
-    }, timeout: const Timeout(Duration(seconds: 20)));
+        await server.shutdown();
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
   });
 }

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
@@ -387,37 +387,36 @@ void main() {
     test(
       'broken protocol server exercises generic error handling',
       () async {
-        // Start a raw HTTP server that immediately closes connections
-        final rawServer = await HttpServer.bind('127.0.0.1', 0);
+        // Start a raw TCP server that immediately closes connections.
+        // This triggers a non-GrpcError (SocketException) in the gRPC client,
+        // exercising the generic catch block. Unlike an HTTP server that sends
+        // a non-gRPC response, closing immediately avoids HTTP/2 negotiation
+        // hangs that cause flaky timeouts.
+        final rawServer = await ServerSocket.bind('127.0.0.1', 0);
         final port = rawServer.port;
-        rawServer.listen((request) {
-          // Send a non-gRPC response to break protocol
-          request.response.statusCode = 200;
-          request.response.headers.set('content-type', 'text/plain');
-          request.response.write('not a gRPC response');
-          request.response.close();
+        rawServer.listen((socket) {
+          socket.destroy();
         });
 
-        // Use no retries; generous timeout to avoid flakiness under concurrency
         final exporter = OtlpGrpcSpanExporter(
           OtlpGrpcExporterConfig(
             endpoint: 'http://localhost:$port',
             insecure: true,
             maxRetries: 0,
-            timeout: const Duration(seconds: 10),
+            timeout: const Duration(seconds: 5),
             baseDelay: const Duration(milliseconds: 1),
             maxDelay: const Duration(milliseconds: 10),
           ),
         );
         final span = _createTestSpan(name: 'broken-protocol-span');
 
-        // Should throw some kind of error (GrpcError or other)
+        // Should throw some kind of error (GrpcError or SocketException)
         await expectLater(() => exporter.export([span]), throwsA(anything));
 
         await exporter.shutdown();
-        await rawServer.close(force: true);
+        await rawServer.close();
       },
-      timeout: const Timeout(Duration(seconds: 60)),
+      timeout: const Timeout(Duration(seconds: 30)),
     );
 
     // -----------------------------------------------------------------------

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
@@ -20,7 +20,9 @@ class MockTraceService extends TraceServiceBase {
 
   @override
   Future<ExportTraceServiceResponse> export(
-      ServiceCall call, ExportTraceServiceRequest request) async {
+    ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
     exportCount++;
     requests.add(request);
     if (errorCode != null) {
@@ -43,7 +45,9 @@ class RetryMockTraceService extends TraceServiceBase {
 
   @override
   Future<ExportTraceServiceResponse> export(
-      ServiceCall call, ExportTraceServiceRequest request) async {
+    ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
     exportCount++;
     if (exportCount <= failCount) {
       throw GrpcError.custom(failCode, 'Mock error');
@@ -183,8 +187,12 @@ class _TestSpan implements Span {
   void addEvent(SpanEvent spanEvent) {}
 
   @override
-  void recordException(Object exception,
-      {StackTrace? stackTrace, Attributes? attributes, bool? escaped}) {}
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Attributes? attributes,
+    bool? escaped,
+  }) {}
 
   @override
   void setStringAttribute<T>(String name, String value) {}
@@ -207,10 +215,12 @@ Span _createTestSpan({
     spanId: OTel.spanIdFrom(spanId ?? '0011223344556677'),
   );
 
-  final resource = OTel.resource(OTel.attributesFromMap({
-    'service.name': 'test-service',
-    'service.version': '1.0.0',
-  }));
+  final resource = OTel.resource(
+    OTel.attributesFromMap({
+      'service.name': 'test-service',
+      'service.version': '1.0.0',
+    }),
+  );
 
   final instrumentationScope = OTel.instrumentationScope(
     name: 'test-tracer',
@@ -236,13 +246,15 @@ Span _createTestSpan({
 // ---------------------------------------------------------------------------
 
 OtlpGrpcSpanExporter _createExporter(int port) {
-  return OtlpGrpcSpanExporter(OtlpGrpcExporterConfig(
-    endpoint: 'http://localhost:$port',
-    insecure: true,
-    maxRetries: 2,
-    baseDelay: const Duration(milliseconds: 1),
-    maxDelay: const Duration(milliseconds: 10),
-  ));
+  return OtlpGrpcSpanExporter(
+    OtlpGrpcExporterConfig(
+      endpoint: 'http://localhost:$port',
+      insecure: true,
+      maxRetries: 2,
+      baseDelay: const Duration(milliseconds: 1),
+      maxDelay: const Duration(milliseconds: 10),
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -330,10 +342,7 @@ void main() {
 
       final span = _createTestSpan(name: 'after-shutdown-span');
 
-      expect(
-        () => exporter.export([span]),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => exporter.export([span]), throwsA(isA<StateError>()));
     });
 
     // 5
@@ -558,11 +567,13 @@ void main() {
 
       await expectLater(
         () => retryExporter.export([span]),
-        throwsA(isA<GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(StatusCode.invalidArgument),
-        )),
+        throwsA(
+          isA<GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(StatusCode.invalidArgument),
+          ),
+        ),
       );
 
       // Should have been called exactly once (no retries for non-retryable codes).
@@ -589,11 +600,13 @@ void main() {
 
       await expectLater(
         () => retryExporter.export([span]),
-        throwsA(isA<GrpcError>().having(
-          (e) => e.code,
-          'code',
-          equals(StatusCode.unavailable),
-        )),
+        throwsA(
+          isA<GrpcError>().having(
+            (e) => e.code,
+            'code',
+            equals(StatusCode.unavailable),
+          ),
+        ),
       );
 
       // maxRetries=2 means initial attempt + 2 retries = 3 total attempts.

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_state_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_state_test.dart
@@ -9,7 +9,9 @@ void main() {
     setUp(() async {
       await OTel.reset();
       await OTel.initialize(
-          serviceName: 'test', detectPlatformResources: false);
+        serviceName: 'test',
+        detectPlatformResources: false,
+      );
     });
 
     tearDown(() async {
@@ -107,9 +109,9 @@ void main() {
           traceId: OTel.traceIdFrom('00112233445566778899aabbccddeeff'),
           spanId: OTel.spanIdFrom('0011223344556677'),
         );
-        final resource = OTel.resource(OTel.attributesFromMap({
-          'service.name': 'test-service',
-        }));
+        final resource = OTel.resource(
+          OTel.attributesFromMap({'service.name': 'test-service'}),
+        );
         final instrumentationScope = OTel.instrumentationScope(
           name: 'test-tracer',
           version: '1.0.0',
@@ -124,10 +126,7 @@ void main() {
           startTime: DateTime.now(),
         );
 
-        expect(
-          () => exporter.export([span]),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => exporter.export([span]), throwsA(isA<StateError>()));
       });
 
       test('export with empty span list handles gracefully', () async {
@@ -268,8 +267,12 @@ class _TestSpan implements Span {
   void addEvent(SpanEvent spanEvent) {}
 
   @override
-  void recordException(Object exception,
-      {StackTrace? stackTrace, Attributes? attributes, bool? escaped}) {}
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Attributes? attributes,
+    bool? escaped,
+  }) {}
 
   @override
   void setStringAttribute<T>(String name, String value) {}

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_test.dart
@@ -171,8 +171,12 @@ class MockSpan implements Span {
   }
 
   @override
-  void recordException(Object exception,
-      {StackTrace? stackTrace, Attributes? attributes, bool? escaped}) {
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Attributes? attributes,
+    bool? escaped,
+  }) {
     // TODO: implement recordException
   }
 
@@ -197,10 +201,12 @@ Span createTestSpan({
     spanId: OTel.spanIdFrom(spanId ?? '0011223344556677'),
   );
 
-  final resource = OTel.resource(OTel.attributesFromMap({
-    'service.name': 'test-service',
-    'service.version': '1.0.0',
-  }));
+  final resource = OTel.resource(
+    OTel.attributesFromMap({
+      'service.name': 'test-service',
+      'service.version': '1.0.0',
+    }),
+  );
 
   final instrumentationScope = OTel.instrumentationScope(
     name: 'test-tracer',
@@ -240,10 +246,7 @@ void main() {
     test('creates proper OTLP export request from spans', () {
       final testSpan = createTestSpan(
         name: 'test-span',
-        attributes: {
-          'test.key': 'test.value',
-          'test.number': 42,
-        },
+        attributes: {'test.key': 'test.value', 'test.number': 42},
         traceId: '00112233445566778899aabbccddeeff',
         spanId: '0011223344556677',
       );
@@ -264,12 +267,14 @@ void main() {
       expect(protoSpan.name, equals('test-span'));
 
       // Verify attributes
-      final testKeyAttr =
-          protoSpan.attributes.firstWhere((a) => a.key == 'test.key');
+      final testKeyAttr = protoSpan.attributes.firstWhere(
+        (a) => a.key == 'test.key',
+      );
       expect(testKeyAttr.value.stringValue, equals('test.value'));
 
-      final testNumberAttr =
-          protoSpan.attributes.firstWhere((a) => a.key == 'test.number');
+      final testNumberAttr = protoSpan.attributes.firstWhere(
+        (a) => a.key == 'test.number',
+      );
       expect(testNumberAttr.value.intValue.toInt(), equals(42));
     });
 
@@ -302,8 +307,9 @@ void main() {
         final protoSpan = scopeSpan.spans[i];
         expect(protoSpan.name, equals('span-$i'));
 
-        final indexAttr =
-            protoSpan.attributes.firstWhere((a) => a.key == 'index');
+        final indexAttr = protoSpan.attributes.firstWhere(
+          (a) => a.key == 'index',
+        );
         expect(indexAttr.value.intValue.toInt(), equals(i));
       }
     });
@@ -369,20 +375,24 @@ void main() {
           request.resourceSpans.first.scopeSpans.first.spans.first;
 
       // Verify each attribute type
-      final stringAttr =
-          protoSpan.attributes.firstWhere((a) => a.key == 'string.attr');
+      final stringAttr = protoSpan.attributes.firstWhere(
+        (a) => a.key == 'string.attr',
+      );
       expect(stringAttr.value.stringValue, equals('string.value'));
 
-      final intAttr =
-          protoSpan.attributes.firstWhere((a) => a.key == 'int.attr');
+      final intAttr = protoSpan.attributes.firstWhere(
+        (a) => a.key == 'int.attr',
+      );
       expect(intAttr.value.intValue.toInt(), equals(123));
 
-      final boolAttr =
-          protoSpan.attributes.firstWhere((a) => a.key == 'bool.attr');
+      final boolAttr = protoSpan.attributes.firstWhere(
+        (a) => a.key == 'bool.attr',
+      );
       expect(boolAttr.value.boolValue, equals(true));
 
-      final doubleAttr =
-          protoSpan.attributes.firstWhere((a) => a.key == 'double.attr');
+      final doubleAttr = protoSpan.attributes.firstWhere(
+        (a) => a.key == 'double.attr',
+      );
       expect(doubleAttr.value.doubleValue, equals(45.67));
     });
 
@@ -401,19 +411,21 @@ void main() {
           request.resourceSpans.first.scopeSpans.first.spans.first;
 
       expect(protoSpan.startTimeUnixNano.toInt(), greaterThan(0));
-      expect(protoSpan.endTimeUnixNano.toInt(),
-          greaterThan(protoSpan.startTimeUnixNano.toInt()));
+      expect(
+        protoSpan.endTimeUnixNano.toInt(),
+        greaterThan(protoSpan.startTimeUnixNano.toInt()),
+      );
     });
 
     test('groups spans by resource correctly', () {
       // Create spans with different resources
-      final service1Resource = OTel.resource(OTel.attributesFromMap({
-        'service.name': 'service1',
-      }));
+      final service1Resource = OTel.resource(
+        OTel.attributesFromMap({'service.name': 'service1'}),
+      );
 
-      final service2Resource = OTel.resource(OTel.attributesFromMap({
-        'service.name': 'service2',
-      }));
+      final service2Resource = OTel.resource(
+        OTel.attributesFromMap({'service.name': 'service2'}),
+      );
 
       final instrumentationScope = OTel.instrumentationScope(
         name: 'test-tracer',
@@ -463,10 +475,14 @@ void main() {
         ),
       );
 
-      expect(service1ResourceSpan.scopeSpans.first.spans.first.name,
-          equals('span1'));
-      expect(service2ResourceSpan.scopeSpans.first.spans.first.name,
-          equals('span2'));
+      expect(
+        service1ResourceSpan.scopeSpans.first.spans.first.name,
+        equals('span1'),
+      );
+      expect(
+        service2ResourceSpan.scopeSpans.first.spans.first.name,
+        equals('span2'),
+      );
     });
 
     test('handles parent-child span relationships', () {
@@ -485,15 +501,19 @@ void main() {
         parentSpan: parentSpan,
       );
 
-      final request =
-          OtlpSpanTransformer.transformSpans([parentSpan, childSpan]);
+      final request = OtlpSpanTransformer.transformSpans([
+        parentSpan,
+        childSpan,
+      ]);
       final protoSpans = request.resourceSpans.first.scopeSpans.first.spans;
 
       // Find parent and child spans
-      final parentProtoSpan =
-          protoSpans.firstWhere((s) => s.name == 'parent-span');
-      final childProtoSpan =
-          protoSpans.firstWhere((s) => s.name == 'child-span');
+      final parentProtoSpan = protoSpans.firstWhere(
+        (s) => s.name == 'parent-span',
+      );
+      final childProtoSpan = protoSpans.firstWhere(
+        (s) => s.name == 'child-span',
+      );
 
       // Parent should not have parentSpanId
       expect(parentProtoSpan.hasParentSpanId(), isFalse);

--- a/test/unit/trace/export/simple_span_export_test.dart
+++ b/test/unit/trace/export/simple_span_export_test.dart
@@ -61,7 +61,9 @@ void main() {
 
       final exportedSpan = exporter.findSpanByName('direct-test-span')!;
       expect(
-          exportedSpan.attributes.getString('test.key'), equals('test.value'));
+        exportedSpan.attributes.getString('test.key'),
+        equals('test.value'),
+      );
       expect(exportedSpan.attributes.getInt('test.number'), equals(42));
       expect(exportedSpan.isEnded, isTrue);
     });

--- a/test/unit/trace/file_export_test.dart
+++ b/test/unit/trace/file_export_test.dart
@@ -63,15 +63,12 @@ void main() {
       final span = tracer.startSpan('test-with-span');
 
       // Act
-      tracer.withSpan(
-        span,
-        () {
-          final currentSpan = tracer.currentSpan;
-          print('Current span in withSpan: ${currentSpan?.name}');
-          result = currentSpan?.name ?? 'No active span';
-          return result;
-        },
-      );
+      tracer.withSpan(span, () {
+        final currentSpan = tracer.currentSpan;
+        print('Current span in withSpan: ${currentSpan?.name}');
+        result = currentSpan?.name ?? 'No active span';
+        return result;
+      });
 
       // Must manually end the span - this is key for it to be exported
       span.end();
@@ -102,21 +99,28 @@ void main() {
         final dynamic parsedContent = jsonDecode(fileContent);
         if (parsedContent is! List) {
           fail(
-              'Expected JSON content to be a List but got ${parsedContent.runtimeType}');
+            'Expected JSON content to be a List but got ${parsedContent.runtimeType}',
+          );
         }
 
         // Use step-by-step casting to avoid type cast errors
         final batches = parsedContent;
         print('Found ${batches.length} batches in file');
 
-        expect(batches, isNotEmpty,
-            reason: 'Expected at least one batch of spans');
+        expect(
+          batches,
+          isNotEmpty,
+          reason: 'Expected at least one batch of spans',
+        );
 
         bool found = false;
         // Iterate through batches
         for (final batchData in batches) {
-          expect(batchData, isA<List>(),
-              reason: 'Expected batch to be a list of spans');
+          expect(
+            batchData,
+            isA<List>(),
+            reason: 'Expected batch to be a list of spans',
+          );
 
           final batch = batchData as List;
           // Iterate through spans in the batch
@@ -136,8 +140,11 @@ void main() {
           if (found) break;
         }
 
-        expect(found, isTrue,
-            reason: 'Expected to find span with name "test-with-span"');
+        expect(
+          found,
+          isTrue,
+          reason: 'Expected to find span with name "test-with-span"',
+        );
       } catch (e) {
         fail('Error parsing file content: $e');
       }
@@ -145,24 +152,22 @@ void main() {
 
     test('withSpanAsync executes async code with an active span', () async {
       print(
-          'Starting test: withSpanAsync executes async code with an active span');
+        'Starting test: withSpanAsync executes async code with an active span',
+      );
 
       // Arrange
       String result = '';
       final span = tracer.startSpan('test-with-span-async');
 
       // Act
-      await tracer.withSpanAsync(
-        span,
-        () async {
-          // Simulate async work
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          final currentSpan = tracer.currentSpan;
-          print('Current span in withSpanAsync: ${currentSpan?.name}');
-          result = currentSpan?.name ?? 'No active span';
-          return result;
-        },
-      );
+      await tracer.withSpanAsync(span, () async {
+        // Simulate async work
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final currentSpan = tracer.currentSpan;
+        print('Current span in withSpanAsync: ${currentSpan?.name}');
+        result = currentSpan?.name ?? 'No active span';
+        return result;
+      });
 
       // Must manually end the span - this is key for it to be exported
       span.end();
@@ -184,21 +189,28 @@ void main() {
         final dynamic parsedContent = jsonDecode(fileContent);
         if (parsedContent is! List) {
           fail(
-              'Expected JSON content to be a List but got ${parsedContent.runtimeType}');
+            'Expected JSON content to be a List but got ${parsedContent.runtimeType}',
+          );
         }
 
         // Use step-by-step casting to avoid type cast errors
         final batches = parsedContent;
         print('Found ${batches.length} batches in file');
 
-        expect(batches, isNotEmpty,
-            reason: 'Expected at least one batch of spans');
+        expect(
+          batches,
+          isNotEmpty,
+          reason: 'Expected at least one batch of spans',
+        );
 
         bool found = false;
         // Iterate through batches
         for (final batchData in batches) {
-          expect(batchData, isA<List>(),
-              reason: 'Expected batch to be a list of spans');
+          expect(
+            batchData,
+            isA<List>(),
+            reason: 'Expected batch to be a list of spans',
+          );
 
           final batch = batchData as List;
           // Iterate through spans in the batch
@@ -218,8 +230,11 @@ void main() {
           if (found) break;
         }
 
-        expect(found, isTrue,
-            reason: 'Expected to find span with name "test-with-span-async"');
+        expect(
+          found,
+          isTrue,
+          reason: 'Expected to find span with name "test-with-span-async"',
+        );
       } catch (e) {
         fail('Error parsing file content: $e');
       }
@@ -253,21 +268,28 @@ void main() {
         final dynamic parsedContent = jsonDecode(fileContent);
         if (parsedContent is! List) {
           fail(
-              'Expected JSON content to be a List but got ${parsedContent.runtimeType}');
+            'Expected JSON content to be a List but got ${parsedContent.runtimeType}',
+          );
         }
 
         // Use step-by-step casting to avoid type cast errors
         final batches = parsedContent;
         print('Found ${batches.length} batches in file');
 
-        expect(batches, isNotEmpty,
-            reason: 'Expected at least one batch of spans');
+        expect(
+          batches,
+          isNotEmpty,
+          reason: 'Expected at least one batch of spans',
+        );
 
         bool found = false;
         // Iterate through batches
         for (final batchData in batches) {
-          expect(batchData, isA<List>(),
-              reason: 'Expected batch to be a list of spans');
+          expect(
+            batchData,
+            isA<List>(),
+            reason: 'Expected batch to be a list of spans',
+          );
 
           final batch = batchData as List;
           // Iterate through spans in the batch
@@ -287,8 +309,11 @@ void main() {
           if (found) break;
         }
 
-        expect(found, isTrue,
-            reason: 'Expected to find span with name "auto-record-span"');
+        expect(
+          found,
+          isTrue,
+          reason: 'Expected to find span with name "auto-record-span"',
+        );
       } catch (e) {
         fail('Error parsing file content: $e');
       }

--- a/test/unit/trace/parent_span_id_test.dart
+++ b/test/unit/trace/parent_span_id_test.dart
@@ -8,9 +8,7 @@ void main() {
   group('Parent Span ID Tests', () {
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
     });
 
     tearDown(() async {
@@ -36,8 +34,10 @@ void main() {
       final childSpan = tracer.startSpan('child', context: parentContext);
 
       // Parent span ID should be set to the parent's span ID
-      expect(childSpan.spanContext.parentSpanId,
-          equals(parentSpan.spanContext.spanId));
+      expect(
+        childSpan.spanContext.parentSpanId,
+        equals(parentSpan.spanContext.spanId),
+      );
       expect(childSpan.spanContext.parentSpanId!.isValid, isTrue);
 
       childSpan.end();
@@ -62,11 +62,17 @@ void main() {
       // Verify parent relationships
       expect(rootSpan.spanContext.parentSpanId.toString(), equals('0' * 16));
       expect(
-          child1.spanContext.parentSpanId, equals(rootSpan.spanContext.spanId));
+        child1.spanContext.parentSpanId,
+        equals(rootSpan.spanContext.spanId),
+      );
       expect(
-          child2.spanContext.parentSpanId, equals(child1.spanContext.spanId));
+        child2.spanContext.parentSpanId,
+        equals(child1.spanContext.spanId),
+      );
       expect(
-          child3.spanContext.parentSpanId, equals(child2.spanContext.spanId));
+        child3.spanContext.parentSpanId,
+        equals(child2.spanContext.spanId),
+      );
 
       // End all spans
       child3.end();

--- a/test/unit/trace/sampling/always_off_sampler_test.dart
+++ b/test/unit/trace/sampling/always_off_sampler_test.dart
@@ -11,9 +11,7 @@ void main() {
 
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
       sampler = const AlwaysOffSampler();
     });
 

--- a/test/unit/trace/sampling/always_on_sampler_test.dart
+++ b/test/unit/trace/sampling/always_on_sampler_test.dart
@@ -11,9 +11,7 @@ void main() {
 
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
       sampler = const AlwaysOnSampler();
     });
 
@@ -46,22 +44,24 @@ void main() {
       expect(result.attributes, isNull);
     });
 
-    test('shouldSample returns recordAndSample decision with null parameters',
-        () {
-      // Call shouldSample with null for optional parameters
-      final result = sampler.shouldSample(
-        parentContext: OTelAPI.context(),
-        traceId: '00000000000000000000000000000001',
-        name: 'test-span',
-        spanKind: SpanKind.internal,
-        attributes: null,
-        links: null,
-      );
+    test(
+      'shouldSample returns recordAndSample decision with null parameters',
+      () {
+        // Call shouldSample with null for optional parameters
+        final result = sampler.shouldSample(
+          parentContext: OTelAPI.context(),
+          traceId: '00000000000000000000000000000001',
+          name: 'test-span',
+          spanKind: SpanKind.internal,
+          attributes: null,
+          links: null,
+        );
 
-      // Verify the result
-      expect(result.decision, equals(SamplingDecision.recordAndSample));
-      expect(result.source, equals(SamplingDecisionSource.tracerConfig));
-      expect(result.attributes, isNull);
-    });
+        // Verify the result
+        expect(result.decision, equals(SamplingDecision.recordAndSample));
+        expect(result.source, equals(SamplingDecisionSource.tracerConfig));
+        expect(result.attributes, isNull);
+      },
+    );
   });
 }

--- a/test/unit/trace/sampling/counting_sampler_conditions_test.dart
+++ b/test/unit/trace/sampling/counting_sampler_conditions_test.dart
@@ -7,10 +7,7 @@ import 'package:test/test.dart';
 void main() {
   setUp(() async {
     await OTel.reset();
-    await OTel.initialize(
-      serviceName: 'test',
-      detectPlatformResources: false,
-    );
+    await OTel.initialize(serviceName: 'test', detectPlatformResources: false);
   });
 
   tearDown(() async {
@@ -109,20 +106,21 @@ void main() {
     });
 
     test(
-        'shouldSampleCondition returns true when status_description is non-empty',
-        () {
-      final attributes = OTel.attributes([
-        OTel.attributeString('otel.status_description', 'some error'),
-      ]);
+      'shouldSampleCondition returns true when status_description is non-empty',
+      () {
+        final attributes = OTel.attributes([
+          OTel.attributeString('otel.status_description', 'some error'),
+        ]);
 
-      final result = condition.shouldSampleCondition(
-        name: 'test',
-        spanKind: SpanKind.internal,
-        attributes: attributes,
-      );
+        final result = condition.shouldSampleCondition(
+          name: 'test',
+          spanKind: SpanKind.internal,
+          attributes: attributes,
+        );
 
-      expect(result, isTrue);
-    });
+        expect(result, isTrue);
+      },
+    );
 
     test('shouldSampleCondition returns false with null attributes', () {
       final result = condition.shouldSampleCondition(
@@ -189,7 +187,9 @@ void main() {
     test('description includes pattern', () {
       expect(condition.description, contains('error'));
       expect(
-          condition.description, equals('NamePatternSamplingCondition{error}'));
+        condition.description,
+        equals('NamePatternSamplingCondition{error}'),
+      );
     });
 
     test('shouldSampleCondition returns true when name contains pattern', () {
@@ -203,16 +203,17 @@ void main() {
     });
 
     test(
-        'shouldSampleCondition returns false when name does not contain pattern',
-        () {
-      final result = condition.shouldSampleCondition(
-        name: 'normal-request',
-        spanKind: SpanKind.internal,
-        attributes: null,
-      );
+      'shouldSampleCondition returns false when name does not contain pattern',
+      () {
+        final result = condition.shouldSampleCondition(
+          name: 'normal-request',
+          spanKind: SpanKind.internal,
+          attributes: null,
+        );
 
-      expect(result, isFalse);
-    });
+        expect(result, isFalse);
+      },
+    );
 
     test('shouldSample delegates correctly', () {
       final matchResult = condition.shouldSample(
@@ -245,14 +246,13 @@ void main() {
       );
       expect(condition.description, contains('my.key'));
       expect(
-          condition.description, equals('AttributeSamplingCondition{my.key}'));
+        condition.description,
+        equals('AttributeSamplingCondition{my.key}'),
+      );
     });
 
     test('throws when no value provided', () {
-      expect(
-        () => AttributeSamplingCondition('my.key'),
-        throwsArgumentError,
-      );
+      expect(() => AttributeSamplingCondition('my.key'), throwsArgumentError);
     });
 
     test('throws when multiple values provided', () {
@@ -346,10 +346,7 @@ void main() {
     });
 
     test('int value matching works', () {
-      final condition = AttributeSamplingCondition(
-        'priority',
-        intValue: 1,
-      );
+      final condition = AttributeSamplingCondition('priority', intValue: 1);
 
       final matchAttributes = OTel.attributes([
         OTel.attributeInt('priority', 1),

--- a/test/unit/trace/sampling/debug_invalid_parent_id_test.dart
+++ b/test/unit/trace/sampling/debug_invalid_parent_id_test.dart
@@ -9,9 +9,7 @@ void main() {
   group('Debug Invalid Parent ID Tests', () {
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
     });
 
     tearDown(() async {
@@ -21,8 +19,11 @@ void main() {
     test('spanIdInvalid returns a proper zero-filled ID', () {
       final invalidId = OTel.spanIdInvalid();
       expect(invalidId.toString(), equals('0000000000000000'));
-      expect(invalidId.isValid, isFalse,
-          reason: 'Invalid span ID should not be valid');
+      expect(
+        invalidId.isValid,
+        isFalse,
+        reason: 'Invalid span ID should not be valid',
+      );
     });
 
     test('root span creation sets proper parent span ID directly', () {
@@ -39,10 +40,16 @@ void main() {
       );
 
       // Verify the parent span ID is zeros, not null
-      expect(spanContext.parentSpanId, isNotNull,
-          reason: 'Parent span ID should not be null');
-      expect(spanContext.parentSpanId.toString(), equals('0000000000000000'),
-          reason: 'Parent span ID should be all zeros for root spans');
+      expect(
+        spanContext.parentSpanId,
+        isNotNull,
+        reason: 'Parent span ID should not be null',
+      );
+      expect(
+        spanContext.parentSpanId.toString(),
+        equals('0000000000000000'),
+        reason: 'Parent span ID should be all zeros for root spans',
+      );
     });
 
     test('tracer creates root span with zero-filled parent ID', () {
@@ -55,13 +62,21 @@ void main() {
       print('Is valid: ${rootSpan.spanContext.parentSpanId!.isValid}');
 
       // Test that parent span ID is properly zero-filled
-      expect(rootSpan.spanContext.parentSpanId, isNotNull,
-          reason: 'Parent span ID should not be null');
-      expect(rootSpan.spanContext.parentSpanId.toString(),
-          equals('0000000000000000'),
-          reason: 'Parent span ID should be all zeros for root spans');
-      expect(rootSpan.spanContext.parentSpanId!.isValid, isFalse,
-          reason: 'Root span parent ID should be invalid');
+      expect(
+        rootSpan.spanContext.parentSpanId,
+        isNotNull,
+        reason: 'Parent span ID should not be null',
+      );
+      expect(
+        rootSpan.spanContext.parentSpanId.toString(),
+        equals('0000000000000000'),
+        reason: 'Parent span ID should be all zeros for root spans',
+      );
+      expect(
+        rootSpan.spanContext.parentSpanId!.isValid,
+        isFalse,
+        reason: 'Root span parent ID should be invalid',
+      );
 
       rootSpan.end();
     });

--- a/test/unit/trace/sampling/debug_root_span_test.dart
+++ b/test/unit/trace/sampling/debug_root_span_test.dart
@@ -8,9 +8,7 @@ void main() {
   group('Root Span Debug Tests', () {
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
     });
 
     tearDown(() async {
@@ -28,12 +26,15 @@ void main() {
       print('Parent Span ID: ${span.spanContext.parentSpanId}');
       print('Parent Span ID to string: ${span.spanContext.parentSpanId}');
       print(
-          'Parent Span ID isValid: ${span.spanContext.parentSpanId?.isValid}');
+        'Parent Span ID isValid: ${span.spanContext.parentSpanId?.isValid}',
+      );
 
       // Check that the parent span ID is all zeros for a root span
       expect(span.spanContext.parentSpanId, isNotNull);
       expect(
-          span.spanContext.parentSpanId.toString(), equals('0000000000000000'));
+        span.spanContext.parentSpanId.toString(),
+        equals('0000000000000000'),
+      );
 
       span.end();
     });

--- a/test/unit/trace/sampling/debugging_test.dart
+++ b/test/unit/trace/sampling/debugging_test.dart
@@ -8,9 +8,7 @@ void main() {
   group('Sampling Debugging', () {
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
     });
 
     tearDown(() async {
@@ -27,10 +25,7 @@ void main() {
 
       // Create a span using this explicit context
       final tracer = OTel.tracerProvider().getTracer('test');
-      final span = tracer.startSpan(
-        'test-span',
-        spanContext: explicitContext,
-      );
+      final span = tracer.startSpan('test-span', spanContext: explicitContext);
 
       // Verify the span has a new ID, not the one we provided
       expect(span.spanContext.spanId, isNot(equals(originalSpanId)));
@@ -50,8 +45,11 @@ void main() {
       final tracer1 = provider1.getTracer('test');
       final span1 = tracer1.startSpan('test');
 
-      expect(span1.spanContext.traceFlags.isSampled, isTrue,
-          reason: 'AlwaysOnSampler should set sampled flag to true');
+      expect(
+        span1.spanContext.traceFlags.isSampled,
+        isTrue,
+        reason: 'AlwaysOnSampler should set sampled flag to true',
+      );
 
       // Test with AlwaysOffSampler
       final provider2 = OTel.addTracerProvider(
@@ -61,8 +59,11 @@ void main() {
       final tracer2 = provider2.getTracer('test');
       final span2 = tracer2.startSpan('test');
 
-      expect(span2.spanContext.traceFlags.isSampled, isFalse,
-          reason: 'AlwaysOffSampler should set sampled flag to false');
+      expect(
+        span2.spanContext.traceFlags.isSampled,
+        isFalse,
+        reason: 'AlwaysOffSampler should set sampled flag to false',
+      );
 
       span1.end();
       span2.end();
@@ -85,17 +86,16 @@ void main() {
       final parentContext = OTel.context().withSpan(parent);
 
       // Create a child span with this context
-      final child = tracer.startSpan(
-        'child',
-        context: parentContext,
-      );
+      final child = tracer.startSpan('child', context: parentContext);
 
       // Child should inherit parent's sampling decision
       expect(child.spanContext.traceFlags.isSampled, isTrue);
       expect(child.spanContext.traceId, equals(parent.spanContext.traceId));
       expect(child.spanContext.parentSpanId, equals(parent.spanContext.spanId));
-      expect(child.spanContext.spanId.toString(),
-          isNot(equals(parent.spanContext.spanId.toString())));
+      expect(
+        child.spanContext.spanId.toString(),
+        isNot(equals(parent.spanContext.spanId.toString())),
+      );
 
       parent.end();
       child.end();

--- a/test/unit/trace/sampling/final_parent_id_test.dart
+++ b/test/unit/trace/sampling/final_parent_id_test.dart
@@ -8,9 +8,7 @@ void main() {
   group('Final Parent ID Tests', () {
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
     });
 
     tearDown(() async {
@@ -25,14 +23,18 @@ void main() {
       // Print debug info
       print('Root span parent ID: ${rootSpan.spanContext.parentSpanId}');
       print(
-          'Root span parent ID toString: ${rootSpan.spanContext.parentSpanId}');
+        'Root span parent ID toString: ${rootSpan.spanContext.parentSpanId}',
+      );
       print(
-          'Root span parent ID isValid: ${rootSpan.spanContext.parentSpanId!.isValid}');
+        'Root span parent ID isValid: ${rootSpan.spanContext.parentSpanId!.isValid}',
+      );
 
       // Test that the parent ID is zero-filled
       expect(rootSpan.spanContext.parentSpanId, isNotNull);
-      expect(rootSpan.spanContext.parentSpanId.toString(),
-          equals('0000000000000000'));
+      expect(
+        rootSpan.spanContext.parentSpanId.toString(),
+        equals('0000000000000000'),
+      );
       expect(rootSpan.spanContext.parentSpanId!.isValid, isFalse);
 
       rootSpan.end();

--- a/test/unit/trace/sampling/parent_based_sampler_test.dart
+++ b/test/unit/trace/sampling/parent_based_sampler_test.dart
@@ -12,17 +12,17 @@ void main() {
 
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
       // Use TraceIdRatioSampler(0.5) as the root sampler for testing
       rootSampler = TraceIdRatioSampler(0.5);
       sampler = ParentBasedSampler(rootSampler);
     });
 
     test('description returns expected value', () {
-      expect(sampler.description,
-          equals('ParentBased{root=${rootSampler.description}}'));
+      expect(
+        sampler.description,
+        equals('ParentBased{root=${rootSampler.description}}'),
+      );
     });
 
     test('uses root sampler when parent is absent', () {
@@ -171,73 +171,79 @@ void main() {
       // Test the custom behaviors
 
       // 1. Remote + Sampled parent -> Should sample
-      final remoteParentSampledContext =
-          OTelAPI.context().withSpanContext(OTel.spanContext(
-        traceId: OTel.traceIdFrom('00000000000000000000000000000001'),
-        spanId: OTel.spanIdFrom('0000000000000001'),
-        traceFlags: TraceFlags.sampled,
-        traceState: OTel.traceState({}),
-        isRemote: true,
-      ));
+      final remoteParentSampledContext = OTelAPI.context().withSpanContext(
+        OTel.spanContext(
+          traceId: OTel.traceIdFrom('00000000000000000000000000000001'),
+          spanId: OTel.spanIdFrom('0000000000000001'),
+          traceFlags: TraceFlags.sampled,
+          traceState: OTel.traceState({}),
+          isRemote: true,
+        ),
+      );
 
       expect(
-          customSampler
-              .shouldSample(
-                parentContext: remoteParentSampledContext,
-                traceId: '00000000000000000000000000000001',
-                name: 'test-span',
-                spanKind: SpanKind.internal,
-                attributes: null,
-                links: null,
-              )
-              .decision,
-          equals(SamplingDecision.recordAndSample));
+        customSampler
+            .shouldSample(
+              parentContext: remoteParentSampledContext,
+              traceId: '00000000000000000000000000000001',
+              name: 'test-span',
+              spanKind: SpanKind.internal,
+              attributes: null,
+              links: null,
+            )
+            .decision,
+        equals(SamplingDecision.recordAndSample),
+      );
 
       // 2. Remote + Not Sampled parent -> Should sample (custom behavior)
-      final remoteParentNotSampledContext =
-          OTelAPI.context().withSpanContext(OTel.spanContext(
-        traceId: OTel.traceIdFrom('00000000000000000000000000000001'),
-        spanId: OTel.spanIdFrom('0000000000000001'),
-        traceFlags: OTel.traceFlags(0),
-        traceState: OTel.traceState({}),
-        isRemote: true,
-      ));
+      final remoteParentNotSampledContext = OTelAPI.context().withSpanContext(
+        OTel.spanContext(
+          traceId: OTel.traceIdFrom('00000000000000000000000000000001'),
+          spanId: OTel.spanIdFrom('0000000000000001'),
+          traceFlags: OTel.traceFlags(0),
+          traceState: OTel.traceState({}),
+          isRemote: true,
+        ),
+      );
 
       expect(
-          customSampler
-              .shouldSample(
-                parentContext: remoteParentNotSampledContext,
-                traceId: '00000000000000000000000000000001',
-                name: 'test-span',
-                spanKind: SpanKind.internal,
-                attributes: null,
-                links: null,
-              )
-              .decision,
-          equals(SamplingDecision.recordAndSample));
+        customSampler
+            .shouldSample(
+              parentContext: remoteParentNotSampledContext,
+              traceId: '00000000000000000000000000000001',
+              name: 'test-span',
+              spanKind: SpanKind.internal,
+              attributes: null,
+              links: null,
+            )
+            .decision,
+        equals(SamplingDecision.recordAndSample),
+      );
 
       // 3. Local + Sampled parent -> Should NOT sample (custom behavior)
-      final localParentSampledContext =
-          OTelAPI.context().withSpanContext(OTel.spanContext(
-        traceId: OTel.traceIdFrom('00000000000000000000000000000001'),
-        spanId: OTel.spanIdFrom('0000000000000001'),
-        traceFlags: TraceFlags.sampled,
-        traceState: OTel.traceState({}),
-        isRemote: false,
-      ));
+      final localParentSampledContext = OTelAPI.context().withSpanContext(
+        OTel.spanContext(
+          traceId: OTel.traceIdFrom('00000000000000000000000000000001'),
+          spanId: OTel.spanIdFrom('0000000000000001'),
+          traceFlags: TraceFlags.sampled,
+          traceState: OTel.traceState({}),
+          isRemote: false,
+        ),
+      );
 
       expect(
-          customSampler
-              .shouldSample(
-                parentContext: localParentSampledContext,
-                traceId: '00000000000000000000000000000001',
-                name: 'test-span',
-                spanKind: SpanKind.internal,
-                attributes: null,
-                links: null,
-              )
-              .decision,
-          equals(SamplingDecision.drop));
+        customSampler
+            .shouldSample(
+              parentContext: localParentSampledContext,
+              traceId: '00000000000000000000000000000001',
+              name: 'test-span',
+              spanKind: SpanKind.internal,
+              attributes: null,
+              links: null,
+            )
+            .decision,
+        equals(SamplingDecision.drop),
+      );
     });
   });
 }

--- a/test/unit/trace/sampling/parent_context_test.dart
+++ b/test/unit/trace/sampling/parent_context_test.dart
@@ -34,7 +34,9 @@ void main() {
       // Verify parent relationship
       expect(span.spanContext.traceId, equals(parentSpan.spanContext.traceId));
       expect(
-          span.spanContext.parentSpanId, equals(parentSpan.spanContext.spanId));
+        span.spanContext.parentSpanId,
+        equals(parentSpan.spanContext.spanId),
+      );
 
       // Reset current context
       Context.current = Context.root;
@@ -56,8 +58,10 @@ void main() {
 
       // Verify parent relationship is with parent2
       expect(span.spanContext.traceId, equals(parentSpan2.spanContext.traceId));
-      expect(span.spanContext.parentSpanId,
-          equals(parentSpan2.spanContext.spanId));
+      expect(
+        span.spanContext.parentSpanId,
+        equals(parentSpan2.spanContext.spanId),
+      );
 
       // Reset current context
       Context.current = Context.root;
@@ -78,14 +82,15 @@ void main() {
 
       // Attempt to create child span with different trace ID
       expect(
-          () => tracer.startSpan(
-                'child',
-                context: parentContext,
-                spanContext: spanContext,
-              ),
-          throwsArgumentError,
-          reason:
-              'Should not allow creating span with different trace ID than parent');
+        () => tracer.startSpan(
+          'child',
+          context: parentContext,
+          spanContext: spanContext,
+        ),
+        throwsArgumentError,
+        reason:
+            'Should not allow creating span with different trace ID than parent',
+      );
     });
 
     test('uses explicit spanContext trace ID while generating new span ID', () {
@@ -111,21 +116,31 @@ void main() {
       // Verify:
       // 1. Trace ID matches parent (required by spec)
       expect(
-          span.spanContext.traceId, equals(parentContext.spanContext!.traceId),
-          reason: 'Child should use parent trace ID');
+        span.spanContext.traceId,
+        equals(parentContext.spanContext!.traceId),
+        reason: 'Child should use parent trace ID',
+      );
 
       // 2. Span ID is new (not the same as explicitSpanContext)
-      expect(span.spanContext.spanId, isNot(equals(explicitSpanContext.spanId)),
-          reason: 'Child should get new span ID');
+      expect(
+        span.spanContext.spanId,
+        isNot(equals(explicitSpanContext.spanId)),
+        reason: 'Child should get new span ID',
+      );
 
       // 3. Parent span ID properly set
       expect(
-          span.spanContext.parentSpanId, equals(parentSpan.spanContext.spanId),
-          reason: 'Child should reference parent span ID');
+        span.spanContext.parentSpanId,
+        equals(parentSpan.spanContext.spanId),
+        reason: 'Child should reference parent span ID',
+      );
 
       // 4. All IDs are valid
-      expect(span.spanContext.isValid, isTrue,
-          reason: 'Child context should be valid');
+      expect(
+        span.spanContext.isValid,
+        isTrue,
+        reason: 'Child context should be valid',
+      );
     });
 
     test('uses bad explicit spanContext over context parent', () {
@@ -139,9 +154,11 @@ void main() {
         spanId: OTel.spanId(),
       );
 
-      expect(() => parentContext.withSpanContext(explicitSpanContext),
-          throwsArgumentError,
-          reason: 'Should not allow changing trace ID via withSpanContext');
+      expect(
+        () => parentContext.withSpanContext(explicitSpanContext),
+        throwsArgumentError,
+        reason: 'Should not allow changing trace ID via withSpanContext',
+      );
     });
 
     test('properly inherits parent trace ID in various scenarios', () {
@@ -150,22 +167,23 @@ void main() {
       final rootContext = Context.current.withSpan(rootSpan);
 
       // 1. Create child with parent context
-      final childViaContext = tracer.startSpan(
-        'child1',
-        context: rootContext,
+      final childViaContext = tracer.startSpan('child1', context: rootContext);
+      expect(
+        childViaContext.spanContext.traceId,
+        equals(rootSpan.spanContext.traceId),
+        reason: 'Child via context should inherit parent trace ID',
       );
-      expect(childViaContext.spanContext.traceId,
-          equals(rootSpan.spanContext.traceId),
-          reason: 'Child via context should inherit parent trace ID');
 
       // 2. Create child with explicit parent span
       final childViaParentSpan = tracer.startSpan(
         'child2',
         parentSpan: rootSpan,
       );
-      expect(childViaParentSpan.spanContext.traceId,
-          equals(rootSpan.spanContext.traceId),
-          reason: 'Child via parent span should inherit parent trace ID');
+      expect(
+        childViaParentSpan.spanContext.traceId,
+        equals(rootSpan.spanContext.traceId),
+        reason: 'Child via parent span should inherit parent trace ID',
+      );
 
       // 3. Create child with matching spanContext
       final matchingSpanContext = OTel.spanContext(
@@ -177,9 +195,11 @@ void main() {
         context: rootContext,
         spanContext: matchingSpanContext,
       );
-      expect(childViaSpanContext.spanContext.traceId,
-          equals(rootSpan.spanContext.traceId),
-          reason: 'Child via matching span context should maintain trace ID');
+      expect(
+        childViaSpanContext.spanContext.traceId,
+        equals(rootSpan.spanContext.traceId),
+        reason: 'Child via matching span context should maintain trace ID',
+      );
     });
 
     test('throws when parentSpan and spanContext have different spanIds', () {
@@ -214,10 +234,14 @@ void main() {
       );
 
       // Verify explicit parent was used
-      expect(span.spanContext.traceId,
-          equals(explicitParentSpan.spanContext.traceId));
-      expect(span.spanContext.parentSpanId,
-          equals(explicitParentSpan.spanContext.spanId));
+      expect(
+        span.spanContext.traceId,
+        equals(explicitParentSpan.spanContext.traceId),
+      );
+      expect(
+        span.spanContext.parentSpanId,
+        equals(explicitParentSpan.spanContext.spanId),
+      );
     });
 
     test('creates root span when no parent context available', () {
@@ -226,7 +250,9 @@ void main() {
       // Verify the parent span ID is zero-filled (invalid)
       expect(span.spanContext.parentSpanId, isNotNull);
       expect(
-          span.spanContext.parentSpanId.toString(), equals('0000000000000000'));
+        span.spanContext.parentSpanId.toString(),
+        equals('0000000000000000'),
+      );
       expect(span.spanContext.traceId.isValid, isTrue);
       expect(span.spanContext.spanId.isValid, isTrue);
     });

--- a/test/unit/trace/sampling/samplers_test.dart
+++ b/test/unit/trace/sampling/samplers_test.dart
@@ -82,32 +82,34 @@ void main() {
     test('samples every Nth request', () {
       final sampler = CountingSampler(3);
       final decisions = List.generate(
-          9,
-          (index) => sampler
-              .shouldSample(
-                parentContext: emptyContext,
-                traceId: 'trace$index',
-                name: 'test',
-                spanKind: SpanKind.internal,
-                attributes: null,
-                links: null,
-              )
-              .decision);
+        9,
+        (index) => sampler
+            .shouldSample(
+              parentContext: emptyContext,
+              traceId: 'trace$index',
+              name: 'test',
+              spanKind: SpanKind.internal,
+              attributes: null,
+              links: null,
+            )
+            .decision,
+      );
 
       // Should sample every 3rd request (indices 2, 5, 8)
       expect(
-          decisions,
-          equals([
-            SamplingDecision.drop,
-            SamplingDecision.drop,
-            SamplingDecision.recordAndSample,
-            SamplingDecision.drop,
-            SamplingDecision.drop,
-            SamplingDecision.recordAndSample,
-            SamplingDecision.drop,
-            SamplingDecision.drop,
-            SamplingDecision.recordAndSample,
-          ]));
+        decisions,
+        equals([
+          SamplingDecision.drop,
+          SamplingDecision.drop,
+          SamplingDecision.recordAndSample,
+          SamplingDecision.drop,
+          SamplingDecision.drop,
+          SamplingDecision.recordAndSample,
+          SamplingDecision.drop,
+          SamplingDecision.drop,
+          SamplingDecision.recordAndSample,
+        ]),
+      );
     });
 
     test('overrides count based on error condition', () {
@@ -155,7 +157,7 @@ void main() {
       final sampler = CountingSampler(
         3,
         overrideConditions: [
-          AttributeSamplingCondition('priority', stringValue: 'high')
+          AttributeSamplingCondition('priority', stringValue: 'high'),
         ],
       );
 
@@ -175,8 +177,10 @@ void main() {
 
   group('RateLimitingSampler', () {
     test('limits sampling rate', () async {
-      final sampler = RateLimitingSampler(10,
-          timeWindow: const Duration(milliseconds: 100)); // 10 per second
+      final sampler = RateLimitingSampler(
+        10,
+        timeWindow: const Duration(milliseconds: 100),
+      ); // 10 per second
       var sampledCount = 0;
 
       // Try to sample 100 times in rapid succession
@@ -196,15 +200,19 @@ void main() {
 
       // Should be limited to roughly 1 sample (10 per second * 0.1 seconds)
       expect(
-          sampledCount, lessThanOrEqualTo(2)); // Allow some margin for timing
+        sampledCount,
+        lessThanOrEqualTo(2),
+      ); // Allow some margin for timing
 
       // Clean up
       sampler.dispose();
     });
 
     test('replenishes tokens over time', () async {
-      final sampler = RateLimitingSampler(10,
-          timeWindow: const Duration(milliseconds: 100));
+      final sampler = RateLimitingSampler(
+        10,
+        timeWindow: const Duration(milliseconds: 100),
+      );
       var initialSampledCount = 0;
       var laterSampledCount = 0;
 
@@ -309,34 +317,38 @@ void main() {
       ]);
 
       final decisions = List.generate(
-          4,
-          (index) => sampler
-              .shouldSample(
-                parentContext: emptyContext,
-                traceId: 'trace$index',
-                name: 'test',
-                spanKind: SpanKind.internal,
-                attributes: null,
-                links: null,
-              )
-              .decision);
+        4,
+        (index) => sampler
+            .shouldSample(
+              parentContext: emptyContext,
+              traceId: 'trace$index',
+              name: 'test',
+              spanKind: SpanKind.internal,
+              attributes: null,
+              links: null,
+            )
+            .decision,
+      );
 
       // Should only sample every 2nd request due to CountingSampler
       expect(
-          decisions,
-          equals([
-            SamplingDecision.drop,
-            SamplingDecision.recordAndSample,
-            SamplingDecision.drop,
-            SamplingDecision.recordAndSample,
-          ]));
+        decisions,
+        equals([
+          SamplingDecision.drop,
+          SamplingDecision.recordAndSample,
+          SamplingDecision.drop,
+          SamplingDecision.recordAndSample,
+        ]),
+      );
     });
 
     test('OR composition accepts if any sampler accepts', () {
       final sampler = CompositeSampler.or([
         CountingSampler(3), // Samples every 3rd
-        AttributeSamplingCondition('priority',
-            stringValue: 'high'), // Samples high priority
+        AttributeSamplingCondition(
+          'priority',
+          stringValue: 'high',
+        ), // Samples high priority
       ]);
 
       final results = [
@@ -376,12 +388,13 @@ void main() {
       ];
 
       expect(
-          results,
-          equals([
-            SamplingDecision.drop,
-            SamplingDecision.recordAndSample,
-            SamplingDecision.recordAndSample,
-          ]));
+        results,
+        equals([
+          SamplingDecision.drop,
+          SamplingDecision.recordAndSample,
+          SamplingDecision.recordAndSample,
+        ]),
+      );
     });
   });
 }

--- a/test/unit/trace/sampling/sampling_integration_test.dart
+++ b/test/unit/trace/sampling/sampling_integration_test.dart
@@ -101,10 +101,7 @@ void main() {
       final parentContext = OTel.context().withSpan(parent);
 
       // Create child span - should inherit sampling decision
-      final child = tracer.startSpan(
-        'child',
-        context: parentContext,
-      );
+      final child = tracer.startSpan('child', context: parentContext);
       expect(child.spanContext.traceFlags.isSampled, isTrue);
 
       // End spans to release resources

--- a/test/unit/trace/sampling/trace_id_ratio_sampler_test.dart
+++ b/test/unit/trace/sampling/trace_id_ratio_sampler_test.dart
@@ -11,9 +11,7 @@ void main() {
   group('TraceIdRatioSampler Tests', () {
     setUp(() async {
       await OTel.reset();
-      await OTel.initialize(
-        serviceName: 'test-service',
-      );
+      await OTel.initialize(serviceName: 'test-service');
     });
     test('constructor throws ArgumentError for invalid ratio values', () {
       expect(() => TraceIdRatioSampler(-0.1), throwsArgumentError);
@@ -121,8 +119,9 @@ void main() {
         // Create a random trace ID using random bytes
         final buffer = StringBuffer();
         for (int j = 0; j < 32; j++) {
-          buffer
-              .write(random.nextInt(16).toRadixString(16)); // Random hex digit
+          buffer.write(
+            random.nextInt(16).toRadixString(16),
+          ); // Random hex digit
         }
         final traceId = buffer.toString();
 
@@ -144,7 +143,8 @@ void main() {
       // Allow for some statistical variation (±10%)
       final samplingRate = sampledCount / totalRuns;
       print(
-          'Sampled $sampledCount out of $totalRuns traces (rate: $samplingRate)');
+        'Sampled $sampledCount out of $totalRuns traces (rate: $samplingRate)',
+      );
       expect(samplingRate, closeTo(0.3, 0.1));
     });
   });

--- a/test/unit/trace/simple_span_processor_test.dart
+++ b/test/unit/trace/simple_span_processor_test.dart
@@ -227,8 +227,10 @@ void main() {
 
       expect(trackingExporter.shutdownCalled, isTrue);
       expect(trackingExporter.exportedSpans, hasLength(1));
-      expect(trackingExporter.exportedSpans.first.name,
-          equals('shutdown-test-span'));
+      expect(
+        trackingExporter.exportedSpans.first.name,
+        equals('shutdown-test-span'),
+      );
     });
   });
 }

--- a/test/unit/trace/simple_test_file_exporter_test.dart
+++ b/test/unit/trace/simple_test_file_exporter_test.dart
@@ -84,8 +84,11 @@ void main() {
       // Verify the file has content
       final content = file.readAsStringSync();
       print('File content after export: $content');
-      expect(content.isNotEmpty, isTrue,
-          reason: 'Expected file to have content');
+      expect(
+        content.isNotEmpty,
+        isTrue,
+        reason: 'Expected file to have content',
+      );
 
       // Verify the content can be parsed as JSON
       try {
@@ -96,8 +99,11 @@ void main() {
 
         // Cast to List for type safety
         final batches = jsonData as List;
-        expect(batches, isNotEmpty,
-            reason: 'Expected non-empty list of batches');
+        expect(
+          batches,
+          isNotEmpty,
+          reason: 'Expected non-empty list of batches',
+        );
 
         // Get the first batch
         final firstBatch = batches[0];
@@ -115,14 +121,23 @@ void main() {
         final spanMap = spanData as Map<String, dynamic>;
 
         // Verify span properties
-        expect(spanMap['name'], equals('test-span'),
-            reason: 'Expected span name to match');
-        expect(spanMap['attributes'], isA<Map>(),
-            reason: 'Expected span to have attributes');
+        expect(
+          spanMap['name'],
+          equals('test-span'),
+          reason: 'Expected span name to match',
+        );
+        expect(
+          spanMap['attributes'],
+          isA<Map>(),
+          reason: 'Expected span to have attributes',
+        );
 
         final attributes = spanMap['attributes'] as Map<String, dynamic>;
-        expect(attributes['test.key'], equals('test.value'),
-            reason: 'Expected attribute to be set');
+        expect(
+          attributes['test.key'],
+          equals('test.value'),
+          reason: 'Expected attribute to be set',
+        );
       } catch (e) {
         fail('Error parsing JSON: $e\nContent: $content');
       }

--- a/test/unit/trace/span_lifecycle_test.dart
+++ b/test/unit/trace/span_lifecycle_test.dart
@@ -54,10 +54,7 @@ void main() {
         'test.double': 3.14,
       }.toAttributes();
 
-      final span = tracer.startSpan(
-        'direct-test-span',
-        attributes: attributes,
-      );
+      final span = tracer.startSpan('direct-test-span', attributes: attributes);
 
       span.end();
 
@@ -127,7 +124,9 @@ void main() {
       expect(events[0].name, equals('event1'));
       expect(events[1].name, equals('event2'));
       expect(
-          events[1].attributes!.getString('event.key'), equals('event.value'));
+        events[1].attributes!.getString('event.key'),
+        equals('event.value'),
+      );
     });
 
     test('span should record exceptions', () async {
@@ -157,10 +156,14 @@ void main() {
       expect(events, isNotNull);
       expect(events!.length, equals(1));
       expect(events[0].name, equals('exception'));
-      expect(events[0].attributes!.getString('exception.type'),
-          contains('Exception'));
-      expect(events[0].attributes!.getString('exception.message'),
-          contains('Test exception'));
+      expect(
+        events[0].attributes!.getString('exception.type'),
+        contains('Exception'),
+      );
+      expect(
+        events[0].attributes!.getString('exception.message'),
+        contains('Test exception'),
+      );
     });
 
     test('span should support adding links', () async {
@@ -219,13 +222,15 @@ void main() {
       expect(exportedSpan.startTime, isNotNull);
       expect(exportedSpan.endTime, isNotNull);
       expect(
-          exportedSpan.startTime
-              .isAfter(startTime.subtract(const Duration(seconds: 1))),
-          isTrue);
+        exportedSpan.startTime.isAfter(
+          startTime.subtract(const Duration(seconds: 1)),
+        ),
+        isTrue,
+      );
       expect(
-          exportedSpan.endTime!
-              .isBefore(endTime.add(const Duration(seconds: 1))),
-          isTrue);
+        exportedSpan.endTime!.isBefore(endTime.add(const Duration(seconds: 1))),
+        isTrue,
+      );
       expect(exportedSpan.endTime!.isAfter(exportedSpan.startTime), isTrue);
     });
 

--- a/test/unit/trace/span_processor_test.dart
+++ b/test/unit/trace/span_processor_test.dart
@@ -71,15 +71,21 @@ void main() {
       );
 
       // Verify that isRecording is true before ending
-      expect(span.isRecording, isTrue,
-          reason: 'Span should be recording before end()');
+      expect(
+        span.isRecording,
+        isTrue,
+        reason: 'Span should be recording before end()',
+      );
 
       // End the span
       span.end();
 
       // Verify that isRecording is false after ending
-      expect(span.isRecording, isFalse,
-          reason: 'Span should NOT be recording after end()');
+      expect(
+        span.isRecording,
+        isFalse,
+        reason: 'Span should NOT be recording after end()',
+      );
 
       // Wait a bit for async operations to complete
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -103,10 +109,7 @@ void main() {
       tracerProvider.addSpanProcessor(processor);
 
       // Create and end a span - this should not throw despite the exporter having an error
-      final span = tracer.startSpan(
-        'test-span',
-        kind: SpanKind.internal,
-      );
+      final span = tracer.startSpan('test-span', kind: SpanKind.internal);
 
       // Should not throw
       span.end();
@@ -131,10 +134,7 @@ void main() {
       await processor.shutdown();
 
       // Create and end a span after shutdown
-      final span = tracer.startSpan(
-        'test-span',
-        kind: SpanKind.internal,
-      );
+      final span = tracer.startSpan('test-span', kind: SpanKind.internal);
 
       span.end();
 
@@ -188,10 +188,7 @@ void main() {
       // Verify spans were exported
       expect(exporter.exportedSpans, hasLength(3));
       for (var i = 0; i < 3; i++) {
-        expect(
-          exporter.exportedSpans[i].name,
-          equals('test-span-$i'),
-        );
+        expect(exporter.exportedSpans[i].name, equals('test-span-$i'));
       }
 
       await processor.shutdown();
@@ -209,10 +206,7 @@ void main() {
       tracerProvider.addSpanProcessor(processor);
 
       // Create and end a span
-      final span = tracer.startSpan(
-        'test-span',
-        kind: SpanKind.internal,
-      );
+      final span = tracer.startSpan('test-span', kind: SpanKind.internal);
       span.end();
 
       // Should not throw
@@ -232,10 +226,7 @@ void main() {
       tracerProvider.addSpanProcessor(processor);
 
       // Create and end a span
-      final span = tracer.startSpan(
-        'test-span',
-        kind: SpanKind.internal,
-      );
+      final span = tracer.startSpan('test-span', kind: SpanKind.internal);
       span.end();
 
       // Wait a bit for async processing
@@ -254,13 +245,13 @@ void main() {
 
       // Create batch processor with small batch size for testing
       final processor = BatchSpanProcessor(
-          exporter,
-          const BatchSpanProcessorConfig(
-              maxExportBatchSize: 2,
-              exportTimeout: Duration(milliseconds: 1000),
-              scheduleDelay: Duration(
-                milliseconds: 100,
-              )));
+        exporter,
+        const BatchSpanProcessorConfig(
+          maxExportBatchSize: 2,
+          exportTimeout: Duration(milliseconds: 1000),
+          scheduleDelay: Duration(milliseconds: 100),
+        ),
+      );
 
       // Register the processor with the tracer provider
       tracerProvider.addSpanProcessor(processor);
@@ -283,8 +274,9 @@ void main() {
       // Verify span names
       for (var i = 0; i < 5; i++) {
         expect(
-          exporter.exportedSpans
-              .any((span) => span.name == 'batch-test-span-$i'),
+          exporter.exportedSpans.any(
+            (span) => span.name == 'batch-test-span-$i',
+          ),
           isTrue,
           reason: 'Should find span with name batch-test-span-$i',
         );

--- a/test/unit/trace/span_test.dart
+++ b/test/unit/trace/span_test.dart
@@ -47,18 +47,17 @@ void main() {
       final parentSpan = tracer.startSpan('parent-span');
 
       // Create a child span by using the parent span
-      final childSpan = tracer.startSpan(
-        'child-span',
-        parentSpan: parentSpan,
-      );
+      final childSpan = tracer.startSpan('child-span', parentSpan: parentSpan);
 
       // Verify the parent span context
       expect(childSpan.parentSpanContext, isNotNull);
       expect(childSpan.parentSpanContext, equals(parentSpan.spanContext));
 
       // Verify trace ID is inherited from parent
-      expect(childSpan.spanContext.traceId,
-          equals(parentSpan.spanContext.traceId));
+      expect(
+        childSpan.spanContext.traceId,
+        equals(parentSpan.spanContext.traceId),
+      );
 
       childSpan.end();
       parentSpan.end();
@@ -150,10 +149,14 @@ void main() {
       expect(events, isNotNull);
       expect(events!.length, equals(1));
       expect(events[0].name, equals('exception'));
-      expect(events[0].attributes!.getString('exception.type'),
-          contains('Exception'));
-      expect(events[0].attributes!.getString('exception.message'),
-          contains('Test exception'));
+      expect(
+        events[0].attributes!.getString('exception.type'),
+        contains('Exception'),
+      );
+      expect(
+        events[0].attributes!.getString('exception.message'),
+        contains('Test exception'),
+      );
 
       span.end();
     });

--- a/test/unit/trace/span_transformer_advanced_test.dart
+++ b/test/unit/trace/span_transformer_advanced_test.dart
@@ -45,8 +45,9 @@ void main() {
       final request = OtlpSpanTransformer.transformSpans([span]);
       final attrs =
           request.resourceSpans.first.scopeSpans.first.spans.first.attributes;
-      final attributeMap =
-          Map.fromEntries(attrs.map((a) => MapEntry(a.key, a.value)));
+      final attributeMap = Map.fromEntries(
+        attrs.map((a) => MapEntry(a.key, a.value)),
+      );
 
       expect(attributeMap['string_attr']?.stringValue, equals('value'));
       expect(attributeMap['int_attr']?.intValue, equals(Int64(42)));
@@ -89,7 +90,9 @@ void main() {
       final link = links[0];
       expect(bytesToHex(link.spanId), equals(linkedContext.spanId.toString()));
       expect(
-          bytesToHex(link.traceId), equals(linkedContext.traceId.toString()));
+        bytesToHex(link.traceId),
+        equals(linkedContext.traceId.toString()),
+      );
 
       final linkAttrs = Map.fromEntries(
         links[0].attributes.map((a) => MapEntry(a.key, a.value)),
@@ -114,10 +117,7 @@ void main() {
       };
 
       for (final entry in kindMap.entries) {
-        final span = tracer!.startSpan(
-          'kind-test',
-          kind: entry.key,
-        );
+        final span = tracer!.startSpan('kind-test', kind: entry.key);
 
         final request = OtlpSpanTransformer.transformSpans([span]);
         final protoSpan =

--- a/test/unit/trace/tracer_and_span_coverage_test.dart
+++ b/test/unit/trace/tracer_and_span_coverage_test.dart
@@ -49,8 +49,9 @@ class _LateAttributeSampler implements Sampler {
     required List<SpanLink>? links,
   }) {
     // Create attributes lazily so OTel is initialized
-    final attrs =
-        OTel.attributes([OTel.attributeString(attributeKey, attributeValue)]);
+    final attrs = OTel.attributes([
+      OTel.attributeString(attributeKey, attributeValue),
+    ]);
     return SamplingResult(
       decision: decision,
       source: SamplingDecisionSource.tracerConfig,
@@ -205,10 +206,18 @@ class _InvalidSpanWrapper implements APISpan {
   @override
   void addSpanLink(SpanLink spanLink) => _delegate.addSpanLink(spanLink);
   @override
-  void recordException(Object exception,
-          {StackTrace? stackTrace, Attributes? attributes, bool? escaped}) =>
-      _delegate.recordException(exception,
-          stackTrace: stackTrace, attributes: attributes, escaped: escaped);
+  void recordException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Attributes? attributes,
+    bool? escaped,
+  }) =>
+      _delegate.recordException(
+        exception,
+        stackTrace: stackTrace,
+        attributes: attributes,
+        escaped: escaped,
+      );
   @override
   void setBoolAttribute(String name, bool value) =>
       _delegate.setBoolAttribute(name, value);
@@ -271,7 +280,7 @@ void main() {
   group('Tracer getters', () {
     test('schemaUrl returns delegate schemaUrl', () {
       final tracer = OTel.tracer();
-      // schemaUrl may be null, but accessing it exercises the getter (line 58)
+      // schemaUrl may be null, but accessing it exercises the getter
       final schemaUrl = tracer.schemaUrl;
       // Just verify it does not throw and returns something (possibly null)
       expect(schemaUrl, anyOf(isNull, isA<String>()));
@@ -279,14 +288,14 @@ void main() {
 
     test('version returns delegate version', () {
       final tracer = OTel.tracer();
-      // Exercises line 61
+      // Exercises the version getter
       final version = tracer.version;
       expect(version, anyOf(isNull, isA<String>()));
     });
 
     test('attributes getter and setter', () {
       final tracer = OTel.tracer();
-      // Exercises getter (line 64) and setter (line 67)
+      // Exercises attributes getter and setter
       final originalAttrs = tracer.attributes;
       expect(originalAttrs, anyOf(isNull, isA<Attributes>()));
 
@@ -297,14 +306,14 @@ void main() {
 
     test('currentSpan returns delegate currentSpan', () {
       final tracer = OTel.tracer();
-      // Exercises line 73
+      // Exercises the currentSpan getter
       final current = tracer.currentSpan;
       expect(current, anyOf(isNull, isA<APISpan>()));
     });
 
     test('enabled setter works', () {
       final tracer = OTel.tracer();
-      // Exercises line 79
+      // Exercises the enabled setter
       expect(tracer.enabled, isTrue);
       tracer.enabled = false;
       expect(tracer.enabled, isFalse);
@@ -324,7 +333,7 @@ void main() {
       final realSpan = tracer.startSpan('will-be-invalid');
       final invalidSpan = _InvalidSpanWrapper(realSpan);
 
-      // withSpan should complete but log the invalid-span warning (lines 120-123)
+      // withSpan should complete but log the invalid-span warning
       final result = tracer.withSpan(invalidSpan, () => 42);
       expect(result, equals(42));
 
@@ -344,9 +353,11 @@ void main() {
       final realSpan = tracer.startSpan('will-be-invalid-async');
       final invalidSpan = _InvalidSpanWrapper(realSpan);
 
-      // Exercises lines 159-162
-      final result =
-          await tracer.withSpanAsync(invalidSpan, () async => 'hello');
+      // Exercises the invalid span warning path in withSpanAsync
+      final result = await tracer.withSpanAsync(
+        invalidSpan,
+        () async => 'hello',
+      );
       expect(result, equals('hello'));
 
       expect(
@@ -363,30 +374,32 @@ void main() {
   // tracer.dart - startSpanWithContext updates Context.current
   // =========================================================================
   group('Tracer startSpanWithContext', () {
-    test('startSpanWithContext updates Context.current when context matches',
-        () {
-      final tracer = OTel.tracer();
+    test(
+      'startSpanWithContext updates Context.current when context matches',
+      () {
+        final tracer = OTel.tracer();
 
-      // Set the current context to a known context
-      final ctx = Context.current;
+        // Set the current context to a known context
+        final ctx = Context.current;
 
-      // Call startSpanWithContext with Context.current so that
-      // Context.current == context is true (line 188)
-      final span = tracer.startSpanWithContext(
-        name: 'context-update-span',
-        context: ctx,
-      );
+        // Call startSpanWithContext with Context.current so that
+        // Context.current == context is true, so Context.current gets updated
+        final span = tracer.startSpanWithContext(
+          name: 'context-update-span',
+          context: ctx,
+        );
 
-      // Context.current should now have the span set
-      expect(span, isNotNull);
-      expect(span.name, equals('context-update-span'));
+        // Context.current should now have the span set
+        expect(span, isNotNull);
+        expect(span.name, equals('context-update-span'));
 
-      span.end();
-    });
+        span.end();
+      },
+    );
   });
 
   // =========================================================================
-  // tracer.dart - parentSpan without context spanContext (line 262)
+  // tracer.dart - parentSpan without context spanContext
   // =========================================================================
   group('Tracer startSpan with explicit parentSpan', () {
     test('startSpan uses parentSpan context when no context spanContext', () {
@@ -396,7 +409,7 @@ void main() {
       final parentSpan = tracer.startSpan('parent-span');
 
       // Now start a child span passing parentSpan explicitly, but on Context.root
-      // so there's no spanContext on the context. This exercises line 262.
+      // so there's no spanContext on the context. This exercises the parentSpan fallback.
       final childSpan = tracer.startSpan(
         'child-span',
         context: Context.root,
@@ -415,7 +428,7 @@ void main() {
   });
 
   // =========================================================================
-  // tracer.dart - sampling attributes merge paths (lines 342-347)
+  // tracer.dart - sampling attributes merge paths
   // =========================================================================
   group('Tracer sampling with attributes', () {
     test('sampler attributes set when span has no attributes', () async {
@@ -440,7 +453,7 @@ void main() {
 
       final tracer = OTel.tracer();
 
-      // Start span WITHOUT attributes - exercises line 344
+      // Start span WITHOUT attributes - exercises sampler-attributes-set path
       final span = tracer.startSpan('sampler-attrs-span');
       expect(span, isNotNull);
       span.end();
@@ -466,7 +479,7 @@ void main() {
 
       final tracer = OTel.tracer();
 
-      // Start span WITH attributes - exercises line 346-347
+      // Start span WITH attributes - exercises sampler-attributes-merge path
       final span = tracer.startSpan(
         'sampler-merge-span',
         attributes: OTel.attributes([OTel.attributeString('span.key', 'val')]),
@@ -484,7 +497,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('bool-list-span');
 
-      // Exercises line 158
+      // Exercises setBoolListAttribute delegation
       span.setBoolListAttribute('test.bools', [true, false, true]);
       span.end();
     });
@@ -493,7 +506,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('double-list-span');
 
-      // Exercises line 166
+      // Exercises setDoubleListAttribute delegation
       span.setDoubleListAttribute('test.doubles', [1.1, 2.2, 3.3]);
       span.end();
     });
@@ -502,7 +515,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('int-list-span');
 
-      // Exercises line 174
+      // Exercises setIntListAttribute delegation
       span.setIntListAttribute('test.ints', [1, 2, 3]);
       span.end();
     });
@@ -511,7 +524,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('string-list-span');
 
-      // Exercises line 191
+      // Exercises setStringListAttribute delegation
       span.setStringListAttribute<String>('test.strings', ['a', 'b', 'c']);
       span.end();
     });
@@ -520,7 +533,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('datetime-span');
 
-      // Exercises line 195
+      // Exercises setDateTimeAsStringAttribute delegation
       span.setDateTimeAsStringAttribute('test.time', DateTime.now());
       span.end();
     });
@@ -529,11 +542,11 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('attrs-setter-span');
 
-      // Exercises line 103 (set attributes)
+      // Exercises the attributes setter
       final newAttrs = OTel.attributesFromMap({'new.key': 'new.value'});
       span.attributes = newAttrs;
 
-      // Exercises line 107 (addAttributes)
+      // Exercises addAttributes
       span.addAttributes(OTel.attributesFromMap({'extra.key': 'extra.value'}));
 
       span.end();
@@ -541,7 +554,7 @@ void main() {
   });
 
   // =========================================================================
-  // span.dart - end() with throwing processor (error paths lines 88-97)
+  // span.dart - end() with throwing processor (error paths)
   // =========================================================================
   group('Span end() with throwing processor', () {
     test('end() catches processor onEnd exception and continues', () async {
@@ -560,7 +573,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('will-throw-on-end');
 
-      // end() should not propagate the processor error (lines 88-91 catch block)
+      // end() should not propagate the processor error (per-processor catch block)
       // The error is caught inside the per-processor try/catch
       span.end();
 
@@ -582,7 +595,9 @@ void main() {
       final span = tracer.startSpan('toString-events-span');
 
       span.addEventNow(
-          'test-event', OTel.attributesFromMap({'event.key': 'event.val'}));
+        'test-event',
+        OTel.attributesFromMap({'event.key': 'event.val'}),
+      );
 
       final str = span.toString();
       expect(str, contains('spanEvents:'));
@@ -600,7 +615,9 @@ void main() {
       final span = tracer.startSpan('toString-links-span');
 
       span.addLink(
-          linkContext, OTel.attributesFromMap({'link.key': 'link.val'}));
+        linkContext,
+        OTel.attributesFromMap({'link.key': 'link.val'}),
+      );
 
       final str = span.toString();
       expect(str, contains('spanLinks:'));
@@ -615,21 +632,21 @@ void main() {
   group('Meter getters', () {
     test('version getter returns delegate version', () {
       final meter = OTel.meter();
-      // Exercises line 57-58
+      // Exercises the version getter
       final version = meter.version;
       expect(version, anyOf(isNull, isA<String>()));
     });
 
     test('schemaUrl getter returns delegate schemaUrl', () {
       final meter = OTel.meter();
-      // Exercises line 63-64
+      // Exercises the schemaUrl getter
       final schemaUrl = meter.schemaUrl;
       expect(schemaUrl, anyOf(isNull, isA<String>()));
     });
 
     test('attributes getter returns delegate attributes', () {
       final meter = OTel.meter();
-      // Exercises line 69-70
+      // Exercises the attributes getter
       final attrs = meter.attributes;
       expect(attrs, anyOf(isNull, isA<Attributes>()));
     });
@@ -638,21 +655,21 @@ void main() {
   group('NoopMeter observable instrument collect', () {
     test('NoopObservableCounter collect returns empty list', () {
       final noop = NoopObservableCounter<int>(name: 'noop-counter');
-      // Exercises line 693 (NoopObservableCounter.collect)
+      // Exercises NoopObservableCounter.collect
       final measurements = noop.collect();
       expect(measurements, isEmpty);
     });
 
     test('NoopObservableUpDownCounter collect returns empty list', () {
       final noop = NoopObservableUpDownCounter<int>(name: 'noop-updown');
-      // Exercises line 766 (NoopObservableUpDownCounter.collect)
+      // Exercises NoopObservableUpDownCounter.collect
       final measurements = noop.collect();
       expect(measurements, isEmpty);
     });
 
     test('NoopObservableGauge collect returns empty list', () {
       final noop = NoopObservableGauge<double>(name: 'noop-gauge');
-      // Exercises line 838 (NoopObservableGauge.collect)
+      // Exercises NoopObservableGauge.collect
       final measurements = noop.collect();
       expect(measurements, isEmpty);
     });
@@ -696,7 +713,7 @@ void main() {
       // Give a little time for async operations
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      // Should have logged about dropping spans (lines 114-115)
+      // Should have logged about dropping spans due to full queue
       expect(
         logOutput.any((msg) => msg.contains('queue full')),
         isTrue,
@@ -713,7 +730,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('name-update-test');
 
-      // Exercises line 128 (onNameUpdate)
+      // Exercises onNameUpdate (no-op for batch processor)
       await processor.onNameUpdate(span, 'new-name');
       // No exception means success
 
@@ -727,7 +744,7 @@ void main() {
 
       await processor.shutdown();
 
-      // Exercises lines 172-174 (forceFlush after shutdown)
+      // Exercises forceFlush after shutdown (no-op path)
       await processor.forceFlush();
       // No exception means success
     });
@@ -750,7 +767,7 @@ void main() {
       span.end();
       await processor.onEnd(span);
 
-      // Wait for the timer to fire and hit the error path (line 101)
+      // Wait for the timer to fire and hit the export error path
       await Future<void>.delayed(const Duration(milliseconds: 150));
 
       // The error should be caught, not propagated
@@ -766,7 +783,7 @@ void main() {
       final tracer = OTel.tracer();
       final span = tracer.startSpan('post-shutdown-span');
 
-      // Exercises line 108-109 (onEnd after shutdown)
+      // Exercises onEnd after shutdown (no-op path)
       await processor.onEnd(span);
       // No exception means success
 
@@ -784,7 +801,7 @@ void main() {
         AlwaysOnSampler(),
       ]);
 
-      // Exercises lines 13-15 (description getter)
+      // Exercises the description getter
       final desc = sampler.description;
       expect(desc, contains('CompositeSampler'));
       expect(desc, contains('and'));
@@ -921,7 +938,7 @@ void main() {
   // =========================================================================
   // From final_3_lines_test.dart - Gauge, MetricTransformer, Histogram, Counter
   // =========================================================================
-  // gauge.dart line 88: double type path in getValue
+  // gauge.dart: double type path in getValue
   test('Gauge<double> getValue returns double', () {
     final meter = OTel.meterProvider().getMeter(name: 'test');
     final gauge = meter.createGauge<double>(name: 'dbl_gauge');
@@ -932,29 +949,32 @@ void main() {
     expect(value, isA<double>());
   });
 
-  // metric_transformer.dart line 219: unsupported type defaults to string
+  // metric_transformer.dart: unsupported type defaults to string
   test('transformResource with unsupported attribute type uses toString', () {
     // Create a resource that has list values with mixed types
-    // The _createKeyValue else branch (line 219) handles unknown types
+    // The _createKeyValue else branch handles unknown types via toString
     final resource = ResourceCreate.create(
-        OTel.attributesFromMap({'regular': 'string_val'}));
+      OTel.attributesFromMap({'regular': 'string_val'}),
+    );
     final proto = MetricTransformer.transformResource(resource);
     expect(proto.attributes, isNotEmpty);
   });
 
-  // trace/tracer.dart line 188: Context.current update in startSpanWithContext
-  test('startSpanWithContext updates global context when matching (final_3)',
-      () {
-    final tracer = OTel.tracer();
-    final currentCtx = Context.current;
-    final span = tracer.startSpanWithContext(
-      name: 'ctx-span',
-      context: currentCtx,
-    );
-    span.end();
-  });
+  // trace/tracer.dart: Context.current update in startSpanWithContext
+  test(
+    'startSpanWithContext updates global context when matching (final_3)',
+    () {
+      final tracer = OTel.tracer();
+      final currentCtx = Context.current;
+      final span = tracer.startSpanWithContext(
+        name: 'ctx-span',
+        context: currentCtx,
+      );
+      span.end();
+    },
+  );
 
-  // metrics/instruments/histogram.dart lines 75-76
+  // metrics/instruments/histogram.dart: double type path in getValue
   test('Histogram<double> getValue returns double', () {
     final meter = OTel.meterProvider().getMeter(name: 'test');
     final histogram = meter.createHistogram<double>(name: 'dbl_hist');
@@ -965,7 +985,7 @@ void main() {
     expect(value, isNotNull);
   });
 
-  // metrics/instruments/counter.dart lines 119, 123-124
+  // metrics/instruments/counter.dart: double type path in getValue
   test('Counter<double> getValue returns double', () {
     final meter = OTel.meterProvider().getMeter(name: 'test');
     final counter = meter.createCounter<double>(name: 'dbl_counter');
@@ -980,7 +1000,7 @@ void main() {
   // W3C propagator field length validation
   // =========================================================================
 
-  // ProbabilitySampler - lines 29-30 (description), 41 (validation)
+  // ProbabilitySampler - description and validation
   group('ProbabilitySampler coverage', () {
     test('description returns expected string', () {
       final sampler = ProbabilitySampler(0.5);
@@ -993,7 +1013,7 @@ void main() {
     });
   });
 
-  // RateLimitingSampler - lines 16-18 (description), 32 (validation)
+  // RateLimitingSampler - description and validation
   group('RateLimitingSampler coverage', () {
     test('description returns expected string', () {
       final sampler = RateLimitingSampler(100.0);
@@ -1007,48 +1027,35 @@ void main() {
     });
   });
 
-  // W3C propagator - lines 163-165, 172-174, 181-183
-  // Invalid length traceId, spanId, traceFlags in traceparent
+  // W3C propagator - Invalid length traceId, spanId, traceFlags in traceparent
   group('W3C propagator field length validation', () {
     test('traceparent with short traceId is rejected', () {
       // traceId is only 20 chars (should be 32)
       final map = {
-        'traceparent': '00-abcdef12345678901234-1234567890abcdef-01'
+        'traceparent': '00-abcdef12345678901234-1234567890abcdef-01',
       };
       final propagator = W3CTraceContextPropagator();
-      final context = propagator.extract(
-        Context.root,
-        map,
-        _MapGetter(map),
-      );
+      final context = propagator.extract(Context.root, map, _MapGetter(map));
       expect(context.spanContext, isNull);
     });
 
     test('traceparent with short spanId is rejected', () {
       // spanId only 14 chars (should be 16)
       final map = {
-        'traceparent': '00-abcdef1234567890abcdef12345678-1234567890abcd-01'
+        'traceparent': '00-abcdef1234567890abcdef12345678-1234567890abcd-01',
       };
       final propagator = W3CTraceContextPropagator();
-      final context = propagator.extract(
-        Context.root,
-        map,
-        _MapGetter(map),
-      );
+      final context = propagator.extract(Context.root, map, _MapGetter(map));
       expect(context.spanContext, isNull);
     });
 
     test('traceparent with short traceFlags is rejected', () {
       // traceFlags only 1 char (should be 2)
       final map = {
-        'traceparent': '00-abcdef1234567890abcdef12345678-1234567890abcdef-0'
+        'traceparent': '00-abcdef1234567890abcdef12345678-1234567890abcdef-0',
       };
       final propagator = W3CTraceContextPropagator();
-      final context = propagator.extract(
-        Context.root,
-        map,
-        _MapGetter(map),
-      );
+      final context = propagator.extract(Context.root, map, _MapGetter(map));
       expect(context.spanContext, isNull);
     });
   });

--- a/test/unit/trace/tracer_method_test.dart
+++ b/test/unit/trace/tracer_method_test.dart
@@ -51,14 +51,11 @@ void main() {
       final span = tracer.startSpan('test-with-span');
 
       // Act
-      tracer.withSpan(
-        span,
-        () {
-          final currentSpan = tracer.currentSpan;
-          result = currentSpan?.name ?? 'No active span';
-          return result;
-        },
-      );
+      tracer.withSpan(span, () {
+        final currentSpan = tracer.currentSpan;
+        result = currentSpan?.name ?? 'No active span';
+        return result;
+      });
 
       // End the span explicitly since withSpan doesn't end it
       span.end();
@@ -80,16 +77,13 @@ void main() {
       final span = tracer.startSpan('test-with-span-async');
 
       // Act
-      await tracer.withSpanAsync(
-        span,
-        () async {
-          // Simulate async work
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          final currentSpan = tracer.currentSpan;
-          result = currentSpan?.name ?? 'No active span';
-          return result;
-        },
-      );
+      await tracer.withSpanAsync(span, () async {
+        // Simulate async work
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final currentSpan = tracer.currentSpan;
+        result = currentSpan?.name ?? 'No active span';
+        return result;
+      });
 
       // End the span explicitly since withSpanAsync doesn't end it
       span.end();
@@ -126,30 +120,32 @@ void main() {
       expect(exportedSpan.isEnded, isTrue);
     });
 
-    test('recordSpanAsync creates and automatically ends an async span',
-        () async {
-      exporter.clear();
+    test(
+      'recordSpanAsync creates and automatically ends an async span',
+      () async {
+        exporter.clear();
 
-      // Act
-      final result = await tracer.recordSpanAsync(
-        name: 'async-record-span',
-        fn: () async {
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          return 'async success';
-        },
-      );
+        // Act
+        final result = await tracer.recordSpanAsync(
+          name: 'async-record-span',
+          fn: () async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            return 'async success';
+          },
+        );
 
-      // Force export
-      await processor.forceFlush();
+        // Force export
+        await processor.forceFlush();
 
-      // Assert
-      expect(result, equals('async success'));
-      expect(exporter.spans, hasLength(1));
-      expect(exporter.hasSpanWithName('async-record-span'), isTrue);
+        // Assert
+        expect(result, equals('async success'));
+        expect(exporter.spans, hasLength(1));
+        expect(exporter.hasSpanWithName('async-record-span'), isTrue);
 
-      final exportedSpan = exporter.findSpanByName('async-record-span')!;
-      expect(exportedSpan.isEnded, isTrue);
-    });
+        final exportedSpan = exporter.findSpanByName('async-record-span')!;
+        expect(exportedSpan.isEnded, isTrue);
+      },
+    );
 
     test('recordSpan captures exceptions and sets error status', () async {
       exporter.clear();
@@ -203,35 +199,37 @@ void main() {
       expect(exportedSpan.isEnded, isTrue);
     });
 
-    test('startActiveSpanAsync activates span during async execution',
-        () async {
-      exporter.clear();
+    test(
+      'startActiveSpanAsync activates span during async execution',
+      () async {
+        exporter.clear();
 
-      // Act
-      final result = await tracer.startActiveSpanAsync(
-        name: 'active-async-span',
-        fn: (span) async {
-          // Simulate async work
-          await Future<void>.delayed(const Duration(milliseconds: 10));
+        // Act
+        final result = await tracer.startActiveSpanAsync(
+          name: 'active-async-span',
+          fn: (span) async {
+            // Simulate async work
+            await Future<void>.delayed(const Duration(milliseconds: 10));
 
-          // Get current span to verify it's the same
-          final currentSpan = tracer.currentSpan;
-          expect(currentSpan, equals(span));
-          return 'active async span success';
-        },
-      );
+            // Get current span to verify it's the same
+            final currentSpan = tracer.currentSpan;
+            expect(currentSpan, equals(span));
+            return 'active async span success';
+          },
+        );
 
-      // Force export
-      await processor.forceFlush();
+        // Force export
+        await processor.forceFlush();
 
-      // Assert
-      expect(result, equals('active async span success'));
-      expect(exporter.spans, hasLength(1));
-      expect(exporter.hasSpanWithName('active-async-span'), isTrue);
+        // Assert
+        expect(result, equals('active async span success'));
+        expect(exporter.spans, hasLength(1));
+        expect(exporter.hasSpanWithName('active-async-span'), isTrue);
 
-      final exportedSpan = exporter.findSpanByName('active-async-span')!;
-      expect(exportedSpan.isEnded, isTrue);
-    });
+        final exportedSpan = exporter.findSpanByName('active-async-span')!;
+        expect(exportedSpan.isEnded, isTrue);
+      },
+    );
 
     test('withSpan maintains span context during execution', () async {
       exporter.clear();
@@ -239,15 +237,14 @@ void main() {
       final parentSpan = tracer.startSpan('parent-span');
       final parentContext = OTel.context().withSpan(parentSpan);
 
-      tracer.withSpan(
-        parentSpan,
-        () {
-          // Start a child span within the parent context
-          final childSpan =
-              tracer.startSpan('child-span', context: parentContext);
-          childSpan.end();
-        },
-      );
+      tracer.withSpan(parentSpan, () {
+        // Start a child span within the parent context
+        final childSpan = tracer.startSpan(
+          'child-span',
+          context: parentContext,
+        );
+        childSpan.end();
+      });
 
       parentSpan.end();
 
@@ -262,10 +259,14 @@ void main() {
       final parentExported = exporter.findSpanByName('parent-span')!;
       final childExported = exporter.findSpanByName('child-span')!;
 
-      expect(childExported.parentSpanContext!.spanId,
-          equals(parentExported.spanContext.spanId));
-      expect(childExported.spanContext.traceId,
-          equals(parentExported.spanContext.traceId));
+      expect(
+        childExported.parentSpanContext!.spanId,
+        equals(parentExported.spanContext.spanId),
+      );
+      expect(
+        childExported.spanContext.traceId,
+        equals(parentExported.spanContext.traceId),
+      );
     });
   });
 }

--- a/test/unit/trace/tracer_methods_test.dart
+++ b/test/unit/trace/tracer_methods_test.dart
@@ -37,21 +37,26 @@ void main() {
       span.end();
     });
 
-    test('sets context during execution so Context.current.span is the span',
-        () {
-      final tracer = OTel.tracer();
-      final span = tracer.startSpan('context-span');
+    test(
+      'sets context during execution so Context.current.span is the span',
+      () {
+        final tracer = OTel.tracer();
+        final span = tracer.startSpan('context-span');
 
-      APISpan? capturedSpan;
-      tracer.withSpan(span, () {
-        capturedSpan = Context.current.span;
-        return null;
-      });
+        APISpan? capturedSpan;
+        tracer.withSpan(span, () {
+          capturedSpan = Context.current.span;
+          return null;
+        });
 
-      expect(capturedSpan, isNotNull);
-      expect(capturedSpan!.spanContext.spanId, equals(span.spanContext.spanId));
-      span.end();
-    });
+        expect(capturedSpan, isNotNull);
+        expect(
+          capturedSpan!.spanContext.spanId,
+          equals(span.spanContext.spanId),
+        );
+        span.end();
+      },
+    );
 
     test('restores context after completion', () {
       final tracer = OTel.tracer();
@@ -73,11 +78,13 @@ void main() {
         () => tracer.withSpan(span, () {
           throw Exception('withSpan test error');
         }),
-        throwsA(isA<Exception>().having(
-          (e) => e.toString(),
-          'message',
-          contains('withSpan test error'),
-        )),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('withSpan test error'),
+          ),
+        ),
       );
 
       // The span should have recorded the exception and error status
@@ -85,10 +92,7 @@ void main() {
       expect(span.statusDescription, contains('withSpan test error'));
       expect(span.spanEvents, isNotNull);
       expect(span.spanEvents!.length, greaterThanOrEqualTo(1));
-      expect(
-        span.spanEvents!.any((e) => e.name == 'exception'),
-        isTrue,
-      );
+      expect(span.spanEvents!.any((e) => e.name == 'exception'), isTrue);
       span.end();
     });
 
@@ -125,43 +129,41 @@ void main() {
       span.end();
     });
 
-    test('on error: records exception and sets error status, rethrows',
-        () async {
-      final tracer = OTel.tracer();
-      final span = tracer.startSpan('async-error-span');
+    test(
+      'on error: records exception and sets error status, rethrows',
+      () async {
+        final tracer = OTel.tracer();
+        final span = tracer.startSpan('async-error-span');
 
-      await expectLater(
-        () => tracer.withSpanAsync(span, () async {
-          await Future<void>.delayed(const Duration(milliseconds: 5));
-          throw Exception('withSpanAsync test error');
-        }),
-        throwsA(isA<Exception>().having(
-          (e) => e.toString(),
-          'message',
-          contains('withSpanAsync test error'),
-        )),
-      );
+        await expectLater(
+          () => tracer.withSpanAsync(span, () async {
+            await Future<void>.delayed(const Duration(milliseconds: 5));
+            throw Exception('withSpanAsync test error');
+          }),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('withSpanAsync test error'),
+            ),
+          ),
+        );
 
-      expect(span.status, equals(SpanStatusCode.Error));
-      expect(span.statusDescription, contains('withSpanAsync test error'));
-      expect(span.spanEvents, isNotNull);
-      expect(span.spanEvents!.length, greaterThanOrEqualTo(1));
-      expect(
-        span.spanEvents!.any((e) => e.name == 'exception'),
-        isTrue,
-      );
-      span.end();
-    });
+        expect(span.status, equals(SpanStatusCode.Error));
+        expect(span.statusDescription, contains('withSpanAsync test error'));
+        expect(span.spanEvents, isNotNull);
+        expect(span.spanEvents!.length, greaterThanOrEqualTo(1));
+        expect(span.spanEvents!.any((e) => e.name == 'exception'), isTrue);
+        span.end();
+      },
+    );
   });
 
   group('recordSpan', () {
     test('creates span, runs function, and ends span', () async {
       final tracer = OTel.tracer();
 
-      tracer.recordSpan(
-        name: 'record-span',
-        fn: () => 'done',
-      );
+      tracer.recordSpan(name: 'record-span', fn: () => 'done');
 
       await OTel.tracerProvider().forceFlush();
 
@@ -181,36 +183,40 @@ void main() {
       expect(result, equals(99));
     });
 
-    test('on error: records exception, sets error, ends span, rethrows',
-        () async {
-      final tracer = OTel.tracer();
+    test(
+      'on error: records exception, sets error, ends span, rethrows',
+      () async {
+        final tracer = OTel.tracer();
 
-      expect(
-        () => tracer.recordSpan(
-          name: 'record-span-error',
-          fn: () {
-            throw StateError('recordSpan test error');
-          },
-        ),
-        throwsA(isA<StateError>().having(
-          (e) => e.message,
-          'message',
-          equals('recordSpan test error'),
-        )),
-      );
+        expect(
+          () => tracer.recordSpan(
+            name: 'record-span-error',
+            fn: () {
+              throw StateError('recordSpan test error');
+            },
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              equals('recordSpan test error'),
+            ),
+          ),
+        );
 
-      await OTel.tracerProvider().forceFlush();
+        await OTel.tracerProvider().forceFlush();
 
-      expect(exporter.hasSpanWithName('record-span-error'), isTrue);
-      final exportedSpan = exporter.findSpanByName('record-span-error')!;
-      expect(exportedSpan.isEnded, isTrue);
-      expect(exportedSpan.status, equals(SpanStatusCode.Error));
-      expect(exportedSpan.spanEvents, isNotNull);
-      expect(
-        exportedSpan.spanEvents!.any((e) => e.name == 'exception'),
-        isTrue,
-      );
-    });
+        expect(exporter.hasSpanWithName('record-span-error'), isTrue);
+        final exportedSpan = exporter.findSpanByName('record-span-error')!;
+        expect(exportedSpan.isEnded, isTrue);
+        expect(exportedSpan.status, equals(SpanStatusCode.Error));
+        expect(exportedSpan.spanEvents, isNotNull);
+        expect(
+          exportedSpan.spanEvents!.any((e) => e.name == 'exception'),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('recordSpanAsync', () {
@@ -234,61 +240,67 @@ void main() {
       expect(exportedSpan.isEnded, isTrue);
     });
 
-    test('on error: records exception, sets error, ends span, rethrows',
-        () async {
-      final tracer = OTel.tracer();
+    test(
+      'on error: records exception, sets error, ends span, rethrows',
+      () async {
+        final tracer = OTel.tracer();
 
-      await expectLater(
-        () => tracer.recordSpanAsync(
-          name: 'record-async-error',
-          fn: () async {
-            await Future<void>.delayed(const Duration(milliseconds: 5));
-            throw ArgumentError('recordSpanAsync test error');
-          },
-        ),
-        throwsA(isA<ArgumentError>().having(
-          (e) => e.message,
-          'message',
-          equals('recordSpanAsync test error'),
-        )),
-      );
+        await expectLater(
+          () => tracer.recordSpanAsync(
+            name: 'record-async-error',
+            fn: () async {
+              await Future<void>.delayed(const Duration(milliseconds: 5));
+              throw ArgumentError('recordSpanAsync test error');
+            },
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              equals('recordSpanAsync test error'),
+            ),
+          ),
+        );
 
-      await OTel.tracerProvider().forceFlush();
+        await OTel.tracerProvider().forceFlush();
 
-      expect(exporter.hasSpanWithName('record-async-error'), isTrue);
-      final exportedSpan = exporter.findSpanByName('record-async-error')!;
-      expect(exportedSpan.isEnded, isTrue);
-      expect(exportedSpan.status, equals(SpanStatusCode.Error));
-      expect(exportedSpan.spanEvents, isNotNull);
-      expect(
-        exportedSpan.spanEvents!.any((e) => e.name == 'exception'),
-        isTrue,
-      );
-    });
+        expect(exporter.hasSpanWithName('record-async-error'), isTrue);
+        final exportedSpan = exporter.findSpanByName('record-async-error')!;
+        expect(exportedSpan.isEnded, isTrue);
+        expect(exportedSpan.status, equals(SpanStatusCode.Error));
+        expect(exportedSpan.spanEvents, isNotNull);
+        expect(
+          exportedSpan.spanEvents!.any((e) => e.name == 'exception'),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('startActiveSpan', () {
-    test('creates span, runs function with span argument, and ends span',
-        () async {
-      final tracer = OTel.tracer();
-      APISpan? receivedSpan;
+    test(
+      'creates span, runs function with span argument, and ends span',
+      () async {
+        final tracer = OTel.tracer();
+        APISpan? receivedSpan;
 
-      tracer.startActiveSpan(
-        name: 'active-span',
-        fn: (span) {
-          receivedSpan = span;
-          return null;
-        },
-      );
+        tracer.startActiveSpan(
+          name: 'active-span',
+          fn: (span) {
+            receivedSpan = span;
+            return null;
+          },
+        );
 
-      expect(receivedSpan, isNotNull);
+        expect(receivedSpan, isNotNull);
 
-      await OTel.tracerProvider().forceFlush();
+        await OTel.tracerProvider().forceFlush();
 
-      expect(exporter.hasSpanWithName('active-span'), isTrue);
-      final exportedSpan = exporter.findSpanByName('active-span')!;
-      expect(exportedSpan.isEnded, isTrue);
-    });
+        expect(exporter.hasSpanWithName('active-span'), isTrue);
+        final exportedSpan = exporter.findSpanByName('active-span')!;
+        expect(exportedSpan.isEnded, isTrue);
+      },
+    );
 
     test('returns result', () {
       final tracer = OTel.tracer();
@@ -301,36 +313,40 @@ void main() {
       expect(result, equals('active-result'));
     });
 
-    test('on error: records exception via withSpan, ends span, rethrows',
-        () async {
-      final tracer = OTel.tracer();
+    test(
+      'on error: records exception via withSpan, ends span, rethrows',
+      () async {
+        final tracer = OTel.tracer();
 
-      expect(
-        () => tracer.startActiveSpan(
-          name: 'active-span-error',
-          fn: (span) {
-            throw Exception('startActiveSpan test error');
-          },
-        ),
-        throwsA(isA<Exception>().having(
-          (e) => e.toString(),
-          'message',
-          contains('startActiveSpan test error'),
-        )),
-      );
+        expect(
+          () => tracer.startActiveSpan(
+            name: 'active-span-error',
+            fn: (span) {
+              throw Exception('startActiveSpan test error');
+            },
+          ),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('startActiveSpan test error'),
+            ),
+          ),
+        );
 
-      await OTel.tracerProvider().forceFlush();
+        await OTel.tracerProvider().forceFlush();
 
-      expect(exporter.hasSpanWithName('active-span-error'), isTrue);
-      final exportedSpan = exporter.findSpanByName('active-span-error')!;
-      expect(exportedSpan.isEnded, isTrue);
-      expect(exportedSpan.status, equals(SpanStatusCode.Error));
-      expect(exportedSpan.spanEvents, isNotNull);
-      expect(
-        exportedSpan.spanEvents!.any((e) => e.name == 'exception'),
-        isTrue,
-      );
-    });
+        expect(exporter.hasSpanWithName('active-span-error'), isTrue);
+        final exportedSpan = exporter.findSpanByName('active-span-error')!;
+        expect(exportedSpan.isEnded, isTrue);
+        expect(exportedSpan.status, equals(SpanStatusCode.Error));
+        expect(exportedSpan.spanEvents, isNotNull);
+        expect(
+          exportedSpan.spanEvents!.any((e) => e.name == 'exception'),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('startActiveSpanAsync', () {
@@ -368,11 +384,13 @@ void main() {
             throw Exception('startActiveSpanAsync test error');
           },
         ),
-        throwsA(isA<Exception>().having(
-          (e) => e.toString(),
-          'message',
-          contains('startActiveSpanAsync test error'),
-        )),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('startActiveSpanAsync test error'),
+          ),
+        ),
       );
 
       await OTel.tracerProvider().forceFlush();
@@ -401,8 +419,10 @@ void main() {
       );
 
       expect(childSpan, isNotNull);
-      expect(childSpan.spanContext.traceId,
-          equals(parentSpan.spanContext.traceId));
+      expect(
+        childSpan.spanContext.traceId,
+        equals(parentSpan.spanContext.traceId),
+      );
 
       childSpan.end();
       parentSpan.end();
@@ -425,14 +445,20 @@ void main() {
 
       // The child should have the parent's span ID as its parent span ID
       expect(childSpan.parentSpanContext, isNotNull);
-      expect(childSpan.parentSpanContext!.spanId,
-          equals(parentSpan.spanContext.spanId));
+      expect(
+        childSpan.parentSpanContext!.spanId,
+        equals(parentSpan.spanContext.spanId),
+      );
       // The child should share the same trace ID
-      expect(childSpan.spanContext.traceId,
-          equals(parentSpan.spanContext.traceId));
+      expect(
+        childSpan.spanContext.traceId,
+        equals(parentSpan.spanContext.traceId),
+      );
       // The child should have its own unique span ID
-      expect(childSpan.spanContext.spanId,
-          isNot(equals(parentSpan.spanContext.spanId)));
+      expect(
+        childSpan.spanContext.spanId,
+        isNot(equals(parentSpan.spanContext.spanId)),
+      );
 
       childSpan.end();
       parentSpan.end();
@@ -441,8 +467,10 @@ void main() {
 
       final exportedChild = exporter.findSpanByName('context-child')!;
       final exportedParent = exporter.findSpanByName('parent-for-context')!;
-      expect(exportedChild.parentSpanContext!.spanId,
-          equals(exportedParent.spanContext.spanId));
+      expect(
+        exportedChild.parentSpanContext!.spanId,
+        equals(exportedParent.spanContext.spanId),
+      );
     });
   });
 }

--- a/test/unit/trace/tracer_provider_test.dart
+++ b/test/unit/trace/tracer_provider_test.dart
@@ -251,13 +251,16 @@ void main() {
       await tracerProvider.shutdown();
 
       // Trying to add a processor should throw
-      expect(() => tracerProvider.addSpanProcessor(MockSpanProcessor()),
-          throwsStateError);
+      expect(
+        () => tracerProvider.addSpanProcessor(MockSpanProcessor()),
+        throwsStateError,
+      );
     });
 
     test('resource can be set and retrieved', () {
-      final newResource =
-          OTel.resource({'custom.key': 'custom.value'}.toAttributes());
+      final newResource = OTel.resource(
+        {'custom.key': 'custom.value'}.toAttributes(),
+      );
 
       tracerProvider.resource = newResource;
       expect(tracerProvider.resource, equals(newResource));

--- a/test/unit/trace/tracer_test.dart
+++ b/test/unit/trace/tracer_test.dart
@@ -102,27 +102,29 @@ void main() {
       expect(result, equals('active-success'));
     });
 
-    test('startActiveSpanAsync executes with active span for async code',
-        () async {
-      // Execute async code with a new span that is automatically started and ended
-      final result = await tracer.startActiveSpanAsync(
-        name: 'active-async-span',
-        fn: (span) async {
-          // Simulate async work
-          await Future<void>.delayed(const Duration(milliseconds: 10));
+    test(
+      'startActiveSpanAsync executes with active span for async code',
+      () async {
+        // Execute async code with a new span that is automatically started and ended
+        final result = await tracer.startActiveSpanAsync(
+          name: 'active-async-span',
+          fn: (span) async {
+            // Simulate async work
+            await Future<void>.delayed(const Duration(milliseconds: 10));
 
-          // Verify currentSpan is the one we activated
-          expect(tracer.currentSpan, equals(span));
-          expect(span.name, equals('active-async-span'));
+            // Verify currentSpan is the one we activated
+            expect(tracer.currentSpan, equals(span));
+            expect(span.name, equals('active-async-span'));
 
-          // Return a value to test that return values work properly
-          return 'active-async-success';
-        },
-      );
+            // Return a value to test that return values work properly
+            return 'active-async-success';
+          },
+        );
 
-      // Verify return value
-      expect(result, equals('active-async-success'));
-    });
+        // Verify return value
+        expect(result, equals('active-async-success'));
+      },
+    );
 
     test('recordSpan automatically handles span creation and ending', () {
       // Use recordSpan to execute code with a new span
@@ -143,28 +145,30 @@ void main() {
       expect(result, equals('record-success'));
     });
 
-    test('recordSpanAsync automatically handles async span creation and ending',
-        () async {
-      // Use recordSpanAsync to execute async code with a new span
-      final result = await tracer.recordSpanAsync(
-        name: 'record-async-span',
-        fn: () async {
-          // Simulate async work
-          await Future<void>.delayed(const Duration(milliseconds: 10));
+    test(
+      'recordSpanAsync automatically handles async span creation and ending',
+      () async {
+        // Use recordSpanAsync to execute async code with a new span
+        final result = await tracer.recordSpanAsync(
+          name: 'record-async-span',
+          fn: () async {
+            // Simulate async work
+            await Future<void>.delayed(const Duration(milliseconds: 10));
 
-          // Code inside this function is executed with a span
-          final currentSpan = tracer.currentSpan;
-          expect(currentSpan, isNotNull);
-          expect(currentSpan!.name, equals('record-async-span'));
+            // Code inside this function is executed with a span
+            final currentSpan = tracer.currentSpan;
+            expect(currentSpan, isNotNull);
+            expect(currentSpan!.name, equals('record-async-span'));
 
-          // Return a value to test that return values work properly
-          return 'record-async-success';
-        },
-      );
+            // Return a value to test that return values work properly
+            return 'record-async-success';
+          },
+        );
 
-      // Verify return value
-      expect(result, equals('record-async-success'));
-    });
+        // Verify return value
+        expect(result, equals('record-async-success'));
+      },
+    );
 
     test('recordSpan sets error status on exception', () {
       // Try to use recordSpan with code that throws an exception

--- a/test/unit/trace/w3c_trace_context_propagator_coverage_test.dart
+++ b/test/unit/trace/w3c_trace_context_propagator_coverage_test.dart
@@ -41,15 +41,19 @@ void main() {
         propagator.inject(context, carrier, mapSetter);
 
         expect(carrier.containsKey('traceparent'), isTrue);
-        expect(carrier['traceparent'],
-            equals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'));
+        expect(
+          carrier['traceparent'],
+          equals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'),
+        );
       });
 
       test('inject includes tracestate when present', () {
         final traceId = OTel.traceIdFrom('4bf92f3577b34da6a3ce929d0e0e4736');
         final spanId = OTel.spanIdFrom('00f067aa0ba902b7');
-        final traceState =
-            OTel.traceState({'vendor1': 'val1', 'vendor2': 'val2'});
+        final traceState = OTel.traceState({
+          'vendor1': 'val1',
+          'vendor2': 'val2',
+        });
         final spanContext = OTel.spanContext(
           traceId: traceId,
           spanId: spanId,
@@ -118,7 +122,9 @@ void main() {
         expect(sc, isNotNull);
         expect(sc!.isValid, isTrue);
         expect(
-            sc.traceId.hexString, equals('4bf92f3577b34da6a3ce929d0e0e4736'));
+          sc.traceId.hexString,
+          equals('4bf92f3577b34da6a3ce929d0e0e4736'),
+        );
         expect(sc.spanId.hexString, equals('00f067aa0ba902b7'));
         expect(sc.traceFlags.isSampled, isTrue);
         expect(sc.isRemote, isTrue);
@@ -180,7 +186,9 @@ void main() {
         expect(sc, isNotNull);
         expect(sc!.isValid, isTrue);
         expect(
-            sc.traceId.hexString, equals('abcdef1234567890abcdef1234567890'));
+          sc.traceId.hexString,
+          equals('abcdef1234567890abcdef1234567890'),
+        );
         expect(sc.spanId.hexString, equals('1234567890abcdef'));
       });
     });
@@ -206,8 +214,11 @@ void main() {
 
         // Extract from carrier
         final mapGetter = MapTextMapGetter(carrier);
-        final extractedContext =
-            propagator.extract(OTel.context(), carrier, mapGetter);
+        final extractedContext = propagator.extract(
+          OTel.context(),
+          carrier,
+          mapGetter,
+        );
 
         // Verify roundtrip
         final sc = extractedContext.spanContext;

--- a/test/unit/trace/w3c_trace_context_propagator_test.dart
+++ b/test/unit/trace/w3c_trace_context_propagator_test.dart
@@ -38,7 +38,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -50,8 +50,10 @@ void main() {
         final spanContext = extracted.spanContext;
         expect(spanContext, isNotNull);
         expect(spanContext!.isValid, isTrue);
-        expect(spanContext.traceId.hexString,
-            equals('4bf92f3577b34da6a3ce929d0e0e4736'));
+        expect(
+          spanContext.traceId.hexString,
+          equals('4bf92f3577b34da6a3ce929d0e0e4736'),
+        );
         expect(spanContext.spanId.hexString, equals('00f067aa0ba902b7'));
         expect(spanContext.traceFlags.isSampled, isTrue);
         expect(spanContext.isRemote, isTrue);
@@ -62,7 +64,7 @@ void main() {
         final carrier = {
           'traceparent':
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'tracestate': 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'
+          'tracestate': 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -75,8 +77,10 @@ void main() {
         expect(spanContext, isNotNull);
         expect(spanContext!.traceState, isNotNull);
         expect(spanContext.traceState!.entries, hasLength(2));
-        expect(spanContext.traceState!.entries['rojo'],
-            equals('00f067aa0ba902b7'));
+        expect(
+          spanContext.traceState!.entries['rojo'],
+          equals('00f067aa0ba902b7'),
+        );
         expect(spanContext.traceState!.entries['congo'], equals('t61rcWkgMzE'));
       });
 
@@ -84,7 +88,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'
+              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -127,7 +131,7 @@ void main() {
       test('rejects traceparent with wrong length', () {
         // Arrange
         final carrier = {
-          'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7'
+          'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -142,7 +146,7 @@ void main() {
       test('rejects traceparent with wrong number of parts', () {
         // Arrange
         final carrier = {
-          'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7'
+          'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -158,7 +162,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+              '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -174,7 +178,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-00000000000000000000000000000000-00f067aa0ba902b7-01'
+              '00-00000000000000000000000000000000-00f067aa0ba902b7-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -190,7 +194,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'
+              '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -206,7 +210,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e473-00f067aa0ba902b7-01'
+              '00-4bf92f3577b34da6a3ce929d0e0e473-00f067aa0ba902b7-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -222,7 +226,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b-01'
+              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -238,7 +242,7 @@ void main() {
         // Arrange
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1'
+              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -255,7 +259,7 @@ void main() {
         final carrier = {
           'traceparent':
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'tracestate': 'invalid-format'
+          'tracestate': 'invalid-format',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -269,9 +273,10 @@ void main() {
         expect(spanContext!.isValid, isTrue);
         // Tracestate should be null or empty since it was malformed
         expect(
-            spanContext.traceState == null ||
-                spanContext.traceState!.entries.isEmpty,
-            isTrue);
+          spanContext.traceState == null ||
+              spanContext.traceState!.entries.isEmpty,
+          isTrue,
+        );
       });
 
       test('handles tracestate with empty entries', () {
@@ -279,7 +284,7 @@ void main() {
         final carrier = {
           'traceparent':
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'tracestate': 'key1=value1,,key2=value2'
+          'tracestate': 'key1=value1,,key2=value2',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -301,7 +306,7 @@ void main() {
         final carrier = {
           'traceparent':
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'tracestate': ' key1 = value1 , key2 = value2 '
+          'tracestate': ' key1 = value1 , key2 = value2 ',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -338,8 +343,10 @@ void main() {
         propagator.inject(context, carrier, setter);
 
         // Assert
-        expect(carrier['traceparent'],
-            equals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'));
+        expect(
+          carrier['traceparent'],
+          equals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'),
+        );
       });
 
       test('injects span context with tracestate', () {
@@ -347,8 +354,10 @@ void main() {
         final traceId = OTel.traceIdFrom('4bf92f3577b34da6a3ce929d0e0e4736');
         final spanId = OTel.spanIdFrom('00f067aa0ba902b7');
         final traceFlags = TraceFlags.sampled;
-        final traceState = OTel.traceState(
-            {'rojo': '00f067aa0ba902b7', 'congo': 't61rcWkgMzE'});
+        final traceState = OTel.traceState({
+          'rojo': '00f067aa0ba902b7',
+          'congo': 't61rcWkgMzE',
+        });
         final spanContext = OTel.spanContext(
           traceId: traceId,
           spanId: spanId,
@@ -366,11 +375,12 @@ void main() {
         expect(carrier['traceparent'], isNotNull);
         expect(carrier['tracestate'], isNotNull);
         expect(
-            carrier['tracestate'],
-            anyOf(
-              equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'),
-              equals('congo=t61rcWkgMzE,rojo=00f067aa0ba902b7'),
-            ));
+          carrier['tracestate'],
+          anyOf(
+            equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'),
+            equals('congo=t61rcWkgMzE,rojo=00f067aa0ba902b7'),
+          ),
+        );
       });
 
       test('injects non-sampled span context', () {
@@ -391,8 +401,10 @@ void main() {
         propagator.inject(context, carrier, setter);
 
         // Assert
-        expect(carrier['traceparent'],
-            equals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'));
+        expect(
+          carrier['traceparent'],
+          equals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00'),
+        );
       });
 
       test('does not inject invalid span context', () {
@@ -457,12 +469,15 @@ void main() {
     group('round-trip', () {
       test('can extract what was injected', () {
         // Arrange
-        final originalTraceId =
-            OTel.traceIdFrom('4bf92f3577b34da6a3ce929d0e0e4736');
+        final originalTraceId = OTel.traceIdFrom(
+          '4bf92f3577b34da6a3ce929d0e0e4736',
+        );
         final originalSpanId = OTel.spanIdFrom('00f067aa0ba902b7');
         final originalTraceFlags = TraceFlags.sampled;
-        final originalTraceState =
-            OTel.traceState({'vendor1': 'value1', 'vendor2': 'value2'});
+        final originalTraceState = OTel.traceState({
+          'vendor1': 'value1',
+          'vendor2': 'value2',
+        });
         final originalSpanContext = OTel.spanContext(
           traceId: originalTraceId,
           spanId: originalSpanId,
@@ -478,28 +493,40 @@ void main() {
         propagator.inject(originalContext, carrier, setter);
 
         // Act - Extract
-        final extractedContext =
-            propagator.extract(OTel.context(), carrier, getter);
+        final extractedContext = propagator.extract(
+          OTel.context(),
+          carrier,
+          getter,
+        );
 
         // Assert
         final extractedSpanContext = extractedContext.spanContext;
         expect(extractedSpanContext, isNotNull);
-        expect(extractedSpanContext!.traceId.hexString,
-            equals(originalTraceId.hexString));
-        expect(extractedSpanContext.spanId.hexString,
-            equals(originalSpanId.hexString));
-        expect(extractedSpanContext.traceFlags.isSampled,
-            equals(originalTraceFlags.isSampled));
+        expect(
+          extractedSpanContext!.traceId.hexString,
+          equals(originalTraceId.hexString),
+        );
+        expect(
+          extractedSpanContext.spanId.hexString,
+          equals(originalSpanId.hexString),
+        );
+        expect(
+          extractedSpanContext.traceFlags.isSampled,
+          equals(originalTraceFlags.isSampled),
+        );
         expect(extractedSpanContext.isRemote, isTrue);
         expect(extractedSpanContext.traceState, isNotNull);
-        expect(extractedSpanContext.traceState!.entries,
-            equals(originalTraceState.entries));
+        expect(
+          extractedSpanContext.traceState!.entries,
+          equals(originalTraceState.entries),
+        );
       });
 
       test('preserves trace context through multiple hops', () {
         // Arrange
-        final originalTraceId =
-            OTel.traceIdFrom('4bf92f3577b34da6a3ce929d0e0e4736');
+        final originalTraceId = OTel.traceIdFrom(
+          '4bf92f3577b34da6a3ce929d0e0e4736',
+        );
         final originalSpanId = OTel.spanIdFrom('00f067aa0ba902b7');
         final originalTraceFlags = TraceFlags.sampled;
         final originalSpanContext = OTel.spanContext(
@@ -533,8 +560,10 @@ void main() {
         // Assert - TraceId should be preserved through all hops
         final finalSpanContext = context3.spanContext;
         expect(finalSpanContext, isNotNull);
-        expect(finalSpanContext!.traceId.hexString,
-            equals(originalTraceId.hexString));
+        expect(
+          finalSpanContext!.traceId.hexString,
+          equals(originalTraceId.hexString),
+        );
         expect(finalSpanContext.isRemote, isTrue);
       });
     });
@@ -544,7 +573,7 @@ void main() {
         // Example from W3C spec
         final carrier = {
           'traceparent':
-              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+              '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();
@@ -560,7 +589,7 @@ void main() {
         // Smallest non-zero values
         final carrier = {
           'traceparent':
-              '00-00000000000000000000000000000001-0000000000000001-01'
+              '00-00000000000000000000000000000001-0000000000000001-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();

--- a/test/unit/util/otel_env_test.dart
+++ b/test/unit/util/otel_env_test.dart
@@ -95,7 +95,7 @@ void main() {
         LogLevel.info,
         LogLevel.warn,
         LogLevel.error,
-        LogLevel.fatal
+        LogLevel.fatal,
       ];
 
       for (final level in logLevels) {

--- a/test/unit/util/otel_log_test.dart
+++ b/test/unit/util/otel_log_test.dart
@@ -86,21 +86,25 @@ void main() {
       // Verify only the right messages are logged
       expect(logs.length, equals(4)); // info, warn, error, fatal
       expect(
-          logs.any(
-              (log) => log.contains('INFO') && log.contains('Info message')),
-          isTrue);
+        logs.any((log) => log.contains('INFO') && log.contains('Info message')),
+        isTrue,
+      );
       expect(
-          logs.any(
-              (log) => log.contains('WARN') && log.contains('Warn message')),
-          isTrue);
+        logs.any((log) => log.contains('WARN') && log.contains('Warn message')),
+        isTrue,
+      );
       expect(
-          logs.any(
-              (log) => log.contains('ERROR') && log.contains('Error message')),
-          isTrue);
+        logs.any(
+          (log) => log.contains('ERROR') && log.contains('Error message'),
+        ),
+        isTrue,
+      );
       expect(
-          logs.any(
-              (log) => log.contains('FATAL') && log.contains('Fatal message')),
-          isTrue);
+        logs.any(
+          (log) => log.contains('FATAL') && log.contains('Fatal message'),
+        ),
+        isTrue,
+      );
       expect(logs.any((log) => log.contains('TRACE')), isFalse);
       expect(logs.any((log) => log.contains('DEBUG')), isFalse);
     });
@@ -111,37 +115,43 @@ void main() {
       print('env var OTEL_LOG_LEVEL = $envLogLevel');
       expect(OTelLog.isTrace(), envLogLevel == 'trace');
       expect(
-          OTelLog.isDebug(), envLogLevel == 'trace' || envLogLevel == 'debug');
+        OTelLog.isDebug(),
+        envLogLevel == 'trace' || envLogLevel == 'debug',
+      );
       expect(
-          OTelLog.isInfo(),
-          envLogLevel == null ||
-              envLogLevel == 'trace' ||
-              envLogLevel == 'debug' ||
-              envLogLevel == 'info');
+        OTelLog.isInfo(),
+        envLogLevel == null ||
+            envLogLevel == 'trace' ||
+            envLogLevel == 'debug' ||
+            envLogLevel == 'info',
+      );
       expect(
-          OTelLog.isWarn(),
-          envLogLevel == null ||
-              envLogLevel == 'trace' ||
-              envLogLevel == 'debug' ||
-              envLogLevel == 'info' ||
-              envLogLevel == 'warn');
+        OTelLog.isWarn(),
+        envLogLevel == null ||
+            envLogLevel == 'trace' ||
+            envLogLevel == 'debug' ||
+            envLogLevel == 'info' ||
+            envLogLevel == 'warn',
+      );
       expect(
-          OTelLog.isError(),
-          envLogLevel == null ||
-              envLogLevel == 'trace' ||
-              envLogLevel == 'debug' ||
-              envLogLevel == 'info' ||
-              envLogLevel == 'warn' ||
-              envLogLevel == 'error');
+        OTelLog.isError(),
+        envLogLevel == null ||
+            envLogLevel == 'trace' ||
+            envLogLevel == 'debug' ||
+            envLogLevel == 'info' ||
+            envLogLevel == 'warn' ||
+            envLogLevel == 'error',
+      );
       expect(
-          OTelLog.isFatal(),
-          envLogLevel == null ||
-              envLogLevel == 'trace' ||
-              envLogLevel == 'debug' ||
-              envLogLevel == 'info' ||
-              envLogLevel == 'warn' ||
-              envLogLevel == 'error' ||
-              envLogLevel == 'fatal');
+        OTelLog.isFatal(),
+        envLogLevel == null ||
+            envLogLevel == 'trace' ||
+            envLogLevel == 'debug' ||
+            envLogLevel == 'info' ||
+            envLogLevel == 'warn' ||
+            envLogLevel == 'error' ||
+            envLogLevel == 'fatal',
+      );
 
       // Set log function but keep high level
       OTelLog.logFunction = (_) {};
@@ -176,8 +186,10 @@ void main() {
 
       // Verify format
       expect(logs.length, equals(1));
-      expect(logs.first,
-          matches(r'\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+\]')); // timestamp
+      expect(
+        logs.first,
+        matches(r'\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+\]'),
+      ); // timestamp
       expect(logs.first, contains('[INFO]'));
       expect(logs.first, contains('Direct log message'));
     });

--- a/test/unit/util/zip/gzip_test.dart
+++ b/test/unit/util/zip/gzip_test.dart
@@ -22,8 +22,9 @@ void main() {
 
       // Act
       final compressed = await gzip.compress(originalBytes);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
       final decompressedString = utf8.decode(decompressed);
 
       // Assert
@@ -40,8 +41,9 @@ void main() {
 
       // Act
       final compressed = await gzip.compress(emptyData);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Assert
       expect(decompressed, isEmpty);
@@ -53,8 +55,9 @@ void main() {
 
       // Act
       final compressed = await gzip.compress(smallData);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Assert
       expect(Uint8List.fromList(decompressed), equals(smallData));
@@ -62,13 +65,15 @@ void main() {
 
     test('should handle large data', () async {
       // Arrange
-      final largeData =
-          Uint8List.fromList(List.generate(100000, (i) => i % 256));
+      final largeData = Uint8List.fromList(
+        List.generate(100000, (i) => i % 256),
+      );
 
       // Act
       final compressed = await gzip.compress(largeData);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Assert
       expect(Uint8List.fromList(decompressed), equals(largeData));
@@ -78,13 +83,15 @@ void main() {
 
     test('should handle data with repetition efficiently', () async {
       // Arrange
-      final repeatedData =
-          Uint8List.fromList(List.filled(10000, 65)); // 'A' repeated
+      final repeatedData = Uint8List.fromList(
+        List.filled(10000, 65),
+      ); // 'A' repeated
 
       // Act
       final compressed = await gzip.compress(repeatedData);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Assert
       expect(Uint8List.fromList(decompressed), equals(repeatedData));
@@ -98,8 +105,9 @@ void main() {
 
       // Act
       final compressed = await gzip.compress(binaryData);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Assert
       expect(Uint8List.fromList(decompressed), equals(binaryData));
@@ -111,33 +119,34 @@ void main() {
         'resource': {
           'service.name': 'test-service',
           'service.version': '1.0.0',
-          'deployment.environment': 'test'
+          'deployment.environment': 'test',
         },
         'spans': List.generate(
-            100,
-            (i) => {
-                  'name': 'span-$i',
-                  'trace_id': '0123456789abcdef0123456789abcdef',
-                  'span_id': '0123456789abcdef',
-                  'parent_span_id': '',
-                  'start_time': '2025-01-01T00:00:00Z',
-                  'end_time': '2025-01-01T00:00:01Z',
-                  'attributes': {
-                    'http.method': 'GET',
-                    'http.url': 'https://example.com/api/items/$i',
-                    'http.status_code': 200
-                  },
-                  'events': [
-                    {
-                      'name': 'exception',
-                      'time': '2025-01-01T00:00:00.500Z',
-                      'attributes': {
-                        'exception.type': 'NotFoundException',
-                        'exception.message': 'Resource not found'
-                      }
-                    }
-                  ]
-                })
+          100,
+          (i) => {
+            'name': 'span-$i',
+            'trace_id': '0123456789abcdef0123456789abcdef',
+            'span_id': '0123456789abcdef',
+            'parent_span_id': '',
+            'start_time': '2025-01-01T00:00:00Z',
+            'end_time': '2025-01-01T00:00:01Z',
+            'attributes': {
+              'http.method': 'GET',
+              'http.url': 'https://example.com/api/items/$i',
+              'http.status_code': 200,
+            },
+            'events': [
+              {
+                'name': 'exception',
+                'time': '2025-01-01T00:00:00.500Z',
+                'attributes': {
+                  'exception.type': 'NotFoundException',
+                  'exception.message': 'Resource not found',
+                },
+              },
+            ],
+          },
+        ),
       };
 
       final jsonString = jsonEncode(jsonData);
@@ -145,8 +154,9 @@ void main() {
 
       // Act
       final compressed = await gzip.compress(jsonBytes);
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
       final decompressedJson = utf8.decode(decompressed);
 
       // Assert

--- a/test/web/util/zip/gzip_web_test.dart
+++ b/test/web/util/zip/gzip_web_test.dart
@@ -29,8 +29,9 @@ void main() {
       expect(compressed.length, isNot(equals(uint8Data.length)));
 
       // Decompress the data
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Convert back to string and verify
       final resultString = utf8.decode(decompressed);
@@ -44,8 +45,9 @@ void main() {
       final compressed = await gzip.compress(emptyData);
 
       // Decompress the data
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       expect(decompressed, isEmpty);
     });
@@ -64,26 +66,32 @@ void main() {
       expect(compressed.length, lessThan(largeData.length));
 
       // Decompress the data
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(compressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(compressed),
+      );
 
       // Verify that decompressed data matches the original
       expect(decompressed.length, equals(largeData.length));
       // Compare the contents
       for (var i = 0; i < largeData.length; i++) {
-        expect(decompressed[i], equals(largeData[i]),
-            reason: 'Byte at position $i doesn\'t match');
+        expect(
+          decompressed[i],
+          equals(largeData[i]),
+          reason: 'Byte at position $i doesn\'t match',
+        );
       }
     });
 
     test('decompresses pre-compressed data correctly', () async {
       // This is a gzip-compressed version of "OpenTelemetry test data"
       final preCompressed = base64Decode(
-          'H4sIAAAAAAAAA/NIzcnJVyjPL8pJUUjMS1FIKC1OLcpLzE1VyE3MzlQAAAbXZLQcAAAA');
+        'H4sIAAAAAAAAA/NIzcnJVyjPL8pJUUjMS1FIKC1OLcpLzE1VyE3MzlQAAAbXZLQcAAAA',
+      );
 
       // Decompress the data
-      final decompressed =
-          await gzip.decompress(Uint8List.fromList(preCompressed));
+      final decompressed = await gzip.decompress(
+        Uint8List.fromList(preCompressed),
+      );
 
       // Verify the decompressed content
       final resultString = utf8.decode(decompressed);

--- a/test_lambda_comparison.dart
+++ b/test_lambda_comparison.dart
@@ -1,10 +1,9 @@
 void main() {
-  Function noOp = (_) {};
-  Function? savedFunc = noOp;
+  void noOp(_) {}
+  final Function savedFunc = noOp;
 
   print('noOp is print: ${noOp == print}');
   print('noOp != print: ${noOp != print}');
   print('savedFunc is print: ${savedFunc == print}');
   print('savedFunc != print: ${savedFunc != print}');
-  print('noOp != null: ${noOp != null}');
 }

--- a/test_lambda_comparison.dart
+++ b/test_lambda_comparison.dart
@@ -1,0 +1,10 @@
+void main() {
+  Function noOp = (_) {};
+  Function? savedFunc = noOp;
+
+  print('noOp is print: ${noOp == print}');
+  print('noOp != print: ${noOp != print}');
+  print('savedFunc is print: ${savedFunc == print}');
+  print('savedFunc != print: ${savedFunc != print}');
+  print('noOp != null: ${noOp != null}');
+}

--- a/test_otel_log.dart
+++ b/test_otel_log.dart
@@ -1,0 +1,27 @@
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+void main() {
+  print('=== Initial State ===');
+  print('logFunction is print: ${OTelLog.logFunction == print}');
+  print('logFunction == null: ${OTelLog.logFunction == null}');
+  print('currentLevel: ${OTelLog.currentLevel}');
+  print('isDebug(): ${OTelLog.isDebug()}');
+
+  print('\n=== After setup ===');
+  final messages = <String>[];
+  OTelLog.logFunction = messages.add;
+  OTelLog.enableTraceLogging();
+
+  print('logFunction is messages.add: ${OTelLog.logFunction == messages.add}');
+  print('currentLevel: ${OTelLog.currentLevel}');
+  print('isDebug(): ${OTelLog.isDebug()}');
+
+  print('\n=== Calling debug ===');
+  OTelLog.debug('Test debug message');
+
+  print('Captured ${messages.length} messages');
+  if (messages.isNotEmpty) {
+    print('First message: "${messages[0]}"');
+  }
+}

--- a/tool/read_otel_config.dart
+++ b/tool/read_otel_config.dart
@@ -13,7 +13,8 @@ void main(List<String> args) {
     print('  service          - Get service config');
     print('  resource         - Get resource attributes');
     print(
-        '  otlp [signal]    - Get OTLP config for signal (traces, metrics, logs, or general)');
+      '  otlp [signal]    - Get OTLP config for signal (traces, metrics, logs, or general)',
+    );
     print('  headers [signal] - Get parsed headers for signal');
     return;
   }

--- a/tool/update_coverage_badge.sh
+++ b/tool/update_coverage_badge.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Reads coverage percentage from coverage/lcov.info and updates the README badge.
+# Run after tool/coverage.sh, before pushing.
+
+set -e
+
+LCOV_FILE="coverage/lcov.info"
+README="README.md"
+
+if [ ! -f "$LCOV_FILE" ]; then
+  echo "Error: $LCOV_FILE not found. Run tool/coverage.sh first."
+  exit 1
+fi
+
+# Extract coverage percentage from lcov summary
+COVERAGE=$(lcov --summary "$LCOV_FILE" 2>&1 | grep "lines\.\.\.\.\.\.\." | head -1 | sed 's/.*:\s*//' | sed 's/%.*//')
+
+if [ -z "$COVERAGE" ]; then
+  echo "Error: Could not parse coverage percentage from $LCOV_FILE"
+  exit 1
+fi
+
+# Round to integer
+COVERAGE_INT=$(printf "%.0f" "$COVERAGE")
+
+# Pick badge color based on coverage
+if [ "$COVERAGE_INT" -ge 90 ]; then
+  COLOR="brightgreen"
+elif [ "$COVERAGE_INT" -ge 80 ]; then
+  COLOR="green"
+elif [ "$COVERAGE_INT" -ge 70 ]; then
+  COLOR="yellowgreen"
+elif [ "$COVERAGE_INT" -ge 60 ]; then
+  COLOR="yellow"
+else
+  COLOR="red"
+fi
+
+# Build the new badge markdown
+BADGE="[![Coverage](https://img.shields.io/badge/coverage-${COVERAGE_INT}%25-${COLOR}.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)"
+
+# Replace the existing coverage badge line in README
+# Matches any line starting with [![Coverage
+sed -i '' "s|^\[!\[Coverage.*|${BADGE}|" "$README"
+
+echo "Updated README badge: ${COVERAGE_INT}% (${COLOR})"


### PR DESCRIPTION
Implements the OpenTelemetry Log Signal specification including:

- LoggerProvider and Logger with full emit() support
- SimpleLogRecordProcessor for immediate export
- BatchLogRecordProcessor with configurable batching
- ConsoleLogRecordExporter for debugging
- OTLP HTTP and gRPC log exporters
- LogRecordTransformer for OTLP protocol conversion
- DartLogBridge for dart:developer integration
- Print interception via logPrint flag in OTel.initialize()
  - Lazy initialization - bridge created on first use
  - runWithPrintInterception() and runWithPrintInterceptionAsync()
- Comprehensive test suite (14 test files, 100+ tests)

This is an initial attempt.  Needs review.
