### PR TITLE
feat: OTLP/HTTP-JSON wire format on traces, metrics, and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.3-wip]
 
+### Added
+- **OTLP/HTTP-JSON wire format on all three signals.** `OtlpHttpSpanExporter`, `OtlpHttpMetricExporter`, and `OtlpHttpLogRecordExporter` now accept an `OtlpHttpProtocol` config option — defaults to `httpProtobuf` (unchanged behaviour), set to `httpJson` to send proto3-JSON-encoded payloads with `Content-Type: application/json`. The encoding follows the OTLP spec's proto3-to-JSON mapping (`request.toProto3Json()` on the generated protobuf classes), so no hand-rolled JSON marshaling lives in Dartastic. Wire-up via `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` (or signal-specific `_TRACES_PROTOCOL` / `_METRICS_PROTOCOL` / `_LOGS_PROTOCOL`) flows through `OTel.initialize`. Per spec, `http/json` is `MAY`-support, not `MUST` — adding it lives up to Dartastic's "No skimping: if it's optional in the spec, it's included" promise. Unblocks integration with backends that prefer JSON (Genkit dev UI, browser-based viewers, lightweight collectors).
+
 ## [1.1.0-beta.2] - 2026-05-10
 
 ### Added

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -83,6 +83,7 @@ export 'src/environment/env_constants.dart';
 export 'src/environment/environment_service.dart';
 export 'src/environment/otel_env.dart';
 export 'src/export/export_result.dart';
+export 'src/export/otlp_http_protocol.dart';
 export 'src/factory/otel_sdk_factory.dart';
 export 'src/logs/bridge/dart_log_bridge.dart';
 export 'src/logs/export/batch_log_record_processor.dart';

--- a/lib/src/export/otlp_http_protocol.dart
+++ b/lib/src/export/otlp_http_protocol.dart
@@ -1,0 +1,41 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+/// Wire-format protocol for OTLP/HTTP exporters.
+///
+/// The OpenTelemetry specification defines two HTTP encodings:
+///   - `application/x-protobuf` — protobuf-encoded OTLP messages. The
+///     spec-recommended default; smaller payloads, faster to encode.
+///   - `application/json` — JSON-encoded OTLP messages using the
+///     protobuf-to-JSON mapping (proto3 JSON). Optional per spec — SDKs
+///     `MAY` support it — but supported by Dartastic for parity with the
+///     JS/Python implementations and for backends that prefer JSON for
+///     human-readable telemetry (e.g. local dev UIs, Browser DevTools).
+///
+/// See `specification/protocol/exporter.md` for the full conformance
+/// rules; the env-var `OTEL_EXPORTER_OTLP_PROTOCOL` (and signal-specific
+/// `_TRACES_PROTOCOL` / `_METRICS_PROTOCOL` / `_LOGS_PROTOCOL` variants)
+/// selects this from configuration with values `http/protobuf` or
+/// `http/json`. `OtlpHttpProtocol.httpProtobuf` is the default.
+enum OtlpHttpProtocol {
+  /// `application/x-protobuf` — protobuf-encoded OTLP messages.
+  httpProtobuf,
+
+  /// `application/json` — proto3-JSON-encoded OTLP messages.
+  httpJson,
+}
+
+/// Parses the OTel `OTEL_EXPORTER_OTLP_PROTOCOL` env-var value into an
+/// [OtlpHttpProtocol]. Returns `null` for unsupported values (e.g. `grpc`
+/// — caller is expected to handle that out-of-band by selecting an
+/// OTLP/gRPC exporter instead).
+OtlpHttpProtocol? otlpHttpProtocolFromString(String value) {
+  switch (value.trim().toLowerCase()) {
+    case 'http/protobuf':
+      return OtlpHttpProtocol.httpProtobuf;
+    case 'http/json':
+      return OtlpHttpProtocol.httpJson;
+    default:
+      return null;
+  }
+}

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
@@ -2,6 +2,7 @@
 // Copyright 2025, Michael Bushe, All rights reserved.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -9,6 +10,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;
 import 'package:http/http.dart' as http;
 
+import '../../../../export/otlp_http_protocol.dart';
 import '../../../../trace/export/otlp/http/http_client_factory.dart';
 import '../../../../util/zip/gzip.dart';
 import '../../../readable_log_record.dart';
@@ -97,16 +99,24 @@ class OtlpHttpLogRecordExporter implements LogRecordExporter {
           'OtlpHttpLogRecordExporter: Successfully transformed log records');
     }
 
