### PR TITLE
docs: switch examples + README to attributesFromSemanticMap shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.2-wip]
 
+### Added
+- `OTel.attributesFromSemanticMap(Map<OTelSemantic, Object>)` — convenience passthrough to `OTelAPI.attributesFromSemanticMap`. Lets call sites that build attribute maps from typed semconv enums skip the `.key` accessor on every entry: `OTel.attributesFromSemanticMap({HttpResource.requestMethod: 'GET'})` instead of `OTel.attributesFromMap({HttpResource.requestMethod.key: 'GET'})`. Mixing different semconv enum types in one map is fine — the param type is the `OTelSemantic` interface that every semconv enum implements.
+
+### Changed
+- README and every example under `example/` now use `attributesFromSemanticMap` for typed-enum-keyed maps. The longer `attributesFromMap` form remains for raw-string-keyed maps (`{'foo.bar': value}`) and shows up in the README only as a counter-example for app-specific keys without a typed enum.
+
 ## [1.1.0-beta.1] - 2026-05-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ try {
     'database.query',
     kind: SpanKind.client,
     context: OTel.context(spanContext: parentSpan.spanContext),
-    attributes: OTel.attributesFromMap({
-      DatabaseResource.dbSystem.key: 'postgresql',
-      DatabaseResource.dbOperation.key: 'SELECT',
+    attributes: OTel.attributesFromSemanticMap({
+      DatabaseResource.dbSystem: 'postgresql',
+      DatabaseResource.dbOperation: 'SELECT',
     }),
   );
   try {
@@ -350,17 +350,17 @@ final span = tracer.startSpan('operation', attributes: OTel.attributes([
 
 // Or from a map (types are inferred automatically).
 final span = tracer.startSpan('operation',
-  attributes: OTel.attributesFromMap({
-    HttpResource.requestMethod.key: 'GET',
-    HttpResource.responseStatusCode.key: 200,
+  attributes: OTel.attributesFromSemanticMap({
+    HttpResource.requestMethod: 'GET',
+    HttpResource.responseStatusCode: 200,
   }),
 );
 
 // Add attributes after creation.
 span.setStringAttribute(UrlResource.urlFull.key, 'https://api.example.com/data');
 span.setIntAttribute(HttpResource.responseBodySize.key, 1024);
-span.addAttributes(OTel.attributesFromMap({
-  ExampleAttribute.processingStage.key: 'complete',
+span.addAttributes(OTel.attributesFromSemanticMap({
+  ExampleAttribute.processingStage: 'complete',
 }));
 ```
 
@@ -372,7 +372,7 @@ but event attributes still benefit from typed enum keys:
 ```dart
 span.addEvent(OTel.spanEventNow(
   'cache.hit',
-  OTel.attributesFromMap({ExampleAttribute.cacheKey.key: 'user:123'}),
+  OTel.attributesFromSemanticMap({ExampleAttribute.cacheKey: 'user:123'}),
 ));
 
 span.addEventNow('validation.passed');
@@ -385,7 +385,7 @@ Links connect spans across traces — useful for batch processing or fan-out pat
 ```dart
 final link = OTel.spanLink(
   otherSpan.spanContext,
-  attributes: OTel.attributesFromMap({ExampleAttribute.linkType.key: 'triggers'}),
+  attributes: OTel.attributesFromSemanticMap({ExampleAttribute.linkType: 'triggers'}),
 );
 
 final span = tracer.startSpan('batch-process', links: [link]);
@@ -636,9 +636,9 @@ void main() async {
   logger.emit(
     body: 'User logged in',
     severityNumber: Severity.INFO,
-    attributes: OTel.attributesFromMap({
-      UserSemantics.userId.key: 'user123',
-      UserSemantics.userRole.key: 'admin',
+    attributes: OTel.attributesFromSemanticMap({
+      UserSemantics.userId: 'user123',
+      UserSemantics.userRole: 'admin',
     }),
   );
 
@@ -649,9 +649,9 @@ void main() async {
     logger.emit(
       body: 'Operation failed: $e',
       severityNumber: Severity.ERROR,
-      attributes: OTel.attributesFromMap({
-        ExceptionResource.exceptionType.key: e.runtimeType.toString(),
-        ExceptionResource.exceptionStacktrace.key: stackTrace.toString(),
+      attributes: OTel.attributesFromSemanticMap({
+        ExceptionResource.exceptionType: e.runtimeType.toString(),
+        ExceptionResource.exceptionStacktrace: stackTrace.toString(),
       }),
     );
   }
@@ -704,9 +704,9 @@ final logger = OTel.loggerProvider().getLogger('my-service');
 logger.emit(
   severityNumber: Severity.INFO,
   body: 'User successfully logged in.',
-  attributes: OTel.attributesFromMap({
-    UserSemantics.userId.key: 'user-123',
-    ExampleAttribute.authMethod.key: 'oauth',
+  attributes: OTel.attributesFromSemanticMap({
+    UserSemantics.userId: 'user-123',
+    ExampleAttribute.authMethod: 'oauth',
   }),
 );
 
@@ -714,9 +714,9 @@ logger.emit(
 logger.emit(
   severityNumber: Severity.WARN,
   body: 'Cache miss for requested key.',
-  attributes: OTel.attributesFromMap({
-    ExampleAttribute.cacheKey.key: 'profile_42',
-    ExampleAttribute.cacheRegion.key: 'us-east-1',
+  attributes: OTel.attributesFromSemanticMap({
+    ExampleAttribute.cacheKey: 'profile_42',
+    ExampleAttribute.cacheRegion: 'us-east-1',
   }),
 );
 
@@ -724,9 +724,9 @@ logger.emit(
 logger.emit(
   severityNumber: Severity.ERROR,
   body: 'Failed to connect to database.',
-  attributes: OTel.attributesFromMap({
-    DatabaseResource.dbSystem.key: 'postgresql',
-    ErrorSemantics.errorType.key: 'ConnectionTimeout',
+  attributes: OTel.attributesFromSemanticMap({
+    DatabaseResource.dbSystem: 'postgresql',
+    ErrorSemantics.errorType: 'ConnectionTimeout',
   }),
 );
 ```
@@ -742,7 +742,7 @@ try {
     severityNumber: Severity.INFO,
     body: 'Processing order.',
     context: Context.current, // Links this log to the active span
-    attributes: OTel.attributesFromMap({ExampleAttribute.orderId.key: 'order-789'}),
+    attributes: OTel.attributesFromSemanticMap({ExampleAttribute.orderId: 'order-789'}),
   );
   await processOrder();
 } finally {

--- a/example/console_exporter_sanity_check.dart
+++ b/example/console_exporter_sanity_check.dart
@@ -41,11 +41,11 @@ Future<void> main(List<String> arguments) async {
   final rootSpan = tracer.startSpan(
     'root-operation',
     kind: SpanKind.producer,
-    attributes: OTel.attributesFromMap({
-      DemoAttribute.magicNumber.key: 42,
-      DemoAttribute.canUseBoolean.key: true,
-      DemoAttribute.intList.key: [42, 143],
-      DemoAttribute.doubleList.key: [42.1, 143.4],
+    attributes: OTel.attributesFromSemanticMap({
+      DemoAttribute.magicNumber: 42,
+      DemoAttribute.canUseBoolean: true,
+      DemoAttribute.intList: [42, 143],
+      DemoAttribute.doubleList: [42.1, 143.4],
     }),
   );
 
@@ -54,8 +54,9 @@ Future<void> main(List<String> arguments) async {
     importantFunction();
     rootSpan.addEventNow(
       'importantFunction completed',
-      // attributesFromMap can throw with bad types — OTel has typesafe
-      // attribute methods (used here) which avoid that risk.
+      // attributesFromSemanticMap / attributesFromMap can throw with
+      // bad types — OTel has typesafe attribute factories (used here)
+      // which avoid that risk.
       OTel.attributes([
         OTel.attributeString(DemoAttribute.eventFoo.key, 'bar'),
         OTel.attributeBool(DemoAttribute.eventBaz.key, true),

--- a/example/example.dart
+++ b/example/example.dart
@@ -50,9 +50,9 @@ Future<void> main() async {
   final parentSpan = tracer.startSpan(
     'main-operation',
     kind: SpanKind.server,
-    attributes: OTel.attributesFromMap({
-      UserSemantics.userId.key: 'user-123',
-      ExampleSemantics.requestType.key: 'example',
+    attributes: OTel.attributesFromSemanticMap({
+      UserSemantics.userId: 'user-123',
+      ExampleSemantics.requestType: 'example',
     }),
   );
 
@@ -65,7 +65,7 @@ Future<void> main() async {
     parentSpan.addEvent(
       OTel.spanEventNow(
         'operation.completed',
-        OTel.attributesFromMap({ExampleSemantics.itemsProcessed.key: 42}),
+        OTel.attributesFromSemanticMap({ExampleSemantics.itemsProcessed: 42}),
       ),
     );
   } catch (e, stackTrace) {
@@ -89,10 +89,10 @@ Future<void> performDatabaseQuery(Tracer tracer, Span parentSpan) async {
     kind: SpanKind.client,
     // Link to parent span via context
     context: OTel.context(spanContext: parentSpan.spanContext),
-    attributes: OTel.attributesFromMap({
-      DatabaseResource.dbSystem.key: 'postgresql',
-      DatabaseResource.dbOperation.key: 'SELECT',
-      DatabaseResource.dbName.key: 'users',
+    attributes: OTel.attributesFromSemanticMap({
+      DatabaseResource.dbSystem: 'postgresql',
+      DatabaseResource.dbOperation: 'SELECT',
+      DatabaseResource.dbName: 'users',
     }),
   );
 
@@ -116,10 +116,10 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
     'http.request',
     kind: SpanKind.client,
     context: OTel.context(spanContext: parentSpan.spanContext),
-    attributes: OTel.attributesFromMap({
-      HttpResource.requestMethod.key: 'GET',
-      UrlResource.urlFull.key: 'https://api.example.com/data',
-      UrlResource.urlPath.key: '/data',
+    attributes: OTel.attributesFromSemanticMap({
+      HttpResource.requestMethod: 'GET',
+      UrlResource.urlFull: 'https://api.example.com/data',
+      UrlResource.urlPath: '/data',
     }),
   );
 
@@ -129,9 +129,9 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
 
     // Add response attributes.
     span.addAttributes(
-      OTel.attributesFromMap({
-        HttpResource.responseStatusCode.key: 200,
-        HttpResource.responseBodySize.key: 1024,
+      OTel.attributesFromSemanticMap({
+        HttpResource.responseStatusCode: 200,
+        HttpResource.responseBodySize: 1024,
       }),
     );
   } catch (e, stackTrace) {

--- a/example/grafana/grafana_cloud_env_example.dart
+++ b/example/grafana/grafana_cloud_env_example.dart
@@ -84,11 +84,11 @@ Future<void> traceUserLogin(Tracer tracer, String userId) async {
   final span = tracer.startSpan(
     'user.login',
     kind: SpanKind.server,
-    attributes: OTel.attributesFromMap({
-      UserSemantics.userId.key: userId,
-      ExampleAttribute.authMethod.key: 'oauth2',
+    attributes: OTel.attributesFromSemanticMap({
+      UserSemantics.userId: userId,
+      ExampleAttribute.authMethod: 'oauth2',
       // client.address replaces the deprecated client.ip per OTel semconv.
-      ClientResource.clientAddress.key: '192.168.1.100',
+      ClientResource.clientAddress: '192.168.1.100',
     }),
   );
 
@@ -100,10 +100,10 @@ Future<void> traceUserLogin(Tracer tracer, String userId) async {
     span.addEvent(
       OTel.spanEventNow(
         'authentication.success',
-        OTel.attributesFromMap({
-          SessionViewSemantics.sessionId.key:
+        OTel.attributesFromSemanticMap({
+          SessionViewSemantics.sessionId:
               'sess_${DateTime.now().millisecondsSinceEpoch}',
-          ExampleAttribute.permissions.key: 'read,write',
+          ExampleAttribute.permissions: 'read,write',
         }),
       ),
     );
@@ -123,12 +123,12 @@ Future<void> traceHttpRequest(Tracer tracer) async {
   final span = tracer.startSpan(
     'http.request',
     kind: SpanKind.client,
-    attributes: OTel.attributesFromMap({
-      HttpResource.requestMethod.key: 'GET',
-      UrlResource.urlFull.key: 'https://api.example.com/users/123',
-      UrlResource.urlPath.key: '/users/123',
-      ServerResource.serverAddress.key: 'api.example.com',
-      ServerResource.serverPort.key: 443,
+    attributes: OTel.attributesFromSemanticMap({
+      HttpResource.requestMethod: 'GET',
+      UrlResource.urlFull: 'https://api.example.com/users/123',
+      UrlResource.urlPath: '/users/123',
+      ServerResource.serverAddress: 'api.example.com',
+      ServerResource.serverPort: 443,
     }),
   );
 
@@ -138,14 +138,14 @@ Future<void> traceHttpRequest(Tracer tracer) async {
 
     // Set response attributes.
     span.addAttributes(
-      OTel.attributesFromMap({
-        HttpResource.responseStatusCode.key: 200,
-        HttpResource.responseBodySize.key: 1234,
+      OTel.attributesFromSemanticMap({
+        HttpResource.responseStatusCode: 200,
+        HttpResource.responseBodySize: 1234,
       }),
     );
   } catch (e, stackTrace) {
     span.addAttributes(
-        OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
+        OTel.attributesFromSemanticMap({HttpResource.responseStatusCode: 500}));
     // The span has a status of SpanStatus.Ok on creation, set it to
     // Error when an error occurs in the span.
     span.recordException(e, stackTrace: stackTrace);
@@ -161,17 +161,17 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
   final span = tracer.startSpan(
     'db.query',
     kind: SpanKind.client,
-    attributes: OTel.attributesFromMap({
-      DatabaseResource.dbSystem.key: 'postgresql',
-      DatabaseResource.dbName.key: 'users_db',
-      DatabaseResource.dbOperation.key: 'SELECT',
-      DatabaseResource.dbStatement.key:
+    attributes: OTel.attributesFromSemanticMap({
+      DatabaseResource.dbSystem: 'postgresql',
+      DatabaseResource.dbName: 'users_db',
+      DatabaseResource.dbOperation: 'SELECT',
+      DatabaseResource.dbStatement:
           'SELECT * FROM users WHERE active = true LIMIT 100',
-      DatabaseResource.dbUser.key: 'app_user',
+      DatabaseResource.dbUser: 'app_user',
       // server.address / server.port replace the deprecated net.peer.*
       // per OTel semconv.
-      ServerResource.serverAddress.key: 'postgres.example.com',
-      ServerResource.serverPort.key: 5432,
+      ServerResource.serverAddress: 'postgres.example.com',
+      ServerResource.serverPort: 5432,
     }),
   );
 

--- a/example/grafana_cloud_env_example.dart
+++ b/example/grafana_cloud_env_example.dart
@@ -84,11 +84,11 @@ Future<void> traceUserLogin(Tracer tracer, String userId) async {
   final span = tracer.startSpan(
     'user.login',
     kind: SpanKind.server,
-    attributes: OTel.attributesFromMap({
-      UserSemantics.userId.key: userId,
-      ExampleAttribute.authMethod.key: 'oauth2',
+    attributes: OTel.attributesFromSemanticMap({
+      UserSemantics.userId: userId,
+      ExampleAttribute.authMethod: 'oauth2',
       // client.address replaces the deprecated client.ip per OTel semconv.
-      ClientResource.clientAddress.key: '192.168.1.100',
+      ClientResource.clientAddress: '192.168.1.100',
     }),
   );
 
@@ -100,10 +100,10 @@ Future<void> traceUserLogin(Tracer tracer, String userId) async {
     span.addEvent(
       OTel.spanEventNow(
         'authentication.success',
-        OTel.attributesFromMap({
-          SessionViewSemantics.sessionId.key:
+        OTel.attributesFromSemanticMap({
+          SessionViewSemantics.sessionId:
               'sess_${DateTime.now().millisecondsSinceEpoch}',
-          ExampleAttribute.permissions.key: 'read,write',
+          ExampleAttribute.permissions: 'read,write',
         }),
       ),
     );
@@ -123,12 +123,12 @@ Future<void> traceHttpRequest(Tracer tracer) async {
   final span = tracer.startSpan(
     'http.request',
     kind: SpanKind.client,
-    attributes: OTel.attributesFromMap({
-      HttpResource.requestMethod.key: 'GET',
-      UrlResource.urlFull.key: 'https://api.example.com/users/123',
-      UrlResource.urlPath.key: '/users/123',
-      ServerResource.serverAddress.key: 'api.example.com',
-      ServerResource.serverPort.key: 443,
+    attributes: OTel.attributesFromSemanticMap({
+      HttpResource.requestMethod: 'GET',
+      UrlResource.urlFull: 'https://api.example.com/users/123',
+      UrlResource.urlPath: '/users/123',
+      ServerResource.serverAddress: 'api.example.com',
+      ServerResource.serverPort: 443,
     }),
   );
 
@@ -138,14 +138,14 @@ Future<void> traceHttpRequest(Tracer tracer) async {
 
     // Set response attributes.
     span.addAttributes(
-      OTel.attributesFromMap({
-        HttpResource.responseStatusCode.key: 200,
-        HttpResource.responseBodySize.key: 1234,
+      OTel.attributesFromSemanticMap({
+        HttpResource.responseStatusCode: 200,
+        HttpResource.responseBodySize: 1234,
       }),
     );
   } catch (e, stackTrace) {
     span.addAttributes(
-        OTel.attributesFromMap({HttpResource.responseStatusCode.key: 500}));
+        OTel.attributesFromSemanticMap({HttpResource.responseStatusCode: 500}));
     // The span has a status of SpanStatus.Ok on creation, set it to
     // Error when an error occurs in the span.
     span.recordException(e, stackTrace: stackTrace);
@@ -161,17 +161,17 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
   final span = tracer.startSpan(
     'db.query',
     kind: SpanKind.client,
-    attributes: OTel.attributesFromMap({
-      DatabaseResource.dbSystem.key: 'postgresql',
-      DatabaseResource.dbName.key: 'users_db',
-      DatabaseResource.dbOperation.key: 'SELECT',
-      DatabaseResource.dbStatement.key:
+    attributes: OTel.attributesFromSemanticMap({
+      DatabaseResource.dbSystem: 'postgresql',
+      DatabaseResource.dbName: 'users_db',
+      DatabaseResource.dbOperation: 'SELECT',
+      DatabaseResource.dbStatement:
           'SELECT * FROM users WHERE active = true LIMIT 100',
-      DatabaseResource.dbUser.key: 'app_user',
+      DatabaseResource.dbUser: 'app_user',
       // server.address / server.port replace the deprecated net.peer.*
       // per OTel semconv.
-      ServerResource.serverAddress.key: 'postgres.example.com',
-      ServerResource.serverPort.key: 5432,
+      ServerResource.serverAddress: 'postgres.example.com',
+      ServerResource.serverPort: 5432,
     }),
   );
 

--- a/example/otlp_grpc_example.dart
+++ b/example/otlp_grpc_example.dart
@@ -47,15 +47,15 @@ void main() async {
   // Always consult the OTel Semantic Conventions to find an existing
   // convention name for an attribute:
   // https://opentelemetry.io/docs/specs/semconv/general/attributes/
-  tracer.attributes = OTel.attributesFromMap({
-    SourceCodeResource.codeFunctionName.key: 'main',
+  tracer.attributes = OTel.attributesFromSemanticMap({
+    SourceCodeResource.codeFunctionName: 'main',
   });
 
   // Create a new root span. Prefer typed enum keys over raw strings.
   final rootSpan = tracer.startSpan(
     'root-operation-dartastic',
-    attributes: OTel.attributesFromMap({
-      ExampleAttribute.exampleKey.key: 'example-value-dartastic',
+    attributes: OTel.attributesFromSemanticMap({
+      ExampleAttribute.exampleKey: 'example-value-dartastic',
     }),
   );
 

--- a/example/otlp_grpc_simple_sync_example.dart
+++ b/example/otlp_grpc_simple_sync_example.dart
@@ -43,7 +43,7 @@ void main() async {
   // SpanStatusCode.Error per the OTel spec.
   final span = tracer.startSpan(
     'sync-operation',
-    attributes: OTel.attributesFromMap({ExampleAttribute.isSync.key: true}),
+    attributes: OTel.attributesFromSemanticMap({ExampleAttribute.isSync: true}),
   );
   try {
     span.addEventNow('Event within span.');

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -1062,6 +1062,29 @@ class OTel {
     }
   }
 
+  /// Creates an [Attributes] from a map keyed by [OTelSemantic] enum values
+  /// (e.g. `HttpResource.requestMethod`). Each enum's `.key` is used as the
+  /// attribute name. Lets you write
+  ///
+  /// ```dart
+  /// OTel.attributesFromSemanticMap({
+  ///   HttpResource.requestMethod: 'GET',
+  ///   HttpResource.responseStatusCode: 200,
+  /// })
+  /// ```
+  ///
+  /// instead of `attributesFromMap({HttpResource.requestMethod.key: 'GET', …})`.
+  /// Mixing enum types in one map is fine — the param is `Map<OTelSemantic, Object>`,
+  /// and every semconv enum implements `OTelSemantic`.
+  ///
+  /// Passthrough to [OTelAPI.attributesFromSemanticMap] for symmetry with
+  /// the [attributesFromMap] convenience.
+  static Attributes attributesFromSemanticMap(
+    Map<OTelSemantic, Object> semanticMap,
+  ) {
+    return OTelAPI.attributesFromSemanticMap(semanticMap);
+  }
+
   /// Creates an Attributes collection from a list of Attribute objects.
   ///
   /// @param attributeList List of Attribute objects


### PR DESCRIPTION
## Summary

Drops the `.key` accessor from typed-enum-keyed attribute maps in every example and the README. Before/after:

```dart
// before:
OTel.attributesFromMap({
  HttpResource.requestMethod.key: 'GET',
  HttpResource.responseStatusCode.key: 200,
})

// after:
OTel.attributesFromSemanticMap({
  HttpResource.requestMethod: 'GET',
  HttpResource.responseStatusCode: 200,
})
```

Mixing semconv enum types in one map is fine — the API's `attributesFromSemanticMap` takes `Map<OTelSemantic, Object>`, the interface every semconv enum implements.

## Why not `.requestMethod` dot-shorthand?

The user asked for `.serverAddress`-style notation. Dart 3.10's static dot-shorthand needs:
1. The SDK to require Dart 3.10+ (currently `^3.0.0`).
2. The target *static* type at the call site to be a concrete enum.

`attributesFromSemanticMap` takes `Map<OTelSemantic, Object>` — an interface, not a concrete enum — so dot-shorthand wouldn't apply even with the SDK bump. Dropping `.key` is the cleanest shortening that doesn't require raising the min SDK constraint or restructuring the API surface.

## Changes

- New: `OTel.attributesFromSemanticMap(Map<OTelSemantic, Object>)` passthrough on the SDK's `OTel` class, parallel to the existing `OTel.attributesFromMap`. Pure delegation to `OTelAPI.attributesFromSemanticMap`.
- 25 maps converted across README + 6 example files. All converted call sites now use the shorter form.
- Two README maps deliberately left on `attributesFromMap` because they demonstrate the *raw-string-keyed* counter-example (with comments noting "you'd normally use a typed enum here").
- One comment refresh in `console_exporter_sanity_check.dart` to mention both `attributesFromSemanticMap` and `attributesFromMap` can throw on bad value types.

## Test plan

- [x] `dart analyze lib/ example/` clean.
- [x] `dart run example/console_exporter_sanity_check.dart` runs end-to-end and produces the expected attributes (`demo.event_foo: bar`, `demo.event_baz: true`, etc.).
- [ ] CI's collector-backed suite passes (no functional change — pure rename + new passthrough method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)