### PR TITLE
chore: bump dartastic_opentelemetry_api to ^1.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.1-wip]
 
+### Changed
+- Bumped `dartastic_opentelemetry_api` to `^1.0.0-beta.3`. Beta.3 fixes a `ServiceResource` semconv key that was mangled by an over-broad find/replace: the entry called `ServiceResource.serviceResourcepace` (with key `service.Resourcepace`) is restored to `ServiceResource.serviceNamespace` / `service.namespace`. If you used the misspelled name in your own code, replace it with `ServiceResource.serviceNamespace`.
+
 ## [1.1.0-beta] - 2026-05-07
 
 ### Changed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-beta.2
+  dartastic_opentelemetry_api: ^1.0.0-beta.3
   fixnum: ^1.1.1
   grpc: ^5.1.0
   http: ^1.5.0


### PR DESCRIPTION
## Summary

Bumps the API dependency from `^1.0.0-beta.2` to `^1.0.0-beta.3`. Beta.3 of the API restores `ServiceResource.serviceNamespace` (`service.namespace`), which beta.2 had mangled to `serviceResourcepace` via an over-broad find/replace.

The SDK doesn't reference the mangled name anywhere in its tree (grep-confirmed), so this is a transitive consumer fix; the bump just ensures `dart pub get` resolves to the corrected API.

## Test plan

- [x] `dart pub get` resolves to API 1.0.0-beta.3.
- [x] `dart analyze` is clean.
- [ ] `tool/test.sh` passes (collector-backed suite — run locally before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)