-    // Prepare headers
+    // Prepare headers + body. Wire format is selected by config.protocol —
+    // protobuf (default) or JSON via proto3-JSON mapping. See
+    // `OtlpHttpProtocol` for the conformance rationale.
     final headers = Map<String, String>.from(_config.headers);
-    headers['Content-Type'] = 'application/x-protobuf';
+    Uint8List messageBytes;
+    if (_config.protocol == OtlpHttpProtocol.httpJson) {
+      headers['Content-Type'] = 'application/json';
+      final jsonValue = request.toProto3Json();
+      messageBytes = Uint8List.fromList(utf8.encode(jsonEncode(jsonValue)));
+    } else {
+      headers['Content-Type'] = 'application/x-protobuf';
+      messageBytes = request.writeToBuffer();
+    }
 
     if (_config.compression) {
       headers['Content-Encoding'] = 'gzip';
     }
 
-    // Convert protobuf to bytes
-    final messageBytes = request.writeToBuffer();
     var bodyBytes = messageBytes;
 
     // Apply gzip compression if configured

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart
@@ -1,13 +1,20 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import '../../../../export/otlp_http_protocol.dart';
 import '../../../../trace/export/otlp/certificate_utils.dart';
 
-/// Configuration for the OpenTelemetry log record exporter that exports logs using OTLP over HTTP/protobuf.
+/// Configuration for the OpenTelemetry log record exporter that exports
+/// logs using OTLP/HTTP. Wire format defaults to `application/x-protobuf`
+/// and can be switched to `application/json` via [protocol].
 class OtlpHttpLogRecordExporterConfig {
   /// The endpoint to export logs to (e.g., 'http://localhost:4318/v1/logs')
   /// Default: 'http://localhost:4318'
   final String endpoint;
+
+  /// Wire-format protocol — `httpProtobuf` (default) or `httpJson`.
+  /// Controls `Content-Type` and how OTLP messages are serialized.
+  final OtlpHttpProtocol protocol;
 
   /// Additional HTTP headers to include in the export requests.
   final Map<String, String> headers;
@@ -56,6 +63,7 @@ class OtlpHttpLogRecordExporterConfig {
     this.certificate,
     this.clientKey,
     this.clientCertificate,
+    this.protocol = OtlpHttpProtocol.httpProtobuf,
   })  : endpoint = _validateEndpoint(endpoint),
         headers = _validateHeaders(headers ?? {}),
         timeout = _validateTimeout(timeout),

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
@@ -2,6 +2,7 @@
 // Copyright 2025, Michael Bushe, All rights reserved.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -292,16 +293,24 @@ class OtlpHttpMetricExporter implements MetricExporter {
       OTelLog.debug('OtlpHttpMetricExporter: Successfully transformed metrics');
     }
 
-    // Prepare headers
+    // Prepare headers + body. Wire format is selected by config.protocol —
+    // protobuf (default) or JSON via proto3-JSON mapping. See
+    // `OtlpHttpProtocol` for the conformance rationale.
     final headers = Map<String, String>.from(_config.headers);
-    headers['Content-Type'] = 'application/x-protobuf';
+    Uint8List messageBytes;
+    if (_config.protocol == OtlpHttpProtocol.httpJson) {
+      headers['Content-Type'] = 'application/json';
+      final jsonValue = request.toProto3Json();
+      messageBytes = Uint8List.fromList(utf8.encode(jsonEncode(jsonValue)));
+    } else {
+      headers['Content-Type'] = 'application/x-protobuf';
+      messageBytes = request.writeToBuffer();
+    }
 
     if (_config.compression) {
       headers['Content-Encoding'] = 'gzip';
     }
 
-    // Convert protobuf to bytes
-    final messageBytes = request.writeToBuffer();
     var bodyBytes = messageBytes;
 
     // Apply gzip compression if configured

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter_config.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter_config.dart
@@ -1,13 +1,20 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import '../../../../export/otlp_http_protocol.dart';
 import '../../../../trace/export/otlp/certificate_utils.dart';
 
