### PR TITLE
1.1.0-beta.5: add testing.dart + remove startSpanWithContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.5-wip]
 
+### Added
+- **`package:dartastic_opentelemetry/testing.dart`** — opt-in library with the in-memory test harness used by the dart-otel-reference-demo and every OTel-Dart wrapper. Exports `InMemorySpanExporter` (with `findSpanByName` / `findSpansByName` / `findSpansStartingWith` / `clear`), `InMemoryLogExporter`, `InMemoryMetricExporter`, `OnDemandMetricReader` (timer-free; tests call `collect()` explicitly via `TestHarness.collectMetrics`), `TestHarness` aggregator, and `maybeInitializeOtelForTest()` (singleton initializer for `setUpAll`). Deliberately *not* re-exported from the main barrel so production bundles don't carry the test classes — import the `/testing.dart` path explicitly. Unifies the test scaffolding across the SDK, the reference demo, and the `otel_*` wrapper packages; previously each wrapper had its own near-identical copy.
+
 ### Removed
 - **Breaking: `Tracer.startSpanWithContext` is removed.** Deprecated since 1.1.0-beta (released 2026-05-07), four betas ago. Migration is a 1:1 rename — `tracer.startSpanWithContext(name: x, context: ctx, kind: k, attributes: a)` → `tracer.startSpan(x, context: ctx, kind: k, attributes: a)`. To make the returned span active for a scope, wrap the work with `tracer.withSpan` (sync) or `tracer.withSpanAsync` (async); the deprecated method had stopped activating the span as of 1.1.0-beta anyway, so call sites that relied on activation already needed updating. Test suites that exercised `startSpanWithContext` were migrated in this release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.5-wip]
 
+### Removed
+- **Breaking: `Tracer.startSpanWithContext` is removed.** Deprecated since 1.1.0-beta (released 2026-05-07), four betas ago. Migration is a 1:1 rename — `tracer.startSpanWithContext(name: x, context: ctx, kind: k, attributes: a)` → `tracer.startSpan(x, context: ctx, kind: k, attributes: a)`. To make the returned span active for a scope, wrap the work with `tracer.withSpan` (sync) or `tracer.withSpanAsync` (async); the deprecated method had stopped activating the span as of 1.1.0-beta anyway, so call sites that relied on activation already needed updating. Test suites that exercised `startSpanWithContext` were migrated in this release.
+
 ## [1.1.0-beta.4] - 2026-05-11
 
 ### Changed

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -180,27 +180,6 @@ class Tracer implements APITracer {
     }
   }
 
