### PR TITLE
fixes metric exporter test failuer

### DIFF
--- a/lib/src/metrics/metric_exporter.dart
+++ b/lib/src/metrics/metric_exporter.dart
@@ -5,8 +5,6 @@ import 'dart:async';
 
 import 'data/metric_data.dart';
 
-export '../export/export_result.dart';
-
 /// MetricExporter is responsible for sending metrics to a backend.
 abstract class MetricExporter {
   /// Export a batch of metrics to the backend.


### PR DESCRIPTION
Test HTTP server was sending a non-gRPC response, which caused the gRPC client to hang during HTTP/2 negotiation. Replaced with a TCP server that immediately closes the connection — triggers the same generic catch path but fails fast (~5s) instead of hanging.