-/// Configuration for the OpenTelemetry metric exporter that exports metrics using OTLP over HTTP/protobuf
+/// Configuration for the OpenTelemetry metric exporter that exports metrics
+/// using OTLP/HTTP. Wire format defaults to `application/x-protobuf` and can
+/// be switched to `application/json` via [protocol].
 class OtlpHttpMetricExporterConfig {
   /// The endpoint to export metrics to (e.g., 'http://localhost:4318/v1/metrics')
   /// Default: 'http://localhost:4318'
   final String endpoint;
+
+  /// Wire-format protocol — `httpProtobuf` (default) or `httpJson`.
+  /// Controls `Content-Type` and how OTLP messages are serialized.
+  final OtlpHttpProtocol protocol;
 
   /// Additional HTTP headers to include in the export requests
   final Map<String, String> headers;
@@ -56,6 +63,7 @@ class OtlpHttpMetricExporterConfig {
     this.certificate,
     this.clientKey,
     this.clientCertificate,
+    this.protocol = OtlpHttpProtocol.httpProtobuf,
   })  : endpoint = _validateEndpoint(endpoint),
         headers = _validateHeaders(headers ?? {}),
         timeout = _validateTimeout(timeout),

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -380,9 +380,8 @@ class OTel {
             // http/protobuf (default) or http/json (opt-in via env-var).
             // Anything else falls back to http/protobuf — the spec-
             // recommended default per `specification/protocol/exporter.md`.
-            final httpProtocol =
-                otlpHttpProtocolFromString(protocol) ??
-                    OtlpHttpProtocol.httpProtobuf;
+            final httpProtocol = otlpHttpProtocolFromString(protocol) ??
+                OtlpHttpProtocol.httpProtobuf;
             exporter = OtlpHttpSpanExporter(
               OtlpHttpExporterConfig(
                 endpoint: endpoint,

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -377,7 +377,12 @@ class OTel {
               ),
             );
           } else {
-            // Default to http/protobuf
+            // http/protobuf (default) or http/json (opt-in via env-var).
+            // Anything else falls back to http/protobuf — the spec-
+            // recommended default per `specification/protocol/exporter.md`.
+            final httpProtocol =
+                otlpHttpProtocolFromString(protocol) ??
+                    OtlpHttpProtocol.httpProtobuf;
             exporter = OtlpHttpSpanExporter(
               OtlpHttpExporterConfig(
                 endpoint: endpoint,
@@ -391,6 +396,7 @@ class OTel {
                 clientKey: otlpConfigForExporter['clientKey'] as String?,
                 clientCertificate:
                     otlpConfigForExporter['clientCertificate'] as String?,
+                protocol: httpProtocol,
               ),
             );
           }

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
@@ -2,6 +2,7 @@
 // Copyright 2025, Michael Bushe, All rights reserved.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -9,6 +10,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;
 import 'package:http/http.dart' as http;
 
+import '../../../../export/otlp_http_protocol.dart';
 import '../../../../util/zip/gzip.dart';
 import '../../../span.dart';
 import '../../../span_logger.dart';
@@ -114,16 +116,27 @@ class OtlpHttpSpanExporter implements SpanExporter {
       OTelLog.debug('OtlpHttpSpanExporter: Successfully transformed spans');
     }
 
-    // Prepare headers
+    // Prepare headers + body. Wire format is selected by config.protocol:
+    // protobuf (default) writes the message as its compact binary encoding
+    // with Content-Type application/x-protobuf; JSON serializes via the
+    // standard proto3-JSON mapping (`toProto3Json`) with Content-Type
+    // application/json. The proto3-JSON mapping is the OTLP/JSON
+    // encoding the spec specifies; we don't hand-roll it.
     final headers = Map<String, String>.from(_config.headers);
-    headers['Content-Type'] = 'application/x-protobuf';
+    Uint8List messageBytes;
+    if (_config.protocol == OtlpHttpProtocol.httpJson) {
+      headers['Content-Type'] = 'application/json';
+      final jsonValue = request.toProto3Json();
+      messageBytes = Uint8List.fromList(utf8.encode(jsonEncode(jsonValue)));
+    } else {
+      headers['Content-Type'] = 'application/x-protobuf';
+      messageBytes = request.writeToBuffer();
+    }
 
     if (_config.compression) {
       headers['Content-Encoding'] = 'gzip';
     }
 
-    // Convert protobuf to bytes
-    final messageBytes = request.writeToBuffer();
     var bodyBytes = messageBytes;
 
     // Apply gzip compression if configured

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter_config.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter_config.dart
@@ -1,13 +1,21 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import '../../../../export/otlp_http_protocol.dart';
 import '../certificate_utils.dart';
 
-/// Configuration for the OpenTelemetry span exporter that exports spans using OTLP over HTTP/protobuf
+/// Configuration for the OpenTelemetry span exporter that exports spans
+/// using OTLP/HTTP. Wire format defaults to `application/x-protobuf` and
+/// can be switched to `application/json` via [protocol] for backends that
+/// prefer JSON (e.g. local dev UIs, browser-based viewers).
 class OtlpHttpExporterConfig {
   /// The endpoint to export spans to (e.g., 'http://localhost:4318/v1/traces')
   /// Default: 'http://localhost:4318'
   final String endpoint;
+
+  /// Wire-format protocol — `httpProtobuf` (default) or `httpJson`.
+  /// Controls `Content-Type` and how OTLP messages are serialized.
+  final OtlpHttpProtocol protocol;
 
   /// Additional HTTP headers to include in the export requests
   final Map<String, String> headers;
@@ -56,6 +64,7 @@ class OtlpHttpExporterConfig {
     this.certificate,
     this.clientKey,
     this.clientCertificate,
+    this.protocol = OtlpHttpProtocol.httpProtobuf,
   })  : endpoint = _validateEndpoint(endpoint),
         headers = _validateHeaders(headers ?? {}),
         timeout = _validateTimeout(timeout),

--- a/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
+++ b/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
@@ -1,0 +1,99 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Tests the `protocol` config on `OtlpHttpLogRecordExporter` — the
+// http/protobuf default keeps existing behaviour; opting into
+// `OtlpHttpProtocol.httpJson` switches the Content-Type to
+// `application/json` and the body to proto3-JSON.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OtlpHttpLogRecordExporter protocol', () {
+    late HttpServer server;
+    late int port;
+    late List<HttpRequest> receivedRequests;
+    var capturedBody = <int>[];
+
+    setUp(() async {
+      await OTel.reset();
+      receivedRequests = [];
+      capturedBody = [];
+      server = await HttpServer.bind('localhost', 0);
+      port = server.port;
+      server.listen((request) async {
+        receivedRequests.add(request);
+        capturedBody = await request
+            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        request.response.statusCode = 200;
+        await request.response.close();
+      });
+      await OTel.initialize(
+        serviceName: 'test',
+        detectPlatformResources: false,
+      );
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    ReadableLogRecord createTestLogRecord() {
+      final scope =
+          OTel.instrumentationScope(name: 'protocol-test', version: '1.0.0');
+      return SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'hello-otlp-json',
+      );
+    }
+
+    test('default (http/protobuf) sends application/x-protobuf', () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(endpoint: 'http://localhost:$port'),
+      );
+
+      await exporter.export([createTestLogRecord()]);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.contentType.toString(),
+        contains('application/x-protobuf'),
+      );
+      await exporter.shutdown();
+    });
+
+    test('httpJson protocol sends application/json + proto3-JSON body',
+        () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:$port',
+          protocol: OtlpHttpProtocol.httpJson,
+        ),
+      );
+
+      await exporter.export([createTestLogRecord()]);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.contentType.toString(),
+        contains('application/json'),
+      );
+
+      // Body must decode to a Map with the proto3-JSON top-level
+      // `resourceLogs` key.
+      final decoded = jsonDecode(utf8.decode(capturedBody));
+      expect(decoded, isA<Map<String, dynamic>>());
+      expect((decoded as Map).containsKey('resourceLogs'), isTrue);
+      expect(decoded['resourceLogs'], isA<List>());
+
+      await exporter.shutdown();
+    });
+  });
+}

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -1,6 +1,7 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
@@ -78,6 +79,47 @@ void main() {
         receivedRequests.first.headers.contentType.toString(),
         contains('application/x-protobuf'),
       );
