### PR TITLE
fix: SimpleLogRecordProcessor.shutdown() skips forceFlush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed SimpleLogRecordProcessor.shutdown() not flushing pending exports
+
 ## [1.0.1-alpha] - 2026-04-05
 - Added a BaggageSpanProcessor that adds Baggage as SpanAttributes
 

--- a/lib/src/logs/export/simple_log_record_processor.dart
+++ b/lib/src/logs/export/simple_log_record_processor.dart
@@ -73,10 +73,10 @@ class SimpleLogRecordProcessor implements LogRecordProcessor {
       return;
     }
 
-    _isShutdown = true;
-
-    // Flush any pending exports
+    // Flush before setting _isShutdown (forceFlush is a no-op after shutdown)
     await forceFlush();
+
+    _isShutdown = true;
 
     // Shutdown the exporter
     await exporter.shutdown();

--- a/test/unit/logs/export/simple_log_record_processor_test.dart
+++ b/test/unit/logs/export/simple_log_record_processor_test.dart
@@ -77,8 +77,13 @@ void main() {
 
     test('SimpleLogRecordProcessor forceFlush calls exporter forceFlush',
         () async {
-      // forceFlush should complete without error
-      await expectLater(processor.forceFlush(), completes);
+      final trackingExporter = _TrackingLogRecordExporter();
+      final trackingProcessor = SimpleLogRecordProcessor(trackingExporter);
+
+      await trackingProcessor.forceFlush();
+
+      expect(trackingExporter.forceFlushCallCount, equals(1));
+      expect(trackingExporter.shutdownCallCount, equals(0));
     });
 
     test('SimpleLogRecordProcessor handles export failure gracefully',
@@ -112,6 +117,21 @@ void main() {
 
       expect(exporter.count, equals(1));
     });
+
+    test('SimpleLogRecordProcessor shutdown forceFlushes before shutdown',
+        () async {
+      final trackingExporter = _TrackingLogRecordExporter();
+      final trackingProcessor = SimpleLogRecordProcessor(trackingExporter);
+
+      await trackingProcessor.shutdown();
+
+      expect(trackingExporter.forceFlushCallCount, equals(1));
+      expect(trackingExporter.shutdownCallCount, equals(1));
+      expect(
+        trackingExporter.events,
+        equals(const ['forceFlush', 'shutdown']),
+      );
+    });
   });
 }
 
@@ -127,4 +147,27 @@ class _FailingLogRecordExporter implements LogRecordExporter {
 
   @override
   Future<void> shutdown() async {}
+}
+
+class _TrackingLogRecordExporter implements LogRecordExporter {
+  final List<String> events = [];
+  int forceFlushCallCount = 0;
+  int shutdownCallCount = 0;
+
+  @override
+  Future<ExportResult> export(List<ReadableLogRecord> logRecords) async {
+    return ExportResult.success;
+  }
+
+  @override
+  Future<void> forceFlush() async {
+    forceFlushCallCount++;
+    events.add('forceFlush');
+  }
+
+  @override
+  Future<void> shutdown() async {
+    shutdownCallCount++;
+    events.add('shutdown');
+  }
 }


### PR DESCRIPTION
## Summary
`SimpleLogRecordProcessor.shutdown()` sets `_isShutdown = true` before
calling `forceFlush()`, but `forceFlush()` returns early when
`_isShutdown` is true — making the flush a no-op during shutdown.

The OTel spec requires that shutdown MUST include the effects of
ForceFlush. `BatchLogRecordProcessor` already handles this correctly
by flushing before setting the flag.

## Changes
- Reorder `shutdown()` to call `forceFlush()` before setting `_isShutdown`
- Add regression test verifying flush is called before shutdown
- Update CHANGELOG

## Spec reference
https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordprocessor

> Shutdown SHOULD provide a way to let the caller know whether it
> succeeded, failed or timed out. Shutdown MUST include the effects
> of ForceFlush.

## Test plan
- [x] `./tool/test.sh` — all tests pass (1 pre-existing failure unrelated to this change)
- [x] `dart analyze` — no issues
- [x] `dart format` — no changes needed
- [x] New regression test verifies `forceFlush` is called before `shutdown` on the exporter