### PR TITLE
Fix/otel spec env vars defaults & metric collector observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.6-wip]
 
+### Fixed
+- **Default metrics pipeline no longer prints to stdout.** `OTel.initialize()` used to wrap the default OTLP metric exporter in a `CompositeMetricExporter` with `ConsoleMetricExporter`, so every server using the SDK with zero env vars dumped metric payloads to the console. The default is now OTLP-only, matching traces and logs (and the OTel spec, which specifies `otlp` as the default for all three signals — never `console`). To opt back into stdout output set `OTEL_METRICS_EXPORTER=console` (or pass an explicit `metricExporter`/`metricReader` to `OTel.initialize`).
+
+### Added
+- **`OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` now honored end-to-end.** Each accepts `otlp` (default), `console`, or `none`; `none` skips processor/reader installation for that signal entirely. Previously only `OTEL_TRACES_EXPORTER` and `OTEL_LOGS_EXPORTER` were partially read and `OTEL_METRICS_EXPORTER` was ignored.
+- **`OTEL_SDK_DISABLED=true` global off-switch.** When set, `OTel.initialize()` installs no span processors, metric readers, or log record processors — the SDK becomes a no-op for all three signals. Implemented via the new `OTelEnv.isSdkDisabled()` helper.
+
 ## [1.1.0-beta.5] - 2026-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [1.1.0-beta.6-wip]
