### PR TITLE
fix: default OTLP endpoint to http://localhost:4318 (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [1.0.2-alpha] - 2026-04-19
 ### Fixed
-- Fixed SimpleLogRecordProcessor.shutdown() not flushing pending exports
+- Fixed `OTel.defaultEndpoint` to use the OTLP/HTTP port `4318` instead of the gRPC port `4317`,
+  matching the default `http/protobuf` protocol per the OpenTelemetry specification (#29).
+  Removed the conditional port-swap workarounds in trace and logs configuration.
+- Fixed `SimpleLogRecordProcessor.shutdown()` not flushing pending exports (#28).
+- Fixed flaky `OtlpGrpcLogRecordExporter endpoint empty host defaults to 127.0.0.1`
+  test that depended on no process listening on port 4317.
+
+### Changed
+- `MetricsConfiguration` now defaults to the HTTP/protobuf protocol (consistent with
+  the trace and logs pipelines and with the OpenTelemetry specification). Set
+  `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` (or
+  `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc`) to opt back into gRPC.
+
+### Added
+- Public `exporter` getter on `PeriodicExportingMetricReader` and `exporters`
+  getter on `CompositeMetricExporter` for introspection and testability.
 
 ## [1.0.1-alpha] - 2026-04-05
 - Added a BaggageSpanProcessor that adds Baggage as SpanAttributes

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ billions of customers.  Don't forget:
 Include this in your pubspec.yaml:
 ```
 dependencies:
-  dartastic_opentelemetry: ^1.0.0-alpha
+  dartastic_opentelemetry: ^1.0.2-alpha
 ```
 
 The entrypoint to the SDK is the `OTel` class.  `OTel` has static "factory" methods for all

--- a/lib/src/metrics/export/composite_metric_exporter.dart
+++ b/lib/src/metrics/export/composite_metric_exporter.dart
@@ -30,6 +30,9 @@ class CompositeMetricExporter implements MetricExporter {
   /// @param exporters The list of exporters to which operations will be delegated
   CompositeMetricExporter(this._exporters);
 
+  /// The delegate exporters this composite forwards to.
+  List<MetricExporter> get exporters => List.unmodifiable(_exporters);
+
   /// Exports metrics to all delegate exporters.
   ///
   /// This method forwards the export operation to each delegate exporter.

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -61,10 +61,9 @@ class MetricsConfiguration {
   static MetricExporter _createDefaultExporter(String endpoint, bool secure) {
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
     final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
-    final headers =
-        otlpConfig['headers'] as Map<String, String>? ?? const {};
-    final timeout = otlpConfig['timeout'] as Duration? ??
-        const Duration(seconds: 10);
+    final headers = otlpConfig['headers'] as Map<String, String>? ?? const {};
+    final timeout =
+        otlpConfig['timeout'] as Duration? ?? const Duration(seconds: 10);
     final compression = otlpConfig['compression'] == 'gzip';
     final certificate = otlpConfig['certificate'] as String?;
     final clientKey = otlpConfig['clientKey'] as String?;

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -1,12 +1,18 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    show OTelLog;
+
+import '../../environment/otel_env.dart';
 import '../../otel.dart';
 import '../../resource/resource.dart';
 import '../meter_provider.dart';
 import '../metric_exporter.dart';
 import '../metric_reader.dart';
 import 'composite_metric_exporter.dart';
+import 'otlp/http/otlp_http_metric_exporter.dart';
+import 'otlp/http/otlp_http_metric_exporter_config.dart';
 import 'otlp/otlp_grpc_metric_exporter.dart';
 import 'otlp/otlp_grpc_metric_exporter_config.dart';
 
@@ -15,11 +21,13 @@ class MetricsConfiguration {
   /// Configures a MeterProvider with given settings.
   ///
   /// This configures everything needed for metrics pipeline:
-  /// - An exporter (defaults to OtlpGrpcMetricExporter if none provided)
+  /// - An exporter (defaults to OtlpHttpMetricExporter using http/protobuf,
+  ///   the OTel spec default; selects gRPC when OTEL_EXPORTER_OTLP_PROTOCOL
+  ///   or OTEL_EXPORTER_OTLP_METRICS_PROTOCOL is set to `grpc`)
   /// - A reader (defaults to PeriodicExportingMetricReader if none provided)
   /// - Sets up resources on the MeterProvider
   static MeterProvider configureMeterProvider({
-    String endpoint = 'http://localhost:4317',
+    String endpoint = 'http://localhost:4318',
     bool secure = false,
     MetricExporter? metricExporter,
     MetricReader? metricReader,
@@ -48,16 +56,55 @@ class MetricsConfiguration {
     return meterProvider;
   }
 
-  /// Creates the default metric exporter.
+  /// Creates the default metric exporter using the protocol indicated by
+  /// the OTel environment variables (defaulting to http/protobuf per spec).
   static MetricExporter _createDefaultExporter(String endpoint, bool secure) {
-    // Configure the OTLP gRPC exporter
-    final otlpExporter = OtlpGrpcMetricExporter(
-      OtlpGrpcMetricExporterConfig(
-        endpoint: endpoint,
-        insecure: !secure,
-        timeoutMillis: 10000,
-      ),
-    );
+    final otlpConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
+    final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
+    final headers =
+        otlpConfig['headers'] as Map<String, String>? ?? const {};
+    final timeout = otlpConfig['timeout'] as Duration? ??
+        const Duration(seconds: 10);
+    final compression = otlpConfig['compression'] == 'gzip';
+    final certificate = otlpConfig['certificate'] as String?;
+    final clientKey = otlpConfig['clientKey'] as String?;
+    final clientCertificate = otlpConfig['clientCertificate'] as String?;
+
+    final MetricExporter otlpExporter;
+    if (protocol == 'grpc') {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'MetricsConfiguration: Creating OtlpGrpcMetricExporter for $endpoint');
+      }
+      otlpExporter = OtlpGrpcMetricExporter(
+        OtlpGrpcMetricExporterConfig(
+          endpoint: endpoint,
+          insecure: !secure,
+          headers: headers,
+          timeoutMillis: timeout.inMilliseconds,
+          compression: compression,
+          certificate: certificate,
+          clientKey: clientKey,
+          clientCertificate: clientCertificate,
+        ),
+      );
+    } else {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'MetricsConfiguration: Creating OtlpHttpMetricExporter for $endpoint');
+      }
+      otlpExporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: endpoint,
+          headers: headers,
+          timeout: timeout,
+          compression: compression,
+          certificate: certificate,
+          clientKey: clientKey,
+          clientCertificate: clientCertificate,
+        ),
+      );
+    }
 
     // Use a composite exporter for both OTLP and Console output
     return CompositeMetricExporter([otlpExporter, ConsoleMetricExporter()]);

--- a/lib/src/metrics/metric_reader.dart
+++ b/lib/src/metrics/metric_reader.dart
@@ -49,6 +49,9 @@ class PeriodicExportingMetricReader extends MetricReader {
   /// The exporter to send metrics to.
   final MetricExporter _exporter;
 
+  /// The configured exporter that this reader sends metrics to.
+  MetricExporter get exporter => _exporter;
+
   /// How often to collect and export metrics.
   final Duration _interval;
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -64,8 +64,12 @@ class OTel {
   /// Default service name used if none is provided.
   static const defaultServiceName = "@dart/dartastic_opentelemetry";
 
-  /// Default OTEL endpoint
-  static const defaultEndpoint = "http://localhost:4317";
+  /// Default OTEL endpoint.
+  ///
+  /// Defaults to the OTLP/HTTP port (4318) since http/protobuf is the default
+  /// protocol per the OpenTelemetry specification. When using gRPC, override
+  /// this with port 4317.
+  static const defaultEndpoint = "http://localhost:4318";
 
   /// Default tracer name used if none is provided.
   static const String _defaultTracerName = 'dartastic';
@@ -85,7 +89,7 @@ class OTel {
   /// OTEL_CONSOLE_EXPORTER is set to true, a ConsoleExporter is added to the
   /// exports to print spans.
   ///
-  /// @param endpoint The endpoint URL for the OpenTelemetry collector (default: http://localhost:4317)
+  /// @param endpoint The endpoint URL for the OpenTelemetry collector (default: http://localhost:4318)
   /// @param secure Whether to use TLS for the connection (default: true)
   /// @param serviceName Name that uniquely identifies the service (default: "@dart/dartastic_opentelemetry")
   /// @param serviceVersion Version of the service (defaults to the OTel spec version)
@@ -363,14 +367,9 @@ class OTel {
             );
           } else {
             // Default to http/protobuf
-            // For HTTP, adjust endpoint if it's the gRPC default
-            String httpEndpoint = endpoint;
-            if (endpoint == defaultEndpoint) {
-              httpEndpoint = 'http://localhost:4318';
-            }
             exporter = OtlpHttpSpanExporter(
               OtlpHttpExporterConfig(
-                endpoint: httpEndpoint,
+                endpoint: endpoint,
                 headers:
                     otlpConfigForExporter['headers'] as Map<String, String>? ??
                         {},
@@ -441,13 +440,8 @@ class OTel {
 
     // Configure logs if enabled
     if (enableLogs) {
-      // For HTTP, adjust endpoint if it's the gRPC default
-      String logsEndpoint = endpoint;
-      if (endpoint == defaultEndpoint) {
-        logsEndpoint = 'http://localhost:4318';
-      }
       LogsConfiguration.configureLoggerProvider(
-        endpoint: logsEndpoint,
+        endpoint: endpoint,
         secure: secure,
         logRecordExporter: logRecordExporter,
         logRecordProcessor: logRecordProcessor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartastic_opentelemetry
 description: OpenTelemetry SDK for Dart and Flutter. Distributed tracing, metrics, OTLP exporters (gRPC/HTTP),
   and context propagation for observability backends.
-version: 1.0.1-alpha
+version: 1.0.2-alpha
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry.git
 homepage: https://dartastic.io
 

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
@@ -1397,14 +1397,20 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // Endpoint without port gets default 4317
-    // (testing the _setupChannel parsing)
+    // Endpoint with empty host falls back to 127.0.0.1 (testing the
+    // _setupChannel parsing path). Uses a real local server bound to an
+    // OS-assigned port so the assertion does not depend on whether port 4317
+    // is occupied by some other process (e.g. a local Docker collector).
     // -----------------------------------------------------------------------
     test('endpoint empty host defaults to 127.0.0.1', () async {
-      // This exercises the empty host fallback in _setupChannel
+      final service = SuccessLogsService();
+      final server = Server.create(services: [service]);
+      await server.serve(port: 0);
+      final port = server.port!;
+
       final exporter = OtlpGrpcLogRecordExporter(
         OtlpGrpcLogRecordExporterConfig(
-          endpoint: ':4317',
+          endpoint: ':$port',
           insecure: true,
           maxRetries: 0,
           baseDelay: const Duration(milliseconds: 1),
@@ -1413,11 +1419,14 @@ void main() {
       );
 
       final logRecord = _createTestLogRecord();
-      // This will fail to connect but exercises the host parsing path
+      // The exporter must rewrite the empty host to 127.0.0.1 and reach the
+      // local server, so the export should succeed.
       final result = await exporter.export([logRecord]);
-      expect(result, equals(ExportResult.failure));
+      expect(result, equals(ExportResult.success));
+      expect(service.callCount, greaterThanOrEqualTo(1));
 
       await exporter.shutdown();
+      await server.shutdown();
     });
 
     // -----------------------------------------------------------------------

--- a/test/unit/otel_default_endpoint_test.dart
+++ b/test/unit/otel_default_endpoint_test.dart
@@ -16,7 +16,8 @@ void main() {
       expect(OTel.defaultEndpoint, equals('http://localhost:4318'));
     });
 
-    test('default trace exporter targets port 4318 when no endpoint is supplied',
+    test(
+        'default trace exporter targets port 4318 when no endpoint is supplied',
         () async {
       await OTel.initialize(serviceName: 'default-endpoint-test');
       try {
@@ -38,7 +39,8 @@ void main() {
       }
     });
 
-    test('default metric exporter targets port 4318 over HTTP when no endpoint is supplied',
+    test(
+        'default metric exporter targets port 4318 over HTTP when no endpoint is supplied',
         () async {
       await OTel.initialize(serviceName: 'default-endpoint-test-metrics');
       try {

--- a/test/unit/otel_default_endpoint_test.dart
+++ b/test/unit/otel_default_endpoint_test.dart
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+/// Regression tests for https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/issues/29
+///
+/// The default OTLP protocol is http/protobuf, so [OTel.defaultEndpoint] must
+/// point at the OTLP/HTTP port (4318), not the OTLP/gRPC port (4317). When no
+/// endpoint is supplied to [OTel.initialize], the resulting exporter must
+/// target 4318 directly without any port-swap workaround.
+void main() {
+  group('OTel.defaultEndpoint (issue #29)', () {
+    test('targets the OTLP/HTTP port (4318)', () {
+      expect(OTel.defaultEndpoint, equals('http://localhost:4318'));
+    });
+
+    test('default trace exporter targets port 4318 when no endpoint is supplied',
+        () async {
+      await OTel.initialize(serviceName: 'default-endpoint-test');
+      try {
+        final processors = OTel.tracerProvider().spanProcessors;
+        expect(processors, isNotEmpty,
+            reason: 'OTel.initialize should add a default span processor');
+
+        final batch = processors.whereType<BatchSpanProcessor>().firstOrNull;
+        expect(batch, isNotNull,
+            reason:
+                'Expected a BatchSpanProcessor; got ${processors.map((p) => p.runtimeType).toList()}');
+
+        final exporter = batch!.exporter;
+        expect(exporter, isA<OtlpHttpSpanExporter>(),
+            reason:
+                'Default protocol is http/protobuf, so the default exporter must be HTTP, not gRPC');
+      } finally {
+        await OTel.reset();
+      }
+    });
+
+    test('default metric exporter targets port 4318 over HTTP when no endpoint is supplied',
+        () async {
+      await OTel.initialize(serviceName: 'default-endpoint-test-metrics');
+      try {
+        final readers = OTel.meterProvider().metricReaders;
+        expect(readers, isNotEmpty,
+            reason: 'OTel.initialize should add a default metric reader');
+
+        final periodic =
+            readers.whereType<PeriodicExportingMetricReader>().firstOrNull;
+        expect(periodic, isNotNull,
+            reason:
+                'Expected a PeriodicExportingMetricReader; got ${readers.map((r) => r.runtimeType).toList()}');
+
+        final exporter = periodic!.exporter;
+        // Drill through composite to find the OTLP exporter.
+        final otlp = exporter is CompositeMetricExporter
+            ? exporter.exporters.firstWhere(
+                (e) =>
+                    e is OtlpHttpMetricExporter || e is OtlpGrpcMetricExporter,
+                orElse: () => throw StateError(
+                    'No OTLP exporter found in composite: ${exporter.exporters.map((e) => e.runtimeType).toList()}'),
+              )
+            : exporter;
+
+        expect(otlp, isA<OtlpHttpMetricExporter>(),
+            reason:
+                'Default protocol is http/protobuf, so the default metric exporter must be HTTP (port 4318), not gRPC (port 4317)');
+      } finally {
+        await OTel.reset();
+      }
+    });
+  });
+}


### PR DESCRIPTION
The default protocol is http/protobuf per the OTel spec, so the default endpoint port must be 4318, not the gRPC port 4317. Removes the conditional port-swap workarounds in trace and logs configuration.

Cascade: makes MetricsConfiguration protocol-aware (HTTP/protobuf default, like traces and logs) so the new default endpoint reaches the right port. Set OTEL_EXPORTER_OTLP_PROTOCOL=grpc (or OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc) to opt back into gRPC.

Also includes:
- Fixes flaky `endpoint empty host defaults to 127.0.0.1` test that asserted connection failure on :4317; now uses a real local server on an OS-assigned port.
- Adds `exporter` getter on PeriodicExportingMetricReader and `exporters` getter on CompositeMetricExporter for introspection / testability.
- Bumps to 1.0.2-alpha; CHANGELOG also rolls in the SimpleLogRecordProcessor shutdown fix from #28.