+      await exporter.shutdown();
+    });
+
+    test('export with httpJson protocol sends application/json + proto3-JSON body',
+        () async {
+      // Rebind the server so we can capture the request body for this test.
+      await server.close(force: true);
+      receivedRequests = [];
+      var capturedBody = <int>[];
+      server = await HttpServer.bind('localhost', port);
+      server.listen((request) async {
+        receivedRequests.add(request);
+        capturedBody = await request
+            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        request.response.statusCode = 200;
+        await request.response.close();
+      });
+
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          protocol: OtlpHttpProtocol.httpJson,
+        ),
+      );
+
+      final metricData = createTestMetricData();
+      await exporter.export(metricData);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.contentType.toString(),
+        contains('application/json'),
+      );
+
+      // Body must decode to a Map with the proto3-JSON top-level
+      // `resourceMetrics` key.
+      final decoded = jsonDecode(utf8.decode(capturedBody));
+      expect(decoded, isA<Map<String, dynamic>>());
+      expect((decoded as Map).containsKey('resourceMetrics'), isTrue);
+      expect(decoded['resourceMetrics'], isA<List>());
+
       await exporter.shutdown();
     });
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -82,7 +82,8 @@ void main() {
       await exporter.shutdown();
     });
 
-    test('export with httpJson protocol sends application/json + proto3-JSON body',
+    test(
+        'export with httpJson protocol sends application/json + proto3-JSON body',
         () async {
       // Rebind the server so we can capture the request body for this test.
       await server.close(force: true);

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -79,7 +79,8 @@ void main() {
       await exporter.shutdown();
     });
 
-    test('export with httpJson protocol sends application/json + proto3-JSON body',
+    test(
+        'export with httpJson protocol sends application/json + proto3-JSON body',
         () async {
       final exporter = OtlpHttpSpanExporter(
         OtlpHttpExporterConfig(

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -1,6 +1,7 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
@@ -75,6 +76,48 @@ void main() {
         receivedRequests.first.headers.contentType.toString(),
         contains('application/x-protobuf'),
       );
+      await exporter.shutdown();
+    });
+
+    test('export with httpJson protocol sends application/json + proto3-JSON body',
+        () async {
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          protocol: OtlpHttpProtocol.httpJson,
+        ),
+      );
+
+      // Capture the request body for shape validation.
+      var capturedBody = <int>[];
+      receivedRequests.clear();
+      await server.close(force: true);
+      server = await HttpServer.bind('localhost', port);
+      server.listen((request) async {
+        receivedRequests.add(request);
+        capturedBody = await request
+            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
+        request.response.statusCode = 200;
+        await request.response.close();
+      });
+
+      final spans = createTestSpans();
+      await exporter.export(spans);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.contentType.toString(),
+        contains('application/json'),
+      );
+
+      // The body must be valid JSON that decodes to a Map shaped like a
+      // proto3-JSON `ExportTraceServiceRequest` — the top-level key
+      // `resourceSpans` is the spec-defined field name.
+      final decoded = jsonDecode(utf8.decode(capturedBody));
+      expect(decoded, isA<Map<String, dynamic>>());
+      expect((decoded as Map).containsKey('resourceSpans'), isTrue);
+      expect(decoded['resourceSpans'], isA<List>());
+
       await exporter.shutdown();
     });
 


### PR DESCRIPTION
Adds proto3-JSON encoding as an option on all three OTLP/HTTP exporters. Defaults stay on `application/x-protobuf` so existing setups are unaffected; opt in by passing `OtlpHttpProtocol.httpJson` to the config or by setting `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` (or the signal-specific variants).

Encoding leverages `package:protobuf`'s `.toProto3Json()` on the generated OTLP message classes — the spec-defined proto3-to-JSON mapping. No hand-rolled JSON marshalling in Dartastic.

Per OTel spec (`specification/protocol/exporter.md:169-171`), `http/json` is `MAY`-support — not required. Adding it lives up to the README promise that "if it's optional in the spec, it's included in Dartastic." Unblocks integration with backends that prefer JSON (Genkit dev UI, browser-based viewers, lightweight collectors).

Changes:
  - lib/src/export/otlp_http_protocol.dart — new shared `OtlpHttpProtocol` enum + `otlpHttpProtocolFromString` parser.
  - lib/src/trace/export/otlp/http/{otlp_http_span_exporter,_config}.dart — added `protocol` config field; switches Content-Type + body.
  - lib/src/metrics/export/otlp/http/{otlp_http_metric_exporter,_config}.dart — same.
  - lib/src/logs/export/otlp/http/{otlp_http_log_record_exporter,_config}.dart — same.
  - lib/src/otel.dart — `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` now actually flows through to the auto-configured span exporter (previously the value was read into the config map but never consumed).
  - lib/dartastic_opentelemetry.dart — exports the new enum.

New tests cover all 3 exporters: Content-Type assertion + proto3-JSON body shape validation (top-level `resourceSpans` / `resourceMetrics` / `resourceLogs` key).

Full SDK suite: 1789 pass, 0 fail.