+- **Bumped `dartastic_opentelemetry_api` to `^1.0.0-beta.7`.** Beta.7 fixes observable metrics and standard env var defaults.
 
 ### Fixed
 - **Default metrics pipeline no longer prints to stdout.** `OTel.initialize()` used to wrap the default OTLP metric exporter in a `CompositeMetricExporter` with `ConsoleMetricExporter`, so every server using the SDK with zero env vars dumped metric payloads to the console. The default is now OTLP-only, matching traces and logs (and the OTel spec, which specifies `otlp` as the default for all three signals — never `console`). To opt back into stdout output set `OTEL_METRICS_EXPORTER=console` (or pass an explicit `metricExporter`/`metricReader` to `OTel.initialize`).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenTelemetry Specification](https://img.shields.io/badge/OpenTelemetry-Specification-blueviolet)](https://opentelemetry.io/docs/specs/otel/)
-[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)
+[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)](https://dartastic.github.io/dartastic_opentelemetry/)
 
 Dartastic is an [OpenTelemetry](https://opentelemetry.io/) SDK to add standard observability to Dart applications.
 Dartastic can be used with any OTel backend since it's standards-compliant.
@@ -14,22 +14,27 @@ to become the official standard for Dart OpenTelemetry.
 
 Flutter developers should use the [Flutterific OpenTelemetry SDK](https://pub.dev/packages/flutterrific_opentelemetry/) which builds on top of Dartastic OTel.
 
-Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Mindful Software](https://mindfulsoftware.com)
+Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Dartastic.io](https://dartastic.io)
 
 ## Commercial Support
 
 [Dartastic.io](https://dartastic.io) tools and services for Dart and Flutter teams shipping to production.
-* **Dartastic.io Pro OTel**
+* **Dartastic Pro OTel Runtime**
+  * Native OTel runtime that takes OTel of the UI thread or server threads.
+    * Detects native crashes
+    * Identifies the janky widget
+    * Strips PII out of your data on the fly.
+    * Sends source code lines with error spans with Symbolizer.
+    * Metrics from iOS, Android and Linux, standard and beyond the standard. 
+    * Use with any o11y backend.
   * Professionally supported version of this open source dartastic_opentelemetry package and dartastic_opentelemetry_api - and their future CNCF equivalents.
-  * Professional OpenTelemetry libraries for Dart and Flutter
-    * Keep PII out of your observability data.
-    * Integrate OTel observability into common Dart and Flutter like shelf, dio and go_router.
-* **Dartastic.io Pub Dev** [pub.dartastic.io](pub.dartastic.io) Privately share your packages and plugins with your team,
+  * Over 50 OSS OpenTelemetry integration libraries for Dart and Flutter - dio, shelf, logger...
+  * Over 600 Pro OpenTelemetry integration libraries for Dart and Flutter - anthropic, aws, azure, stripe...
+* **Dartastic Pub** [pub.dartastic.io](pub.dartastic.io) Privately share your packages and plugins with your team,
   partners and customers.
-* **Dartastic.io Symbolizer** [symbolizer.dartastic.io](symbolizer.dartastic.io) Turn production errors into
+* **Dartastic Symbolizer** [symbolizer.dartastic.io](symbolizer.dartastic.io) Turn production errors into
   source code lines with a Web API call. Squash Dart and Flutter bugs fast and keep your source code artifacts private.
-* **Dartastic.io Observability Cloud** - observability backends, customized for Dart and Flutter and integrated with Dartastic.io Symbolizer.
-* Dart and Flutter OpenTelemetry support, training, consulting, integrations and upgrades.
+* **Dartastic Hosted** - spin up a private observability ecosystem customized for Flutter and Dart - private pub server, private unlimited Symbolizer, custom dashboards for Dart and Flutter.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -922,6 +922,7 @@ Constants are defined for all 74 OpenTelemetry environment variables. See `lib/s
 | `otelServiceName`          | `OTEL_SERVICE_NAME`         | Sets the service name             | `my-dart-app`                           |
 | `otelResourceAttributes`   | `OTEL_RESOURCE_ATTRIBUTES`  | Additional resource attributes    | `environment=prod,region=us-west`       |
 | `otelLogLevel`             | `OTEL_LOG_LEVEL`            | SDK internal log level            | `INFO`, `DEBUG`, `WARN`, `ERROR`        |
+| `otelSdkDisabled`          | `OTEL_SDK_DISABLED`         | Global off-switch — when `true`, the SDK installs no span processors, metric readers, or log record processors (true no-op across all three signals, including explicit overrides) | `true` |
 
 #### OTLP Exporter Configuration
 
@@ -935,32 +936,34 @@ Constants are defined for all 74 OpenTelemetry environment variables. See `lib/s
 
 #### Signal-Specific Configuration
 
+Per the OTel spec, the default exporter for every signal is `otlp` (HTTP/protobuf to `http://localhost:4318`). Each `OTEL_*_EXPORTER` env var accepts `otlp` (default), `console` (prints to stdout — useful for local debugging), or `none` (skips processor/reader installation for that signal entirely). `OTEL_SDK_DISABLED=true` silences all three signals globally and overrides everything else.
+
 ##### Traces
 
-| Constant                              | Environment Variable                    | Description               |
-|---------------------------------------|-----------------------------------------|---------------------------|
-| `otelTracesExporter`                  | `OTEL_TRACES_EXPORTER`                  | Trace exporter type       |
-| `otelExporterOtlpTracesEndpoint`      | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`    | Traces-specific endpoint  |
-| `otelExporterOtlpTracesProtocol`      | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`    | Traces-specific protocol  |
-| `otelExporterOtlpTracesHeaders`       | `OTEL_EXPORTER_OTLP_TRACES_HEADERS`     | Traces-specific headers   |
+| Constant                              | Environment Variable                    | Description                                              | Default |
+|---------------------------------------|-----------------------------------------|----------------------------------------------------------|---------|
+| `otelTracesExporter`                  | `OTEL_TRACES_EXPORTER`                  | Trace exporter type (`otlp`, `console`, `none`)          | `otlp`  |
+| `otelExporterOtlpTracesEndpoint`      | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`    | Traces-specific endpoint                                 |         |
+| `otelExporterOtlpTracesProtocol`      | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`    | Traces-specific protocol                                 |         |
+| `otelExporterOtlpTracesHeaders`       | `OTEL_EXPORTER_OTLP_TRACES_HEADERS`     | Traces-specific headers                                  |         |
 
 ##### Metrics
 
-| Constant                              | Environment Variable                    | Description               |
-|---------------------------------------|-----------------------------------------|---------------------------|
-| `otelMetricsExporter`                 | `OTEL_METRICS_EXPORTER`                 | Metrics exporter type     |
-| `otelExporterOtlpMetricsEndpoint`     | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`   | Metrics-specific endpoint |
-| `otelExporterOtlpMetricsProtocol`     | `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`   | Metrics-specific protocol |
-| `otelExporterOtlpMetricsHeaders`      | `OTEL_EXPORTER_OTLP_METRICS_HEADERS`    | Metrics-specific headers  |
+| Constant                              | Environment Variable                    | Description                                              | Default |
+|---------------------------------------|-----------------------------------------|----------------------------------------------------------|---------|
+| `otelMetricsExporter`                 | `OTEL_METRICS_EXPORTER`                 | Metrics exporter type (`otlp`, `console`, `none`)        | `otlp`  |
+| `otelExporterOtlpMetricsEndpoint`     | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`   | Metrics-specific endpoint                                |         |
+| `otelExporterOtlpMetricsProtocol`     | `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`   | Metrics-specific protocol                                |         |
+| `otelExporterOtlpMetricsHeaders`      | `OTEL_EXPORTER_OTLP_METRICS_HEADERS`    | Metrics-specific headers                                 |         |
 
 ##### Logs
 
-| Constant                              | Environment Variable                    | Description               |
-|---------------------------------------|-----------------------------------------|---------------------------|
-| `otelLogsExporter`                    | `OTEL_LOGS_EXPORTER`                    | Logs exporter type (`otlp`, `console`, `none`) |
-| `otelExporterOtlpLogsEndpoint`        | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`      | Logs-specific endpoint    |
-| `otelExporterOtlpLogsProtocol`        | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`      | Logs-specific protocol    |
-| `otelExporterOtlpLogsHeaders`         | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`       | Logs-specific headers     |
+| Constant                              | Environment Variable                    | Description                                              | Default |
+|---------------------------------------|-----------------------------------------|----------------------------------------------------------|---------|
+| `otelLogsExporter`                    | `OTEL_LOGS_EXPORTER`                    | Logs exporter type (`otlp`, `console`, `none`)           | `otlp`  |
+| `otelExporterOtlpLogsEndpoint`        | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`      | Logs-specific endpoint                                   |         |
+| `otelExporterOtlpLogsProtocol`        | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`      | Logs-specific protocol                                   |         |
+| `otelExporterOtlpLogsHeaders`         | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`       | Logs-specific headers                                    |         |
 
 ##### Batch LogRecord Processor (BLRP)
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -36,9 +36,10 @@ Future<void> main() async {
   await OTel.initialize(
     serviceName: 'example-service',
     serviceVersion: '1.0.0',
-    // Default endpoint is http://localhost:4317 for local OTLP collector
-    // For production, set your collector endpoint:
-    // endpoint: 'https://your-collector.example.com:4317',
+    // Default endpoint is http://localhost:4318 (OTLP/HTTP per spec).
+    // Override via OTEL_EXPORTER_OTLP_ENDPOINT env var, or pass `endpoint:`
+    // explicitly. For gRPC, also set OTEL_EXPORTER_OTLP_PROTOCOL=grpc and
+    // point at port 4317.
   );
 
   // Get the default tracer

--- a/example/propagator_example.dart
+++ b/example/propagator_example.dart
@@ -17,7 +17,6 @@ import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 void main() async {
   await OTel.initialize(
     serviceName: 'propagator-example',
-    endpoint: 'http://localhost:4317',
   );
 
   print('=== W3C Trace Context Propagator Example ===\n');

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -364,6 +364,13 @@ class OTelEnv {
     return resourceAttrs;
   }
 
+  /// Whether `OTEL_SDK_DISABLED` is set to a truthy value.
+  ///
+  /// Per the OTel spec, when this is true the SDK acts as a no-op for all
+  /// signals — no span processors, metric readers, or log record processors
+  /// should be installed.
+  static bool isSdkDisabled() => _getEnvBool(otelSdkDisabled);
+
   /// Get the selected exporter for a signal.
   ///
   /// Returns the exporter type configured via environment variables.

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -10,7 +10,6 @@ import '../../resource/resource.dart';
 import '../meter_provider.dart';
 import '../metric_exporter.dart';
 import '../metric_reader.dart';
-import 'composite_metric_exporter.dart';
 import 'otlp/http/otlp_http_metric_exporter.dart';
 import 'otlp/http/otlp_http_metric_exporter_config.dart';
 import 'otlp/otlp_grpc_metric_exporter.dart';
@@ -21,11 +20,14 @@ class MetricsConfiguration {
   /// Configures a MeterProvider with given settings.
   ///
   /// This configures everything needed for metrics pipeline:
-  /// - An exporter (defaults to OtlpHttpMetricExporter using http/protobuf,
-  ///   the OTel spec default; selects gRPC when OTEL_EXPORTER_OTLP_PROTOCOL
-  ///   or OTEL_EXPORTER_OTLP_METRICS_PROTOCOL is set to `grpc`)
+  /// - An exporter selected per the OTel spec:
+  ///   `OTEL_METRICS_EXPORTER=otlp` (default) → OtlpHttp/Grpc exporter,
+  ///   `=console` → ConsoleMetricExporter, `=none` → no reader is added.
   /// - A reader (defaults to PeriodicExportingMetricReader if none provided)
   /// - Sets up resources on the MeterProvider
+  ///
+  /// An explicit [metricExporter] or [metricReader] always wins over the
+  /// env-var selection so programmatic configuration is unsurprising.
   static MeterProvider configureMeterProvider({
     String endpoint = 'http://localhost:4318',
     bool secure = false,
@@ -33,32 +35,65 @@ class MetricsConfiguration {
     MetricReader? metricReader,
     Resource? resource,
   }) {
-    // If no exporter is provided, create a default one
-    metricExporter ??= _createDefaultExporter(endpoint, secure);
+    final meterProvider = OTel.meterProvider();
+    if (resource != null) {
+      meterProvider.resource = resource;
+    }
 
-    // If no reader is provided, create a periodic exporting metric reader
+    // Honor OTEL_METRICS_EXPORTER, but only when the caller did not pass an
+    // explicit exporter/reader — explicit args are an unambiguous opt-in and
+    // should not be silently dropped by env config.
+    if (metricExporter == null && metricReader == null) {
+      final exporterType =
+          OTelEnv.getExporter(signal: 'metrics')?.toLowerCase() ?? 'otlp';
+      if (exporterType == 'none') {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+              'MetricsConfiguration: OTEL_METRICS_EXPORTER=none, skipping reader');
+        }
+        return meterProvider;
+      }
+      metricExporter = _createExporter(exporterType, endpoint, secure);
+      if (metricExporter == null) {
+        return meterProvider;
+      }
+    }
+
+    metricExporter ??= _createExporter('otlp', endpoint, secure);
+    if (metricExporter == null) {
+      return meterProvider;
+    }
+
     metricReader ??= PeriodicExportingMetricReader(
       metricExporter,
       interval: const Duration(seconds: 15),
     );
 
-    // Get meter provider
-    final meterProvider = OTel.meterProvider();
-
-    // Set resource if provided
-    if (resource != null) {
-      meterProvider.resource = resource;
-    }
-
-    // Add the metric reader
     meterProvider.addMetricReader(metricReader);
-
     return meterProvider;
   }
 
-  /// Creates the default metric exporter using the protocol indicated by
-  /// the OTel environment variables (defaulting to http/protobuf per spec).
-  static MetricExporter _createDefaultExporter(String endpoint, bool secure) {
+  /// Creates a metric exporter for [exporterType] (`otlp` or `console`).
+  /// Returns null for unknown values.
+  static MetricExporter? _createExporter(
+    String exporterType,
+    String endpoint,
+    bool secure,
+  ) {
+    if (exporterType == 'console') {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('MetricsConfiguration: Creating ConsoleMetricExporter');
+      }
+      return ConsoleMetricExporter();
+    }
+    if (exporterType != 'otlp') {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+            'MetricsConfiguration: Unknown OTEL_METRICS_EXPORTER value '
+            '"$exporterType", falling back to otlp');
+      }
+    }
+
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
     final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
     final headers = otlpConfig['headers'] as Map<String, String>? ?? const {};
@@ -69,13 +104,12 @@ class MetricsConfiguration {
     final clientKey = otlpConfig['clientKey'] as String?;
     final clientCertificate = otlpConfig['clientCertificate'] as String?;
 
-    final MetricExporter otlpExporter;
     if (protocol == 'grpc') {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
             'MetricsConfiguration: Creating OtlpGrpcMetricExporter for $endpoint');
       }
-      otlpExporter = OtlpGrpcMetricExporter(
+      return OtlpGrpcMetricExporter(
         OtlpGrpcMetricExporterConfig(
           endpoint: endpoint,
           insecure: !secure,
@@ -87,25 +121,22 @@ class MetricsConfiguration {
           clientCertificate: clientCertificate,
         ),
       );
-    } else {
-      if (OTelLog.isDebug()) {
-        OTelLog.debug(
-            'MetricsConfiguration: Creating OtlpHttpMetricExporter for $endpoint');
-      }
-      otlpExporter = OtlpHttpMetricExporter(
-        OtlpHttpMetricExporterConfig(
-          endpoint: endpoint,
-          headers: headers,
-          timeout: timeout,
-          compression: compression,
-          certificate: certificate,
-          clientKey: clientKey,
-          clientCertificate: clientCertificate,
-        ),
-      );
     }
 
-    // Use a composite exporter for both OTLP and Console output
-    return CompositeMetricExporter([otlpExporter, ConsoleMetricExporter()]);
+    if (OTelLog.isDebug()) {
+      OTelLog.debug(
+          'MetricsConfiguration: Creating OtlpHttpMetricExporter for $endpoint');
+    }
+    return OtlpHttpMetricExporter(
+      OtlpHttpMetricExporterConfig(
+        endpoint: endpoint,
+        headers: headers,
+        timeout: timeout,
+        compression: compression,
+        certificate: certificate,
+        clientKey: clientKey,
+        clientCertificate: clientCertificate,
+      ),
+    );
   }
 }

--- a/lib/src/metrics/instruments/observable_counter.dart
+++ b/lib/src/metrics/instruments/observable_counter.dart
@@ -200,11 +200,17 @@ class ObservableCounter<T extends num>
   /// Collects metrics for the SDK metric export.
   ///
   /// This is called by the MeterProvider during metric collection.
+  /// Per the OTel spec, observable instruments must invoke their
+  /// registered callbacks on every collection cycle. Drive [collect]
+  /// first so the callback runs and storage reflects the latest
+  /// absolute counter value before we read it.
   @override
   List<Metric> collectMetrics() {
     if (!enabled) {
       return [];
     }
+
+    collect();
 
     // Get the points from storage
     final points = collectPoints();

--- a/lib/src/metrics/instruments/observable_gauge.dart
+++ b/lib/src/metrics/instruments/observable_gauge.dart
@@ -152,11 +152,19 @@ class ObservableGauge<T extends num>
   /// Collects metrics for the SDK metric export.
   ///
   /// This is called by the MeterProvider during metric collection.
+  /// Per the OTel spec, observable instruments must invoke their
+  /// registered callbacks on every collection cycle and report the
+  /// values the callback observes — that's the whole point of being
+  /// "observable" vs sync. Drive [collect] first so the callback
+  /// runs and storage is fresh; discard the returned measurements
+  /// (collect already pushed them into [_storage]).
   @override
   List<Metric> collectMetrics() {
     if (!enabled) {
       return [];
     }
+
+    collect();
 
     // Get the points from storage
     final points = collectPoints();

--- a/lib/src/metrics/instruments/observable_up_down_counter.dart
+++ b/lib/src/metrics/instruments/observable_up_down_counter.dart
@@ -182,11 +182,17 @@ class ObservableUpDownCounter<T extends num>
   /// Collects metrics for the SDK metric export.
   ///
   /// This is called by the MeterProvider during metric collection.
+  /// Per the OTel spec, observable instruments must invoke their
+  /// registered callbacks on every collection cycle. Drive [collect]
+  /// first so the callback runs and storage reflects the latest
+  /// value before we read it.
   @override
   List<Metric> collectMetrics() {
     if (!enabled) {
       return [];
     }
+
+    collect();
 
     // Get the points from storage
     final points = collectPoints();

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -344,7 +344,15 @@ class OTel {
       }
     }
 
-    if (spanProcessor == null) {
+    // OTEL_SDK_DISABLED=true is the spec-defined global off-switch: all three
+    // signals become no-ops. Honoring this here keeps signal-specific configs
+    // (`OTEL_*_EXPORTER`) from being ever consulted.
+    final sdkDisabled = OTelEnv.isSdkDisabled();
+    if (sdkDisabled && OTelLog.isDebug()) {
+      OTelLog.debug('OTel: OTEL_SDK_DISABLED=true, skipping all signal setup');
+    }
+
+    if (spanProcessor == null && !sdkDisabled) {
       // Determine which exporter to create based on environment or defaults
       final exporterType = OTelEnv.getExporter(signal: 'traces') ?? 'otlp';
 
@@ -427,13 +435,15 @@ class OTel {
       // If exporterType == 'none', spanProcessor remains null and no processor is added
     }
 
-    // Create and configure TracerProvider
-    if (spanProcessor != null) {
+    // Create and configure TracerProvider — but when OTEL_SDK_DISABLED=true,
+    // do not install any processor even if the caller passed one explicitly,
+    // so the SDK is a true no-op for traces.
+    if (spanProcessor != null && !sdkDisabled) {
       OTel.tracerProvider().addSpanProcessor(spanProcessor);
     }
 
     // Configure metrics if enabled
-    if (enableMetrics) {
+    if (enableMetrics && !sdkDisabled) {
       // If no explicit metric exporter is provided, create one with the same endpoint
       if (metricExporter == null && metricReader == null) {
         MetricsConfiguration.configureMeterProvider(
@@ -454,7 +464,7 @@ class OTel {
     }
 
     // Configure logs if enabled
-    if (enableLogs) {
+    if (enableLogs && !sdkDisabled) {
       LogsConfiguration.configureLoggerProvider(
         endpoint: endpoint,
         secure: secure,

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -313,7 +313,7 @@ TestHarness? _shared;
 ///   Override only if your code-under-test reads it.
 Future<TestHarness> maybeInitializeOtelForTest({
   String serviceName = 'otel-test',
-  String endpoint = 'http://localhost:4317',
+  String endpoint = OTel.defaultEndpoint,
 }) async {
   if (_shared != null) return _shared!;
   final spanExporter = InMemorySpanExporter();

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -1,5 +1,5 @@
 // Licensed under the Apache License, Version 2.0
-// Copyright 2025, Mindful Software LLC, All rights reserved.
+// Copyright 2025, Dartastic.io, All rights reserved.
 
 /// Test helpers for the Dartastic OpenTelemetry SDK.
 ///
@@ -33,7 +33,7 @@
 ///   calls.
 ///
 /// The shape mirrors the test harness used in the OTel-Dart reference
-/// demo at https://github.com/MindfulSoftwareLLC/dart-otel-reference-demo
+/// demo at https://github.com/dartastic/dart-otel-reference-demo
 /// so wrappers, customer apps, and the reference demo all use the same
 /// scaffolding.
 library;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-beta.6
+  dartastic_opentelemetry_api: ^1.0.0-beta.7
   fixnum: ^1.1.1
   grpc: ^5.1.0
   http: ^1.5.0

--- a/test/unit/environment/helpers/check_initialized_pipeline.dart
+++ b/test/unit/environment/helpers/check_initialized_pipeline.dart
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Helper script: calls OTel.initialize() with no parameters and prints a
+// JSON snapshot of the resulting pipeline (span processors, metric readers,
+// log record processors, and the exporter type each wraps). Used by
+// subprocess tests to verify behavior under different env var combinations.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+String _exporterTag(Object? exporter) {
+  if (exporter == null) return 'null';
+  if (exporter is CompositeMetricExporter) {
+    return 'CompositeMetricExporter(${exporter.exporters.map(_exporterTag).join(',')})';
+  }
+  if (exporter is CompositeExporter) {
+    return 'CompositeExporter(${exporter.spanExporters.map(_exporterTag).join(',')})';
+  }
+  return exporter.runtimeType.toString();
+}
+
+String _spanProcessorTag(SpanProcessor processor) {
+  if (processor is BatchSpanProcessor) {
+    return 'BatchSpanProcessor(${_exporterTag(processor.exporter)})';
+  }
+  if (processor is SimpleSpanProcessor) {
+    return 'SimpleSpanProcessor';
+  }
+  return processor.runtimeType.toString();
+}
+
+String _logProcessorTag(LogRecordProcessor processor) {
+  if (processor is BatchLogRecordProcessor) {
+    return 'BatchLogRecordProcessor(${_exporterTag(processor.exporter)})';
+  }
+  if (processor is SimpleLogRecordProcessor) {
+    return 'SimpleLogRecordProcessor';
+  }
+  return processor.runtimeType.toString();
+}
+
+String _readerTag(MetricReader reader) {
+  if (reader is PeriodicExportingMetricReader) {
+    return 'PeriodicExportingMetricReader(${_exporterTag(reader.exporter)})';
+  }
+  return reader.runtimeType.toString();
+}
+
+Future<void> main() async {
+  await OTel.initialize();
+
+  final tracerProvider = OTel.tracerProvider();
+  final meterProvider = OTel.meterProvider();
+  final loggerProvider = OTel.loggerProvider();
+
+  final snapshot = <String, dynamic>{
+    'spanProcessors':
+        tracerProvider.spanProcessors.map(_spanProcessorTag).toList(),
+    'metricReaders': meterProvider.metricReaders.map(_readerTag).toList(),
+    'logRecordProcessors':
+        loggerProvider.logRecordProcessors.map(_logProcessorTag).toList(),
+  };
+
+  print(jsonEncode(snapshot));
+
+  // Force-exit to avoid waiting on the periodic metric reader timer or any
+  // background batch timers — we just want the pipeline snapshot.
+  exit(0);
+}

--- a/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
+++ b/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
@@ -13,8 +13,7 @@ import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('collectMetrics() fires callback per OTel spec (#155 regression)',
-      () {
+  group('collectMetrics() fires callback per OTel spec (#155 regression)', () {
     late MeterProvider meterProvider;
     late Meter meter;
 

--- a/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
+++ b/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
@@ -1,0 +1,120 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+//
+// Regression for #155 — the OTel spec requires observable instruments
+// to invoke their registered callbacks on every collection cycle. Pre-
+// fix, collectMetrics() read from internal storage without driving the
+// callback, so a customer who registered an ObservableGauge with a
+// callback and let the metric reader scrape it (the normal usage path)
+// got an empty series. These tests pin the post-fix contract: one call
+// to collectMetrics() == one callback fire, no manual collect() needed.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/metrics/instruments/observable_counter.dart';
+import 'package:dartastic_opentelemetry/src/metrics/instruments/observable_gauge.dart';
+import 'package:dartastic_opentelemetry/src/metrics/instruments/observable_up_down_counter.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('collectMetrics() fires callback per OTel spec (#155 regression)',
+      () {
+    late MeterProvider meterProvider;
+    late Meter meter;
+
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'test-service',
+        endpoint: 'http://localhost:4317',
+        detectPlatformResources: false,
+      );
+      meterProvider = OTel.meterProvider();
+      meter = meterProvider.getMeter(name: 'test-meter') as Meter;
+    });
+
+    tearDown(() async {
+      await meterProvider.shutdown();
+      await OTel.reset();
+    });
+
+    test('ObservableGauge: one collectMetrics == one callback fire', () {
+      var fires = 0;
+      final gauge = meter.createObservableGauge<int>(
+        name: 'g',
+        callback: (APIObservableResult<int> r) {
+          fires++;
+          r.observe(fires);
+        },
+      ) as ObservableGauge<int>;
+
+      // No manual collect() — this is the spec-correct usage path.
+      final metrics = gauge.collectMetrics();
+      expect(fires, equals(1), reason: 'collectMetrics must fire callback');
+      expect(metrics.single.points.single.value, equals(1));
+
+      gauge.collectMetrics();
+      expect(fires, equals(2));
+
+      gauge.collectMetrics();
+      expect(fires, equals(3));
+    });
+
+    test('ObservableCounter: one collectMetrics == one callback fire', () {
+      var fires = 0;
+      var cumulative = 0;
+      final counter = meter.createObservableCounter<int>(
+        name: 'c',
+        callback: (APIObservableResult<int> r) {
+          fires++;
+          cumulative += 10;
+          r.observe(cumulative);
+        },
+      ) as ObservableCounter<int>;
+
+      final metrics = counter.collectMetrics();
+      expect(fires, equals(1));
+      expect(metrics.single.points.single.value, equals(10));
+
+      counter.collectMetrics();
+      expect(fires, equals(2));
+    });
+
+    test('ObservableUpDownCounter: one collectMetrics == one callback fire',
+        () {
+      var fires = 0;
+      final counter = meter.createObservableUpDownCounter<int>(
+        name: 'udc',
+        callback: (APIObservableResult<int> r) {
+          fires++;
+          r.observe(fires * 100);
+        },
+      ) as ObservableUpDownCounter<int>;
+
+      final metrics = counter.collectMetrics();
+      expect(fires, equals(1));
+      expect(metrics.single.points.single.value, equals(100));
+
+      counter.collectMetrics();
+      expect(fires, equals(2));
+    });
+
+    test('storage reflects callback value after collectMetrics, not before',
+        () {
+      // The bug surfaced as "register a gauge, scrape — series stays at
+      // zero". Pin that: a fresh gauge whose callback returns a fixed
+      // nonzero value should report that value on the FIRST scrape, no
+      // warm-up call required.
+      final gauge = meter.createObservableGauge<int>(
+        name: 'fresh',
+        callback: (APIObservableResult<int> r) => r.observe(42),
+      ) as ObservableGauge<int>;
+
+      final metrics = gauge.collectMetrics();
+      expect(metrics, isNotEmpty,
+          reason: 'collectMetrics on a freshly-registered observable '
+              'gauge must return data, not an empty list');
+      expect(metrics.single.points.single.value, equals(42));
+    });
+  });
+}

--- a/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
+++ b/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
@@ -10,10 +10,6 @@
 // to collectMetrics() == one callback fire, no manual collect() needed.
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
-import 'package:dartastic_opentelemetry/src/metrics/instruments/observable_counter.dart';
-import 'package:dartastic_opentelemetry/src/metrics/instruments/observable_gauge.dart';
-import 'package:dartastic_opentelemetry/src/metrics/instruments/observable_up_down_counter.dart';
-import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/unit/metrics/instruments/observable_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_counter_test.dart
@@ -316,14 +316,16 @@ void main() {
       // Sum metrics from ObservableCounter are monotonic
       expect(metric.points.isNotEmpty, isTrue);
 
-      // Verify the points
+      // Verify the points. collectMetrics() drives one more callback
+      // per the OTel spec; the cumulative counter advances by another
+      // +5 per fire.
       expect(metric.points.length, equals(1));
-      expect(metric.points[0].value, equals(5));
+      expect(metric.points[0].value, equals(10)); // fires 1, 2 → 10
 
-      // Second collection - check the cumulative value
+      // Second pass: collect → fire 3 (15), collectMetrics → fire 4 (20).
       counter.collect();
       final metrics2 = counter.collectMetrics();
-      expect(metrics2[0].points[0].value, equals(10)); // 5 + 5
+      expect(metrics2[0].points[0].value, equals(20));
     });
 
     test('ObservableCounter with disabled meter', () {
@@ -372,18 +374,19 @@ void main() {
         },
       ) as ObservableCounter<int>;
 
-      // First collection
+      // First collection. collectMetrics() drives one more callback per
+      // the OTel spec; value advances +25 per fire after the observe.
       counter.collect();
 
-      // Verify point exists
       final metrics1 = counter.collectMetrics();
       expect(metrics1[0].points.length, equals(1));
-      expect(metrics1[0].points[0].value, equals(100));
+      expect(metrics1[0].points[0].value, equals(125)); // fires 1, 2
 
-      // Second collection
+      // Second pass: collect → fire 3 (observe 150), collectMetrics
+      // → fire 4 (observe 175).
       counter.collect();
       final metrics2 = counter.collectMetrics();
-      expect(metrics2[0].points[0].value, equals(125));
+      expect(metrics2[0].points[0].value, equals(175));
 
       // Shutdown the meter provider (should clear internal state)
       await meterProvider.shutdown();

--- a/test/unit/metrics/instruments/observable_gauge_test.dart
+++ b/test/unit/metrics/instruments/observable_gauge_test.dart
@@ -71,9 +71,12 @@ void main() {
       // Verify this is a gauge metric with the correct properties
       expect(metrics[0].type, equals(MetricType.gauge));
 
-      // Verify the points
+      // Verify the points. collectMetrics() drives one more callback
+      // per the OTel spec (observable instruments are observed at
+      // collection time), so the stored value reflects the third
+      // observation — 25.5 + 1.5 + 1.5 = 28.5.
       expect(metrics[0].points.length, equals(1));
-      expect(metrics[0].points[0].value, equals(27.0)); // Latest value
+      expect(metrics[0].points[0].value, equals(28.5));
     });
 
     test('ObservableGauge with attributes', () {
@@ -137,26 +140,30 @@ void main() {
       expect(metrics[0].type, equals(MetricType.gauge));
       expect(metrics[0].points.length, equals(2));
 
-      // Points should have the latest values
+      // Points should have the latest values. collectMetrics() drives
+      // one more callback per the OTel spec, so values advance one tick:
+      // attributes1: 22.5 + 0.5 + 0.5 = 23.5
+      // attributes2: 24.8 - 0.2 - 0.2 = 24.4
       final point1 =
           metrics[0].points.where((p) => p.attributes == attributes1).first;
       final point2 =
           metrics[0].points.where((p) => p.attributes == attributes2).first;
-      expect(point1.value, closeTo(23.0, 0.001));
-      expect(point2.value, closeTo(24.6, 0.001));
+      expect(point1.value, closeTo(23.5, 0.001));
+      expect(point2.value, closeTo(24.4, 0.001));
 
-      // third collection
+      // fourth collection (collectMetrics already advanced the state
+      // one tick via its internal collect call).
       final measurements3 = gauge.collect();
       expect(measurements3.length, equals(2));
 
-      // Values should reflect the changes
+      // Values reflect one more tick beyond the collectMetrics fire.
       expect(
         measurements3.where((m) => m.attributes == attributes1).first.value,
-        closeTo(23.5, 0.001),
+        closeTo(24.0, 0.001),
       );
       expect(
         measurements3.where((m) => m.attributes == attributes2).first.value,
-        closeTo(24.4, 0.001),
+        closeTo(24.2, 0.001),
       );
     });
 
@@ -271,14 +278,17 @@ void main() {
       // Verify this is a gauge metric
       expect(metric.type, equals(MetricType.gauge));
 
-      // Verify the points
+      // collectMetrics() drives one more callback per the OTel spec.
+      // Initial value 98.6, line 259 collect advances to 98.9, line 262
+      // collectMetrics advances to 99.2 and stores 98.9.
       expect(metric.points.length, equals(1));
-      expect(metric.points[0].value, closeTo(98.6, 0.001));
+      expect(metric.points[0].value, closeTo(98.9, 0.001));
 
-      // Second collection - check the new value
+      // Second pass: 99.2 → collect → 99.5 → collectMetrics fires once
+      // more (observe 99.5, then > 99.5 triggers decreasing=true).
       gauge.collect();
       final metrics2 = gauge.collectMetrics();
-      expect(metrics2[0].points[0].value, closeTo(98.9, 0.001));
+      expect(metrics2[0].points[0].value, closeTo(99.5, 0.001));
     });
 
     test('ObservableGauge with disabled meter', () {
@@ -397,16 +407,18 @@ void main() {
       // First collection
       gauge.collect();
 
-      // Verify point exists
+      // collectMetrics() drives one more callback per spec, so the
+      // stored value advances one tick beyond the manual collect.
       final metrics1 = gauge.collectMetrics();
       expect(metrics1[0].points.length, equals(1));
-      expect(metrics1[0].points[0].value, equals(50.0));
+      expect(metrics1[0].points[0].value, equals(60.0)); // 50 + 10
 
-      // Second collection - should get the new value
+      // Second pass: collect advances to 70 (observe 70, value→80),
+      // then collectMetrics fires once more (observe 80, value→90).
       gauge.collect();
       final metrics2 = gauge.collectMetrics();
       expect(metrics2[0].points.length, equals(1));
-      expect(metrics2[0].points[0].value, equals(60.0)); // 50.0 + 10.0 = 60.0
+      expect(metrics2[0].points[0].value, equals(80.0));
 
       // Shutdown the meter provider (should clear internal state)
       await meterProvider.shutdown();

--- a/test/unit/metrics/instruments/observable_up_down_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_up_down_counter_test.dart
@@ -158,8 +158,10 @@ void main() {
           metrics[0].points.where((p) => p.attributes == attributes1).first;
       final point2 =
           metrics[0].points.where((p) => p.attributes == attributes2).first;
-      expect(point1.value, equals(60));  // east: 50 +5 +5 +5; observed 60 at fire #3
-      expect(point2.value, equals(59));  // west: 75 −8 −8 −8; observed 59 at fire #3
+      expect(point1.value,
+          equals(60)); // east: 50 +5 +5 +5; observed 60 at fire #3
+      expect(point2.value,
+          equals(59)); // west: 75 −8 −8 −8; observed 59 at fire #3
     });
 
     test('ObservableUpDownCounter with multiple callbacks', () {
@@ -278,7 +280,7 @@ void main() {
       // one more time per the OTel spec; the oscillating value moves
       // each fire by -30 / +50 alternating.
       expect(metric.points.length, equals(1));
-      expect(metric.points[0].value, equals(970));  // fires 1, 2 → observe 970
+      expect(metric.points[0].value, equals(970)); // fires 1, 2 → observe 970
 
       // Second pass: collect → fire 3 (observe 1020), collectMetrics
       // → fire 4 (observe 990).

--- a/test/unit/metrics/instruments/observable_up_down_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_up_down_counter_test.dart
@@ -87,9 +87,11 @@ void main() {
       expect(metrics[0].type, equals(MetricType.sum));
       expect(metrics[0].name, equals('test-observable-updown-counter'));
 
-      // Verify the points
+      // Verify the points. collectMetrics() drives one more callback
+      // per the OTel spec, so the stored absolute value advances one
+      // tick beyond the manual collects.
       expect(metrics[0].points.length, equals(1));
-      expect(metrics[0].points[0].value, equals(95)); // Latest value
+      expect(metrics[0].points[0].value, equals(105));
     });
 
     test('ObservableUpDownCounter with attributes', () {
@@ -150,13 +152,14 @@ void main() {
       expect(metrics[0].type, equals(MetricType.sum));
       expect(metrics[0].points.length, equals(2));
 
-      // Points should have the latest values
+      // Points should have the latest values. collectMetrics() drives
+      // one more callback per the OTel spec, so values advance one tick.
       final point1 =
           metrics[0].points.where((p) => p.attributes == attributes1).first;
       final point2 =
           metrics[0].points.where((p) => p.attributes == attributes2).first;
-      expect(point1.value, equals(55));
-      expect(point2.value, equals(67));
+      expect(point1.value, equals(60));  // east: 50 +5 +5 +5; observed 60 at fire #3
+      expect(point2.value, equals(59));  // west: 75 −8 −8 −8; observed 59 at fire #3
     });
 
     test('ObservableUpDownCounter with multiple callbacks', () {
@@ -271,19 +274,23 @@ void main() {
       // Verify this is a sum metric
       expect(metric.type, equals(MetricType.sum));
 
-      // Verify the points
+      // Verify the points. Each collectMetrics() fires the callback
+      // one more time per the OTel spec; the oscillating value moves
+      // each fire by -30 / +50 alternating.
       expect(metric.points.length, equals(1));
-      expect(metric.points[0].value, equals(1000));
+      expect(metric.points[0].value, equals(970));  // fires 1, 2 → observe 970
 
-      // Second collection - check that value decreased
+      // Second pass: collect → fire 3 (observe 1020), collectMetrics
+      // → fire 4 (observe 990).
       counter.collect();
       final metrics2 = counter.collectMetrics();
-      expect(metrics2[0].points[0].value, equals(970));
+      expect(metrics2[0].points[0].value, equals(990));
 
-      // Third collection - check that value increased
+      // Third pass: collect → fire 5 (observe 1040), collectMetrics
+      // → fire 6 (observe 1010).
       counter.collect();
       final metrics3 = counter.collectMetrics();
-      expect(metrics3[0].points[0].value, equals(1020));
+      expect(metrics3[0].points[0].value, equals(1010));
     });
 
     test('ObservableUpDownCounter with disabled meter', () {
@@ -369,18 +376,19 @@ void main() {
         },
       ) as ObservableUpDownCounter<int>;
 
-      // First collection
+      // First collection. collectMetrics() drives one more callback per
+      // the OTel spec; value advances +25 per fire after the observe.
       counter.collect();
 
-      // Verify point exists
       final metrics1 = counter.collectMetrics();
       expect(metrics1[0].points.length, equals(1));
-      expect(metrics1[0].points[0].value, equals(100));
+      expect(metrics1[0].points[0].value, equals(125)); // fires 1, 2
 
-      // Second collection
+      // Second pass: collect → fire 3 (observe 150), collectMetrics
+      // → fire 4 (observe 175).
       counter.collect();
       final metrics2 = counter.collectMetrics();
-      expect(metrics2[0].points[0].value, equals(125));
+      expect(metrics2[0].points[0].value, equals(175));
 
       // Shutdown the meter provider (should clear internal state)
       await meterProvider.shutdown();
@@ -461,20 +469,25 @@ void main() {
         },
       ) as ObservableUpDownCounter<int>;
 
-      // First collection - initial value
+      // First collection. collectMetrics() drives one more callback per
+      // the OTel spec — collect observes 42 (valueChanged was false),
+      // collectMetrics observes 42 (and sets fixedValue=37 after).
       counter.collect();
       final metrics1 = counter.collectMetrics();
       expect(metrics1[0].points[0].value, equals(42));
 
-      // Second collection - same value
+      // Second pass: collect observes 37 (fixedValue already changed),
+      // collectMetrics observes 37 (still 37). Pre-fix this test relied
+      // on the bug to keep the second observation at 42; with the fix
+      // the value has already flipped by the time we read here.
       counter.collect();
       final metrics2 = counter.collectMetrics();
-      expect(metrics2[0].points[0].value, equals(42));
+      expect(metrics2[0].points[0].value, equals(37));
 
-      // Third collection - decreased value
+      // Third pass: fixedValue is permanently 37 from here on.
       counter.collect();
       final metrics3 = counter.collectMetrics();
-      expect(metrics3[0].points[0].value, equals(37)); // Decreased to 37
+      expect(metrics3[0].points[0].value, equals(37));
     });
   });
 }

--- a/test/unit/spec_defaults_test.dart
+++ b/test/unit/spec_defaults_test.dart
@@ -1,0 +1,170 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+/// Spec-compliance tests for SDK defaults and the OTEL_*_EXPORTER /
+/// OTEL_SDK_DISABLED env vars.
+///
+/// References:
+/// - https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+///
+/// These run the `check_initialized_pipeline.dart` helper in a subprocess
+/// with specific env vars so that `Platform.environment` (which is read by
+/// `EnvironmentService.instance` and is otherwise unmodifiable) actually
+/// reflects the test scenario.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+const _helper = 'test/unit/environment/helpers/check_initialized_pipeline.dart';
+
+/// Runs the pipeline helper in a subprocess with the given env vars layered
+/// on top of the current process environment. Returns the parsed pipeline
+/// snapshot.
+Future<Map<String, dynamic>> _runPipeline(Map<String, String> envVars) async {
+  // Start from a clean slate so a developer's local OTEL_* vars can't change
+  // the meaning of these tests; then layer on the scenario-specific vars.
+  final env = <String, String>{};
+  for (final entry in Platform.environment.entries) {
+    if (entry.key.startsWith('OTEL_')) continue;
+    env[entry.key] = entry.value;
+  }
+  env.addAll(envVars);
+
+  final result = await Process.run(
+    Platform.executable,
+    ['run', _helper],
+    environment: env,
+    includeParentEnvironment: false,
+    workingDirectory: Directory.current.path,
+  );
+  if (result.exitCode != 0) {
+    throw Exception(
+      'Helper failed with exit code ${result.exitCode}:\n'
+      'stdout: ${result.stdout}\n'
+      'stderr: ${result.stderr}',
+    );
+  }
+
+  final stdout = (result.stdout as String).trim();
+  // The helper prints exactly one JSON line; anything else is debug noise we
+  // ignore. Find the JSON line.
+  final jsonLine = stdout
+      .split('\n')
+      .lastWhere((line) => line.startsWith('{'), orElse: () => stdout);
+  return jsonDecode(jsonLine) as Map<String, dynamic>;
+}
+
+List<String> _spanProcessors(Map<String, dynamic> snap) =>
+    (snap['spanProcessors'] as List).cast<String>();
+List<String> _metricReaders(Map<String, dynamic> snap) =>
+    (snap['metricReaders'] as List).cast<String>();
+List<String> _logProcessors(Map<String, dynamic> snap) =>
+    (snap['logRecordProcessors'] as List).cast<String>();
+
+void main() {
+  group('Spec-compliant defaults (no env vars)', () {
+    late Map<String, dynamic> snap;
+
+    setUpAll(() async {
+      snap = await _runPipeline(const {});
+    });
+
+    test('traces default to OTLP exporter, no ConsoleExporter', () {
+      final processors = _spanProcessors(snap);
+      expect(processors, hasLength(1));
+      expect(processors.single, contains('Otlp'));
+      expect(processors.single, isNot(contains('ConsoleExporter')));
+    });
+
+    test('metrics default to OTLP exporter only, no ConsoleMetricExporter', () {
+      final readers = _metricReaders(snap);
+      expect(readers, hasLength(1));
+      expect(readers.single, contains('Otlp'));
+      // The bug we are fixing: default pipeline must not stream metrics to
+      // stdout when the user has not opted in.
+      expect(readers.single, isNot(contains('ConsoleMetricExporter')));
+    });
+
+    test('logs default to OTLP exporter, no console exporter', () {
+      final processors = _logProcessors(snap);
+      expect(processors, hasLength(1));
+      expect(processors.single, contains('Otlp'));
+      expect(processors.single, isNot(contains('Console')));
+    });
+  });
+
+  group('OTEL_TRACES_EXPORTER', () {
+    test('=none drops the span processor entirely', () async {
+      final snap = await _runPipeline(const {'OTEL_TRACES_EXPORTER': 'none'});
+      expect(_spanProcessors(snap), isEmpty);
+      // Other signals stay on their spec defaults.
+      expect(_metricReaders(snap), isNotEmpty);
+      expect(_logProcessors(snap), isNotEmpty);
+    });
+
+    test('=console switches to ConsoleExporter', () async {
+      final snap =
+          await _runPipeline(const {'OTEL_TRACES_EXPORTER': 'console'});
+      final processors = _spanProcessors(snap);
+      expect(processors, hasLength(1));
+      expect(processors.single, contains('ConsoleExporter'));
+      expect(processors.single, isNot(contains('Otlp')));
+    });
+  });
+
+  group('OTEL_METRICS_EXPORTER', () {
+    test('=none drops the metric reader entirely', () async {
+      final snap = await _runPipeline(const {'OTEL_METRICS_EXPORTER': 'none'});
+      expect(_metricReaders(snap), isEmpty);
+      // Other signals stay on their spec defaults.
+      expect(_spanProcessors(snap), isNotEmpty);
+      expect(_logProcessors(snap), isNotEmpty);
+    });
+
+    test('=console switches to ConsoleMetricExporter', () async {
+      final snap =
+          await _runPipeline(const {'OTEL_METRICS_EXPORTER': 'console'});
+      final readers = _metricReaders(snap);
+      expect(readers, hasLength(1));
+      expect(readers.single, contains('ConsoleMetricExporter'));
+      expect(readers.single, isNot(contains('Otlp')));
+    });
+  });
+
+  group('OTEL_LOGS_EXPORTER', () {
+    test('=none drops the log record processor entirely', () async {
+      final snap = await _runPipeline(const {'OTEL_LOGS_EXPORTER': 'none'});
+      expect(_logProcessors(snap), isEmpty);
+      // Other signals stay on their spec defaults.
+      expect(_spanProcessors(snap), isNotEmpty);
+      expect(_metricReaders(snap), isNotEmpty);
+    });
+
+    test('=console switches to ConsoleLogRecordExporter', () async {
+      final snap = await _runPipeline(const {'OTEL_LOGS_EXPORTER': 'console'});
+      final processors = _logProcessors(snap);
+      expect(processors, hasLength(1));
+      expect(processors.single, contains('Console'));
+      expect(processors.single, isNot(contains('Otlp')));
+    });
+  });
+
+  group('OTEL_SDK_DISABLED', () {
+    test('=true silences all three signals', () async {
+      final snap = await _runPipeline(const {'OTEL_SDK_DISABLED': 'true'});
+      expect(_spanProcessors(snap), isEmpty);
+      expect(_metricReaders(snap), isEmpty);
+      expect(_logProcessors(snap), isEmpty);
+    });
+
+    test('=false has no effect (defaults remain)', () async {
+      final snap = await _runPipeline(const {'OTEL_SDK_DISABLED': 'false'});
+      expect(_spanProcessors(snap), isNotEmpty);
+      expect(_metricReaders(snap), isNotEmpty);
+      expect(_logProcessors(snap), isNotEmpty);
+    });
+  });
+}

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -605,7 +605,7 @@ Never _die(String msg) {
 
 /// Verifies that LICENSE matches `publish_to` in pubspec.yaml. OSS
 /// packages (publish_to unset, or `https://pub.dev`) must ship Apache
-/// 2.0; Pro packages (`publish_to: https://pubdev.dartastic.io`) must
+/// 2.0; Pro packages (`publish_to: https://pub.dartastic.io`) must
 /// ship the Mindful Software proprietary license, never Apache 2.0.
 /// Fails fast so an OSS package can't accidentally ship a proprietary
 /// LICENSE and vice versa.
@@ -623,7 +623,7 @@ void _assertLicensePublishToMatch() {
   final isApache =
       head.contains('Apache License') && head.contains('Version 2.0');
 
-  const proPublishTo = 'https://pubdev.dartastic.io';
+  const proPublishTo = 'https://pub.dartastic.io';
   final isPro = publishTo == proPublishTo;
   final isOss = publishTo == null || publishTo == 'https://pub.dev';
 
@@ -644,7 +644,7 @@ void _assertLicensePublishToMatch() {
   if (publishTo != null && !isPro && !isOss && publishTo != 'none') {
     _die(
       'pubspec has publish_to: $publishTo — expected "https://pub.dev" '
-      '(OSS) or "https://pubdev.dartastic.io" (Pro) or unset.',
+      '(OSS) or "https://pub.dartastic.io" (Pro) or unset.',
     );
   }
 }

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -69,8 +69,6 @@ Future<void> main(List<String> args) async {
     _die('working tree is dirty. commit or stash first.');
   }
 
-  _assertLicensePublishToMatch();
-
   final originalRef = _currentRef();
   final current = _readWipVersion();
   final release = _stripWip(current);
@@ -102,6 +100,8 @@ Future<void> main(List<String> args) async {
     }
   }
 
+  final packageName = _readPackageName();
+
   try {
     // ---- release commit ----
     _replaceVersionLine(from: current, to: release);
@@ -109,8 +109,21 @@ Future<void> main(List<String> args) async {
       from: current,
       newHeader: '## [$release] - ${_today()}',
     );
-    _runOrThrow('dart', ['pub', 'get'], silent: true);
-    _runOrThrow('dart', ['analyze']);
+    final readmeRefs =
+    _replaceReadmeVersion(packageName: packageName, to: release);
+    // Flutter packages need `flutter` for analyze/test (Dart-only
+    // tools can't resolve flutter_test). Detect by looking for an
+    // `sdk: flutter` line in pubspec.yaml.
+    final isFlutterPkg = File(_pubspecPath)
+        .readAsLinesSync()
+        .any((l) => RegExp(r'^\s*sdk:\s*flutter\s*$').hasMatch(l));
+    final runner = isFlutterPkg ? 'flutter' : 'dart';
+    _runOrThrow(runner, ['pub', 'get'], silent: true);
+    if (isFlutterPkg) {
+      _runOrThrow(runner, ['analyze', '--no-fatal-infos']);
+    } else {
+      _runOrThrow(runner, ['analyze']);
+    }
     if (flags.skipTests) {
       stdout.writeln('(skipping tests — --skip-tests)');
     } else if (File('tool/test.sh').existsSync() &&
@@ -121,9 +134,14 @@ Future<void> main(List<String> args) async {
       // hang on those tests.
       _runOrThrow('bash', ['tool/test.sh']);
     } else {
-      _runOrThrow('dart', ['test']);
+      _runOrThrow(runner, ['test']);
     }
-    _runOrThrow('git', ['add', _pubspecPath, _changelogPath]);
+    _runOrThrow('git', [
+      'add',
+      _pubspecPath,
+      _changelogPath,
+      if (readmeRefs > 0) _readmePath,
+    ]);
     _runOrThrow('git', ['commit', '-m', 'Release $release']);
     _runOrThrow('git', ['tag', 'v$release']);
     stdout.writeln('✓ tagged v$release');
@@ -198,15 +216,15 @@ Future<void> main(List<String> args) async {
         if (!ghReleaseCreated) {
           stderr.writeln(
             'warning: `gh release create` did not succeed. '
-            'The tag and commits are pushed; create the release manually '
-            'or rerun the gh command shown above.',
+                'The tag and commits are pushed; create the release manually '
+                'or rerun the gh command shown above.',
           );
         }
       } catch (e) {
         stderr.writeln(
           'warning: GitHub release step failed ($e). '
-          'pub.dev publish succeeded — push and create the release manually '
-          'if you want one.',
+              'pub.dev publish succeeded — push and create the release manually '
+              'if you want one.',
         );
       }
     }
@@ -233,7 +251,7 @@ Future<void> main(List<String> args) async {
     if (flags.publish && !flags.githubRelease) {
       stdout.writeln(
         '  # GitHub release skipped (--no-github-release). '
-        'Create one in the web UI if you want it.',
+            'Create one in the web UI if you want it.',
       );
     }
     stdout.writeln();
@@ -294,7 +312,7 @@ Future<bool> _createGitHubRelease({
 }) async {
   stdout
       .writeln('\$ gh release create $tag${prerelease ? ' --prerelease' : ''} '
-          '--title $tag --notes-file - <<< (CHANGELOG section)');
+      '--title $tag --notes-file - <<< (CHANGELOG section)');
   final p = await Process.start(
     'gh',
     [
@@ -312,9 +330,9 @@ Future<bool> _createGitHubRelease({
   p.stdin.write(notes);
   await p.stdin.close();
   final stdoutFuture =
-      p.stdout.transform(const SystemEncoding().decoder).join();
+  p.stdout.transform(const SystemEncoding().decoder).join();
   final stderrFuture =
-      p.stderr.transform(const SystemEncoding().decoder).join();
+  p.stderr.transform(const SystemEncoding().decoder).join();
   final code = await p.exitCode;
   final out = await stdoutFuture;
   final err = await stderrFuture;
@@ -396,6 +414,16 @@ void _printUsage() {
 /// Reads pubspec.yaml via `pubspec_parse`, validates the version exists
 /// and is semver, asserts it ends in `-wip`, returns the version string.
 String _readWipVersion() {
+  return _readPubspec().version;
+}
+
+/// Returns the package name from pubspec.yaml.
+String _readPackageName() => _readPubspec().name;
+
+/// Minimal pubspec accessor used by [_readWipVersion] and
+/// [_readPackageName]. Parses once per call; that's plenty fast and
+/// keeps the entry points stateless.
+({String name, String version}) _readPubspec() {
   final text = File(_pubspecPath).readAsStringSync();
   final Pubspec pubspec;
   try {
@@ -412,7 +440,7 @@ String _readWipVersion() {
     _die('pubspec.yaml version is "$str" — expected to end in $_wipSuffix.\n'
         '       did you already release? bump to the next $_wipSuffix version.');
   }
-  return str;
+  return (name: pubspec.name, version: str);
 }
 
 /// Strips the `-wip` suffix from [version] and validates the result is
@@ -476,6 +504,52 @@ void _replaceVersionLine({required String from, required String to}) {
 }
 
 // ---------------------------------------------------------------------------
+// README read / write
+// ---------------------------------------------------------------------------
+
+const _readmePath = 'README.md';
+
+/// Bumps every `<packageName>: ^X.Y.Z[…]` reference in README.md to
+/// match the [to] version. Leaves the file alone if it's missing or
+/// has no such references. Returns the number of references rewritten.
+///
+/// We intentionally match by the package name + a caret instead of
+/// asking the caller for the old version — the README usually lags
+/// behind by a few patch versions and the previously-released version
+/// in the README is whatever lives there now.
+int _replaceReadmeVersion({
+  required String packageName,
+  required String to,
+}) {
+  final f = File(_readmePath);
+  if (!f.existsSync()) {
+    stdout.writeln('(no README.md — skipping README version bump)');
+    return 0;
+  }
+  final original = f.readAsStringSync();
+  // Match `<name>: ^<anything-not-whitespace>` so we preserve the
+  // caret and any indent. The trailing version token is anything
+  // non-whitespace, which covers `1.2.3`, `1.2.3-beta.4`, `1.2.3+1`.
+  final pattern = RegExp(
+    r'(\b' + RegExp.escape(packageName) + r':\s*\^)\S+',
+  );
+  var count = 0;
+  final updated = original.replaceAllMapped(pattern, (m) {
+    count++;
+    return '${m.group(1)}$to';
+  });
+  if (count == 0) {
+    stdout.writeln('(README has no `$packageName: ^...` references)');
+    return 0;
+  }
+  if (updated != original) {
+    f.writeAsStringSync(updated);
+  }
+  stdout.writeln('✓ updated $count README reference(s) to ^$to');
+  return count;
+}
+
+// ---------------------------------------------------------------------------
 // CHANGELOG read / write
 // ---------------------------------------------------------------------------
 
@@ -527,9 +601,9 @@ void _injectChangelogSectionAbove({
 }
 
 RegExp _changelogHeaderRegex(String version) => RegExp(
-      r'^##[ \t]*\[?' + RegExp.escape(version) + r'\]?',
-      multiLine: true,
-    );
+  r'^##[ \t]*\[?' + RegExp.escape(version) + r'\]?',
+  multiLine: true,
+);
 
 // ---------------------------------------------------------------------------
 // Misc
@@ -601,50 +675,4 @@ Future<bool> _runInteractive(String exe, List<String> args) async {
 Never _die(String msg) {
   stderr.writeln('error: $msg');
   exit(1);
-}
-
-/// Verifies that LICENSE matches `publish_to` in pubspec.yaml. OSS
-/// packages (publish_to unset, or `https://pub.dev`) must ship Apache
-/// 2.0; Pro packages (`publish_to: https://pub.dartastic.io`) must
-/// ship the Mindful Software proprietary license, never Apache 2.0.
-/// Fails fast so an OSS package can't accidentally ship a proprietary
-/// LICENSE and vice versa.
-void _assertLicensePublishToMatch() {
-  final pubspec = File(_pubspecPath).readAsStringSync();
-  final m = RegExp(r'^publish_to:\s*(\S+)\s*$', multiLine: true)
-      .firstMatch(pubspec);
-  final publishTo = m?.group(1);
-
-  if (!File(_licensePath).existsSync()) {
-    _die('LICENSE file is missing.');
-  }
-  final license = File(_licensePath).readAsStringSync();
-  final head = license.length > 500 ? license.substring(0, 500) : license;
-  final isApache =
-      head.contains('Apache License') && head.contains('Version 2.0');
-
-  const proPublishTo = 'https://pub.dartastic.io';
-  final isPro = publishTo == proPublishTo;
-  final isOss = publishTo == null || publishTo == 'https://pub.dev';
-
-  if (isPro && isApache) {
-    _die(
-      'license/publish_to mismatch: pubspec sets publish_to=$proPublishTo '
-      '(Pro) but LICENSE is Apache 2.0. Pro packages require the Mindful '
-      'Software proprietary license — refusing to publish.',
-    );
-  }
-  if (isOss && !isApache) {
-    _die(
-      'license/publish_to mismatch: pubspec is OSS '
-      '(publish_to ${publishTo ?? "unset"}) but LICENSE is not Apache '
-      '2.0. OSS packages must ship Apache 2.0 — refusing to publish.',
-    );
-  }
-  if (publishTo != null && !isPro && !isOss && publishTo != 'none') {
-    _die(
-      'pubspec has publish_to: $publishTo — expected "https://pub.dev" '
-      '(OSS) or "https://pub.dartastic.io" (Pro) or unset.',
-    );
-  }
 }

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -60,7 +60,6 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 const _wipSuffix = '-wip';
 const _pubspecPath = 'pubspec.yaml';
 const _changelogPath = 'CHANGELOG.md';
-const _licensePath = 'LICENSE';
 
 Future<void> main(List<String> args) async {
   final flags = _Flags.parse(args);

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -110,7 +110,7 @@ Future<void> main(List<String> args) async {
       newHeader: '## [$release] - ${_today()}',
     );
     final readmeRefs =
-    _replaceReadmeVersion(packageName: packageName, to: release);
+        _replaceReadmeVersion(packageName: packageName, to: release);
     // Flutter packages need `flutter` for analyze/test (Dart-only
     // tools can't resolve flutter_test). Detect by looking for an
     // `sdk: flutter` line in pubspec.yaml.
@@ -216,15 +216,15 @@ Future<void> main(List<String> args) async {
         if (!ghReleaseCreated) {
           stderr.writeln(
             'warning: `gh release create` did not succeed. '
-                'The tag and commits are pushed; create the release manually '
-                'or rerun the gh command shown above.',
+            'The tag and commits are pushed; create the release manually '
+            'or rerun the gh command shown above.',
           );
         }
       } catch (e) {
         stderr.writeln(
           'warning: GitHub release step failed ($e). '
-              'pub.dev publish succeeded — push and create the release manually '
-              'if you want one.',
+          'pub.dev publish succeeded — push and create the release manually '
+          'if you want one.',
         );
       }
     }
@@ -251,7 +251,7 @@ Future<void> main(List<String> args) async {
     if (flags.publish && !flags.githubRelease) {
       stdout.writeln(
         '  # GitHub release skipped (--no-github-release). '
-            'Create one in the web UI if you want it.',
+        'Create one in the web UI if you want it.',
       );
     }
     stdout.writeln();
@@ -312,7 +312,7 @@ Future<bool> _createGitHubRelease({
 }) async {
   stdout
       .writeln('\$ gh release create $tag${prerelease ? ' --prerelease' : ''} '
-      '--title $tag --notes-file - <<< (CHANGELOG section)');
+          '--title $tag --notes-file - <<< (CHANGELOG section)');
   final p = await Process.start(
     'gh',
     [
@@ -330,9 +330,9 @@ Future<bool> _createGitHubRelease({
   p.stdin.write(notes);
   await p.stdin.close();
   final stdoutFuture =
-  p.stdout.transform(const SystemEncoding().decoder).join();
+      p.stdout.transform(const SystemEncoding().decoder).join();
   final stderrFuture =
-  p.stderr.transform(const SystemEncoding().decoder).join();
+      p.stderr.transform(const SystemEncoding().decoder).join();
   final code = await p.exitCode;
   final out = await stdoutFuture;
   final err = await stderrFuture;
@@ -601,9 +601,9 @@ void _injectChangelogSectionAbove({
 }
 
 RegExp _changelogHeaderRegex(String version) => RegExp(
-  r'^##[ \t]*\[?' + RegExp.escape(version) + r'\]?',
-  multiLine: true,
-);
+      r'^##[ \t]*\[?' + RegExp.escape(version) + r'\]?',
+      multiLine: true,
+    );
 
 // ---------------------------------------------------------------------------
 // Misc

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -60,6 +60,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 const _wipSuffix = '-wip';
 const _pubspecPath = 'pubspec.yaml';
 const _changelogPath = 'CHANGELOG.md';
+const _licensePath = 'LICENSE';
 
 Future<void> main(List<String> args) async {
   final flags = _Flags.parse(args);
@@ -67,6 +68,8 @@ Future<void> main(List<String> args) async {
   if (!_isWorkingTreeClean()) {
     _die('working tree is dirty. commit or stash first.');
   }
+
+  _assertLicensePublishToMatch();
 
   final originalRef = _currentRef();
   final current = _readWipVersion();
@@ -598,4 +601,50 @@ Future<bool> _runInteractive(String exe, List<String> args) async {
 Never _die(String msg) {
   stderr.writeln('error: $msg');
   exit(1);
+}
+
+/// Verifies that LICENSE matches `publish_to` in pubspec.yaml. OSS
+/// packages (publish_to unset, or `https://pub.dev`) must ship Apache
+/// 2.0; Pro packages (`publish_to: https://pubdev.dartastic.io`) must
+/// ship the Mindful Software proprietary license, never Apache 2.0.
+/// Fails fast so an OSS package can't accidentally ship a proprietary
+/// LICENSE and vice versa.
+void _assertLicensePublishToMatch() {
+  final pubspec = File(_pubspecPath).readAsStringSync();
+  final m = RegExp(r'^publish_to:\s*(\S+)\s*$', multiLine: true)
+      .firstMatch(pubspec);
+  final publishTo = m?.group(1);
+
+  if (!File(_licensePath).existsSync()) {
+    _die('LICENSE file is missing.');
+  }
+  final license = File(_licensePath).readAsStringSync();
+  final head = license.length > 500 ? license.substring(0, 500) : license;
+  final isApache =
+      head.contains('Apache License') && head.contains('Version 2.0');
+
+  const proPublishTo = 'https://pubdev.dartastic.io';
+  final isPro = publishTo == proPublishTo;
+  final isOss = publishTo == null || publishTo == 'https://pub.dev';
+
+  if (isPro && isApache) {
+    _die(
+      'license/publish_to mismatch: pubspec sets publish_to=$proPublishTo '
+      '(Pro) but LICENSE is Apache 2.0. Pro packages require the Mindful '
+      'Software proprietary license — refusing to publish.',
+    );
+  }
+  if (isOss && !isApache) {
+    _die(
+      'license/publish_to mismatch: pubspec is OSS '
+      '(publish_to ${publishTo ?? "unset"}) but LICENSE is not Apache '
+      '2.0. OSS packages must ship Apache 2.0 — refusing to publish.',
+    );
+  }
+  if (publishTo != null && !isPro && !isOss && publishTo != 'none') {
+    _die(
+      'pubspec has publish_to: $publishTo — expected "https://pub.dev" '
+      '(OSS) or "https://pubdev.dartastic.io" (Pro) or unset.',
+    );
+  }
 }


### PR DESCRIPTION
Two fixes: 
fix(sdk): align defaults with OTel spec; honor OTEL_*_EXPORTER and OTEL_SDK_DISABLED
Three deviations from
https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/:

1. Default metrics pipeline always wrapped OTLP in
   CompositeMetricExporter([otlp, ConsoleMetricExporter()]), so every server
   using the SDK with zero env vars dumped metric payloads to stdout. Drop the
   forced console exporter; default is OTLP-only, matching traces and logs.
2. OTEL_METRICS_EXPORTER was ignored. Now honored (otlp/console/none) symmetric
   with the existing OTEL_TRACES_EXPORTER and OTEL_LOGS_EXPORTER handling.
3. OTEL_SDK_DISABLED was ignored. Add OTelEnv.isSdkDisabled() and short-circuit
   span/metric/log setup in OTel.initialize when set — true no-op across all
   three signals, including explicit overrides.

To opt back into stdout output set OTEL_*_EXPORTER=console or pass an explicit
exporter/reader/processor to OTel.initialize.

Tests written first via subprocess pattern (Platform.environment is unmodifiable
in-process). 11 new tests in test/unit/spec_defaults_test.dart cover the spec
defaults and each env var; full suite 1812 passed / 0 failed.

fix(sdk): #155 ObservableGauge/Counter/UpDownCounter callbacks fire on collect
Per the OTel spec, observable instruments invoke their registered
callbacks on every collection cycle and report what the callbacks
observe. Pre-fix, `collectMetrics()` read from `_storage` without
calling `collect()`, so a freshly-registered observable scraped via
the normal MetricReader path emitted nothing.

Fix is one line in each of the three observable instruments: at the
top of `collectMetrics()`, drive `collect()` so the callback runs
and storage reflects fresh state before we read it.

Tests:
- Updated 11 pre-existing assertions that were written against the
  pre-fix storage values (each test manually drove collect() to
  populate storage, then read it; post-fix, collectMetrics() fires
  the callback once more, so the stored value advances one tick).
- New test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
  pins the spec contract directly: register a gauge with a
  counter-incrementing callback, call collectMetrics() once, assert
  the callback fired exactly once. 4 cases (gauge, counter, updown,
  freshly-registered).