-  /// Starts a span using the provided context to determine the parent.
-  ///
-  /// This is now a thin wrapper around [startSpan] with the `context`
-  /// parameter set; it no longer mutates `Context.current`. To make the
-  /// returned span active for a scope, call [withSpan] / [withSpanAsync].
-  @Deprecated(
-      'Use startSpan(name, context: ctx) and tracer.withSpan/withSpanAsync to activate the returned span.')
-  APISpan startSpanWithContext({
-    required String name,
-    required Context context,
-    SpanKind kind = SpanKind.internal,
-    Attributes? attributes,
-  }) {
-    return startSpan(
-      name,
-      context: context,
-      kind: kind,
-      attributes: attributes,
-    );
-  }
-
   @override
   Span createSpan({
     required String name,

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -1,0 +1,338 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Mindful Software LLC, All rights reserved.
+
+/// Test helpers for the Dartastic OpenTelemetry SDK.
+///
+/// Import this library from `test/` only:
+///
+/// ```dart
+/// import 'package:dartastic_opentelemetry/testing.dart';
+/// ```
+///
+/// It is intentionally **not** exported from the main
+/// `package:dartastic_opentelemetry/dartastic_opentelemetry.dart`
+/// barrel so production bundles don't carry the in-memory exporter
+/// classes.
+///
+/// Provides:
+/// - [InMemorySpanExporter] — collects exported spans into a list with
+///   query helpers (`findSpanByName`, `findSpansByName`,
+///   `findSpansStartingWith`, `clear`).
+/// - [InMemoryLogExporter] — same idea for log records.
+/// - [InMemoryMetricExporter] — same idea for metrics; pair with
+///   [OnDemandMetricReader].
+/// - [OnDemandMetricReader] — a metric reader that never fires on a
+///   timer; tests drive `collect()` explicitly via
+///   [TestHarness.collectMetrics].
+/// - [TestHarness] — bundles the three exporters and the reader,
+///   plus a `clear()` to reset between tests.
+/// - [maybeInitializeOtelForTest] — singleton initializer designed
+///   for `setUpAll`. Brings up the real OpenTelemetry SDK pointed at
+///   the in-memory exporters. Safe to call from multiple test files
+///   in the same process; returns the same harness on subsequent
+///   calls.
+///
+/// The shape mirrors the test harness used in the OTel-Dart reference
+/// demo at https://github.com/MindfulSoftwareLLC/dart-otel-reference-demo
+/// so wrappers, customer apps, and the reference demo all use the same
+/// scaffolding.
+library;
+
+import 'dart:async';
+
+import 'dartastic_opentelemetry.dart';
+
+/// Span exporter that buffers spans in memory for inspection.
+///
+/// Tests typically:
+///
+/// ```dart
+/// setUpAll(() async {
+///   harness = await maybeInitializeOtelForTest();
+///   spans = harness.spans;
+/// });
+/// setUp(() => harness.clear());
+///
+/// test('my_op emits a span', () {
+///   doMyOp();
+///   expect(spans.findSpanByName('my_op'), isNotNull);
+/// });
+/// ```
+///
+/// Use [findSpanByName] / [findSpansByName] / [findSpansStartingWith]
+/// instead of indexing into [spans] directly — they make test failures
+/// read more clearly.
+class InMemorySpanExporter implements SpanExporter {
+  /// Creates an exporter.
+  InMemorySpanExporter();
+
+  final List<Span> _spans = <Span>[];
+  bool _isShutdown = false;
+
+  /// All spans exported since the last [clear].
+  List<Span> get spans => List<Span>.unmodifiable(_spans);
+
+  /// All exported span names, in export order. Handy in `expect`
+  /// assertions when you want to check the trace shape.
+  List<String> get spanNames => _spans.map((s) => s.name).toList();
+
+  /// Clears the recorded spans. Call between tests.
+  void clear() => _spans.clear();
+
+  /// Returns the **most recently** exported span with the given
+  /// [name], or `null` if none match. Most-recent makes per-test
+  /// reads stable when a span name happens to be reused across tests.
+  Span? findSpanByName(String name) {
+    for (var i = _spans.length - 1; i >= 0; i--) {
+      if (_spans[i].name == name) return _spans[i];
+    }
+    return null;
+  }
+
+  /// Returns every exported span whose name equals [name].
+  List<Span> findSpansByName(String name) =>
+      _spans.where((s) => s.name == name).toList(growable: false);
+
+  /// Returns every exported span whose name starts with [prefix].
+  /// Useful for category-level assertions
+  /// (e.g. `findSpansStartingWith('http ')`).
+  List<Span> findSpansStartingWith(String prefix) =>
+      _spans.where((s) => s.name.startsWith(prefix)).toList(growable: false);
+
+  @override
+  Future<void> export(List<Span> spans) async {
+    if (_isShutdown) {
+      throw StateError('InMemorySpanExporter is shutdown');
+    }
+    _spans.addAll(spans);
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {
+    _isShutdown = true;
+  }
+}
+
+/// Log-record exporter that buffers records in memory for inspection.
+class InMemoryLogExporter implements LogRecordExporter {
+  /// Creates an exporter.
+  InMemoryLogExporter();
+
+  final List<LogRecord> _records = <LogRecord>[];
+  bool _isShutdown = false;
+
+  /// All records exported since the last [clear].
+  List<LogRecord> get records => List<LogRecord>.unmodifiable(_records);
+
+  /// Clears the recorded log records. Call between tests.
+  void clear() => _records.clear();
+
+  /// Returns every record with the given [severity].
+  List<LogRecord> findRecordsBySeverity(Severity severity) =>
+      _records.where((r) => r.severityNumber == severity).toList();
+
+  @override
+  Future<ExportResult> export(List<LogRecord> r) async {
+    if (_isShutdown) return ExportResult.failure;
+    _records.addAll(r);
+    return ExportResult.success;
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {
+    _isShutdown = true;
+  }
+}
+
+/// Metric exporter that buffers exported metric snapshots in memory.
+///
+/// Use with [OnDemandMetricReader] so tests drive collection
+/// explicitly — tests rarely want a timer fighting their
+/// `expect` assertions.
+class InMemoryMetricExporter implements MetricExporter {
+  /// Creates an exporter.
+  InMemoryMetricExporter();
+
+  final List<Metric> _metrics = <Metric>[];
+  bool _isShutdown = false;
+
+  /// All metrics exported since the last [clear].
+  List<Metric> get metrics => List<Metric>.unmodifiable(_metrics);
+
+  /// Clears the recorded metrics. Call between tests.
+  void clear() => _metrics.clear();
+
+  /// Returns the most-recently exported metric named [name], or
+  /// `null` if none match.
+  Metric? findMetricByName(String name) {
+    for (var i = _metrics.length - 1; i >= 0; i--) {
+      if (_metrics[i].name == name) return _metrics[i];
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> export(MetricData data) async {
+    if (_isShutdown) return false;
+    _metrics.addAll(data.metrics);
+    return true;
+  }
+
+  @override
+  Future<bool> forceFlush() async => !_isShutdown;
+
+  @override
+  Future<bool> shutdown() async {
+    _isShutdown = true;
+    return true;
+  }
+}
+
+/// Metric reader for tests. Never fires on a timer; tests drive
+/// `collect()` explicitly via [TestHarness.collectMetrics] so
+/// assertions don't race against a periodic export.
+class OnDemandMetricReader extends MetricReader {
+  /// Creates a reader that forwards collected metrics to [exporter].
+  OnDemandMetricReader(this.exporter);
+
+  /// The exporter that receives collected metrics.
+  final MetricExporter exporter;
+  bool _isShutdown = false;
+
+  @override
+  Future<MetricData> collect() async {
+    final mp = meterProvider;
+    if (mp == null || _isShutdown) {
+      return MetricData.empty();
+    }
+    final metrics = await mp.collectAllMetrics();
+    return MetricData(resource: mp.resource, metrics: metrics);
+  }
+
+  @override
+  Future<bool> forceFlush() async {
+    if (_isShutdown) return false;
+    final data = await collect();
+    if (data.metrics.isNotEmpty) {
+      await exporter.export(data);
+    }
+    return await exporter.forceFlush();
+  }
+
+  @override
+  Future<bool> shutdown() async {
+    if (_isShutdown) return true;
+    _isShutdown = true;
+    return await exporter.shutdown();
+  }
+}
+
+/// Bundles the three in-memory exporters and the on-demand metric
+/// reader so tests have one handle to `clear()` between cases.
+///
+/// Construct via [maybeInitializeOtelForTest].
+class TestHarness {
+  /// Creates a harness. Prefer [maybeInitializeOtelForTest] over
+  /// calling this directly.
+  TestHarness({
+    required this.spans,
+    required this.logs,
+    required this.metrics,
+    required this.metricReader,
+  });
+
+  /// The span exporter that received every emitted span.
+  final InMemorySpanExporter spans;
+
+  /// The log exporter that received every emitted log record.
+  final InMemoryLogExporter logs;
+
+  /// The metric exporter that received every emitted metric snapshot.
+  /// New snapshots arrive only when you call [collectMetrics].
+  final InMemoryMetricExporter metrics;
+
+  /// The reader driving metric collection.
+  final MetricReader metricReader;
+
+  /// Pumps the meter provider and forwards collected metrics to the
+  /// in-memory exporter. Call this in a test after recording metrics
+  /// but before asserting on [metrics].
+  Future<void> collectMetrics() async {
+    final data = await metricReader.collect();
+    await metrics.export(data);
+  }
+
+  /// Forces the SDK's logger pipeline to flush. Tests that emit logs
+  /// synchronously usually don't need this, but it's safe to call.
+  Future<void> flushLogs() async {
+    await OTel.loggerProvider().forceFlush();
+  }
+
+  /// Resets all three exporters' buffers. Call from `setUp()`.
+  void clear() {
+    spans.clear();
+    logs.clear();
+    metrics.clear();
+  }
+}
+
+TestHarness? _shared;
+
+/// Initializes the OpenTelemetry SDK once per test process with
+/// in-memory exporters for spans / logs / metrics, and returns the
+/// same [TestHarness] on subsequent calls.
+///
+/// Designed for `setUpAll`:
+///
+/// ```dart
+/// late TestHarness harness;
+/// late InMemorySpanExporter spans;
+///
+/// setUpAll(() async {
+///   harness = await maybeInitializeOtelForTest(
+///     serviceName: 'my_wrapper-test',
+///   );
+///   spans = harness.spans;
+/// });
+///
+/// setUp(() => harness.clear());
+/// ```
+///
+/// Idempotent — calling it from multiple test files in the same
+/// process is fine; the SDK is initialized exactly once and every
+/// caller gets the same exporters.
+///
+/// - [serviceName] becomes `service.name` on emitted telemetry.
+/// - [endpoint] is a dummy — no exporter actually hits the network.
+///   Override only if your code-under-test reads it.
+Future<TestHarness> maybeInitializeOtelForTest({
+  String serviceName = 'otel-test',
+  String endpoint = 'http://localhost:4317',
+}) async {
+  if (_shared != null) return _shared!;
+  final spanExporter = InMemorySpanExporter();
+  final logExporter = InMemoryLogExporter();
+  final metricExporter = InMemoryMetricExporter();
+  final reader = OnDemandMetricReader(metricExporter);
+  await OTel.initialize(
+    endpoint: endpoint,
+    serviceName: serviceName,
+    serviceVersion: '0.0.0-test',
+    spanProcessor: SimpleSpanProcessor(spanExporter),
+    logRecordProcessor: SimpleLogRecordProcessor(logExporter),
+    metricReader: reader,
+    detectPlatformResources: false,
+  );
+  return _shared = TestHarness(
+    spans: spanExporter,
+    logs: logExporter,
+    metrics: metricExporter,
+    metricReader: reader,
+  );
+}

--- a/test/unit/sdk_edge_cases_test.dart
+++ b/test/unit/sdk_edge_cases_test.dart
@@ -415,10 +415,13 @@ void main() {
   });
 
   group('Tracer', () {
-    test('startSpanWithContext sets span in context', () {
+    test('startSpan with explicit context attaches to that context', () {
       final tracer = OTel.tracer();
-      final span = tracer.startSpanWithContext(
-        name: 'context-span',
+      // Migrated from the removed `startSpanWithContext`. The behavior
+      // — pass an explicit Context and have the span use it as its
+      // parent — is now expressed via `startSpan(name, context: ...)`.
+      final span = tracer.startSpan(
+        'context-span',
         context: Context.current,
       );
       expect(span, isNotNull);

--- a/test/unit/testing_lib_test.dart
+++ b/test/unit/testing_lib_test.dart
@@ -1,0 +1,130 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Mindful Software LLC, All rights reserved.
+//
+// Self-test for `package:dartastic_opentelemetry/testing.dart`.
+//
+// The point of this file is to make sure the in-memory exporters and
+// `maybeInitializeOtelForTest` stay regression-safe — wrappers across
+// the OTel-Dart ecosystem rely on this harness shape, so a change
+// here has to be deliberate.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late TestHarness harness;
+
+  setUpAll(() async {
+    harness = await maybeInitializeOtelForTest(
+      serviceName: 'testing-lib-self-test',
+    );
+  });
+
+  setUp(() => harness.clear());
+
+  group('InMemorySpanExporter', () {
+    test('records exported spans and offers query helpers', () {
+      final tracer = OTel.tracer();
+      tracer.startSpan('a').end();
+      tracer.startSpan('b').end();
+      tracer.startSpan('a').end();
+      tracer.startSpan('http /users').end();
+
+      expect(harness.spans.spans, hasLength(4));
+      expect(harness.spans.spanNames, ['a', 'b', 'a', 'http /users']);
+
+      expect(harness.spans.findSpanByName('a'), isNotNull);
+      expect(harness.spans.findSpanByName('zzz'), isNull);
+
+      expect(harness.spans.findSpansByName('a'), hasLength(2));
+      expect(
+        harness.spans.findSpansStartingWith('http ').single.name,
+        'http /users',
+      );
+    });
+
+    test('clear() empties the buffer between tests', () {
+      OTel.tracer().startSpan('only-in-this-test').end();
+      expect(harness.spans.spans, hasLength(1));
+      harness.clear();
+      expect(harness.spans.spans, isEmpty);
+    });
+
+    test('most-recent-wins on findSpanByName when names repeat', () {
+      // Same name three times; `findSpanByName` should return the
+      // last one so a test setUp + arrange/act flow stays stable.
+      final tracer = OTel.tracer();
+      final first = tracer.startSpan('dup')
+        ..addAttributes(
+          OTel.attributes([OTel.attributeString('which', 'first')]),
+        )
+        ..end();
+      tracer.startSpan('dup').end();
+      final last = tracer.startSpan('dup')
+        ..addAttributes(
+          OTel.attributes([OTel.attributeString('which', 'last')]),
+        )
+        ..end();
+
+      final found = harness.spans.findSpanByName('dup');
+      expect(found, isNotNull);
+      final attrs = {
+        for (final a in found!.attributes.toList()) a.key: a.value,
+      };
+      expect(attrs['which'], 'last');
+      // The other expected spans exist as well:
+      expect(harness.spans.findSpansByName('dup'), hasLength(3));
+      // (silence the unused warning)
+      expect(first.name, last.name);
+    });
+  });
+
+  group('InMemoryLogExporter', () {
+    test('captures emitted log records and filters by severity', () async {
+      final logger = OTel.loggerProvider().getLogger('self-test');
+      logger.emit(
+        body: 'hello-info',
+        severityNumber: Severity.INFO,
+        severityText: 'INFO',
+      );
+      logger.emit(
+        body: 'hello-warn',
+        severityNumber: Severity.WARN,
+        severityText: 'WARN',
+      );
+      await harness.flushLogs();
+
+      expect(harness.logs.records, hasLength(2));
+      expect(
+        harness.logs.findRecordsBySeverity(Severity.WARN).single.body,
+        'hello-warn',
+      );
+    });
+  });
+
+  group('InMemoryMetricExporter + OnDemandMetricReader', () {
+    test('tests drive collection explicitly', () async {
+      final counter = OTel.meterProvider()
+          .getMeter(name: 'self-test')
+          .createCounter<int>(name: 'pings');
+      counter.add(3);
+      counter.add(2);
+
+      // Nothing exported yet — no timer has fired.
+      expect(harness.metrics.metrics, isEmpty);
+
+      await harness.collectMetrics();
+      final metric = harness.metrics.findMetricByName('pings');
+      expect(metric, isNotNull);
+    });
+  });
+
+  group('maybeInitializeOtelForTest', () {
+    test('returns the same harness on repeat calls in the same process',
+        () async {
+      final again = await maybeInitializeOtelForTest();
+      expect(identical(again, harness), isTrue);
+    });
+  });
+}

--- a/test/unit/trace/debug_logging_coverage_test.dart
+++ b/test/unit/trace/debug_logging_coverage_test.dart
@@ -539,13 +539,14 @@ void main() {
     span.end();
   });
 
-  test('tracer startSpanWithContext logs debug', () {
+  test('tracer startSpan with explicit context logs debug', () {
+    // Migrated from the removed `startSpanWithContext`.
     final tracer = OTel.tracer();
     final ctx = OTel.context();
     logOutput.clear();
 
-    final span = tracer.startSpanWithContext(
-      name: 'ctx-span-test',
+    final span = tracer.startSpan(
+      'ctx-span-test',
       context: ctx,
     );
     expect(span, isNotNull);
@@ -555,7 +556,7 @@ void main() {
         (msg) => msg.contains('Tracer') && msg.contains('Starting span'),
       ),
       isTrue,
-      reason: 'Expected Tracer startSpan debug log from startSpanWithContext',
+      reason: 'Expected Tracer startSpan debug log when context is passed',
     );
     span.end();
   });

--- a/test/unit/trace/tracer_methods_test.dart
+++ b/test/unit/trace/tracer_methods_test.dart
@@ -406,14 +406,20 @@ void main() {
     });
   });
 
-  group('startSpanWithContext', () {
+  group('startSpan with explicit context', () {
+    // Migrated from the removed `startSpanWithContext`. The behavior is
+    // the same — pass an explicit `Context` and the span uses it as
+    // its parent — but expressed via the unified `startSpan(name,
+    // context: ...)` API. To make the returned span active for a scope,
+    // use `tracer.withSpan` / `withSpanAsync`.
+
     test('creates span with given context', () async {
       final tracer = OTel.tracer();
       final parentSpan = tracer.startSpan('parent-span');
       final parentContext = Context.current.withSpan(parentSpan);
 
-      final childSpan = tracer.startSpanWithContext(
-        name: 'child-with-context',
+      final childSpan = tracer.startSpan(
+        'child-with-context',
         context: parentContext,
       );
 
@@ -437,8 +443,8 @@ void main() {
       final parentSpan = tracer.startSpan('parent-for-context');
       final parentContext = Context.current.withSpan(parentSpan);
 
-      final childSpan = tracer.startSpanWithContext(
-        name: 'context-child',
+      final childSpan = tracer.startSpan(
+        'context-child',
         context: parentContext,
       );
 


### PR DESCRIPTION
## Summary

Two changes shipping together in `1.1.0-beta.5`:

1. **Adds `package:dartastic_opentelemetry/testing.dart`** — opt-in library with the in-memory test harness used by the dart-otel-reference-demo and every OTel-Dart wrapper. Consolidates ~7 wrapper-side copies of the same `test/_helpers/otel_test_harness.dart` into one canonical export.
2. **Removes `Tracer.startSpanWithContext`** — `@Deprecated` since 1.1.0-beta (released 2026-05-07), four betas of warning.

## `package:dartastic_opentelemetry/testing.dart`

Deliberately **not** re-exported from the main barrel so production bundles don't carry the in-memory exporter classes. Consumers import the path explicitly (matches `package:flutter_test/flutter_test.dart`).

Exports:
- `InMemorySpanExporter` — `findSpanByName` / `findSpansByName` / `findSpansStartingWith` / `clear`
- `InMemoryLogExporter` — `findRecordsBySeverity`
- `InMemoryMetricExporter`
- `OnDemandMetricReader` — timer-free; tests drive `collect()` explicitly
- `TestHarness` — bundles all three exporters + the reader; `.clear()` helper
- `maybeInitializeOtelForTest()` — singleton initializer for `setUpAll`

Self-tested in `test/unit/testing_lib_test.dart` — 6 tests covering: span query helpers, clear semantics, most-recent-wins on `findSpanByName`, log severity filter, on-demand metric collection, singleton-init identity.

Wrappers can drop their local `test/_helpers/otel_test_harness.dart` and switch to `import 'package:dartastic_opentelemetry/testing.dart';` once `beta.5` lands on pub.dev.

## Removing `Tracer.startSpanWithContext`

1:1 rename, pass the context to `startSpan` directly:

\`\`\`dart
// Before
tracer.startSpanWithContext(name: x, context: ctx, kind: k, attributes: a);

// After
tracer.startSpan(x, context: ctx, kind: k, attributes: a);
\`\`\`

To make the returned span active for a scope, wrap the work with `tracer.withSpan` (sync) or `tracer.withSpanAsync` (async). The deprecated method had stopped activating the span as of 1.1.0-beta anyway, so any call site that relied on activation already needed updating.

Three test sites migrated to `startSpan(name, context: ...)`:
- `test/unit/sdk_edge_cases_test.dart`
- `test/unit/trace/tracer_methods_test.dart`
- `test/unit/trace/debug_logging_coverage_test.dart`

## Test plan

- [x] \`dart analyze\` clean (lib + new test)
- [x] \`dart test test/unit/testing_lib_test.dart\` — 6/6 pass
- [x] \`dart test\` — full suite
- [x] Confirm Flutterrific companion PR for `UITracer` override is ready to land alongside

🤖 Generated with [Claude Code](https://claude.com/claude-code)