### PR TITLE
Fix SDK initialization after API no-op factory is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.7-wip]
 
+### Fixed
+- **`OTel.initialize()` now upgrades the API no-op factory (issue #50).** If the API auto-installed its no-op factory before SDK initialization, the SDK now replaces it with a configured SDK factory instead of refusing to initialize or later failing with API-provider-to-SDK-provider cast errors for traces, metrics, or logs.
+
+### Added
+- **`OTel.isInitialized`** reports whether `OTel.initialize()` has been called since the last `OTel.reset()`.
+
 ## [1.1.0-beta.6] - 2026-05-18
 - **Bumped `dartastic_opentelemetry_api` to `^1.0.0-beta.7`.** Beta.7 fixes observable metrics and standard env var defaults.
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -38,6 +38,16 @@ import '../dartastic_opentelemetry.dart';
 /// List\<String>, List\<bool>, List\<int> or List\<double>).
 class OTel {
   static OTelSDKFactory? _otelFactory;
+
+  /// Whether [initialize] has been explicitly called by the user.
+  ///
+  /// This is intentionally separate from "an [OTelFactory] is installed":
+  /// the API may auto-install a no-op factory before [initialize] runs (see
+  /// [_ensureSDKFactory]). Only an explicit [initialize] call flips this flag,
+  /// so re-initialization is detected correctly while still allowing the SDK
+  /// to replace the API's no-op factory during first initialization.
+  static bool _userInitialized = false;
+
   static Sampler? _defaultSampler;
   static TimeProvider? _defaultTimeProvider;
 
@@ -80,6 +90,13 @@ class OTel {
 
   /// Default tracer version.
   static String defaultTracerVersion = '1.0.0';
+
+  /// Whether [initialize] has been called (and not undone by [reset]).
+  ///
+  /// This reflects the explicit [initialize] call only, so it can still be
+  /// `false` while the API's no-op factory is installed before the SDK has
+  /// been initialized.
+  static bool get isInitialized => _userInitialized;
 
   /// Initializes the OpenTelemetry SDK with the specified configuration.
   ///
@@ -219,10 +236,28 @@ class OTel {
         resourceAttributes = OTel.attributesFromMap(envResourceAttrs);
       }
     }
-    if (OTelFactory.otelFactory != null) {
+    // Re-initialization is keyed on an explicit prior initialize() call, not
+    // on the mere presence of a factory: the API may have auto-installed a
+    // no-op factory before initialize() runs. That no-op factory is
+    // upgraded/overwritten below.
+    if (_userInitialized) {
       throw StateError(
-        'OTelAPI can only be initialized once. If you need multiple endpoints or service names or versions create a named TracerProvider',
+        'OTel.initialize() can only be called once. For additional telemetry '
+        'pipelines, create named tracer, meter, or logger providers instead.',
       );
+    }
+    final installedFactory = OTelFactory.otelFactory;
+    if (installedFactory is OTelSDKFactory) {
+      throw StateError(
+        'An SDK OpenTelemetry factory (${installedFactory.runtimeType}) is '
+        'already installed. OTel.initialize() can only install the global SDK '
+        'factory once. Call OTel.reset() first if this is a test.',
+      );
+    }
+    if (installedFactory != null && installedFactory is! OTelAPIFactory) {
+      // A foreign, caller-supplied factory is installed; refuse rather than
+      // silently discard it.
+      throw _foreignFactoryError(installedFactory);
     }
 
     if (endpoint.isEmpty) {
@@ -247,11 +282,25 @@ class OTel {
     // Initialize logging from environment variables if needed
     initializeLogging();
 
-    OTelFactory.otelFactory = factoryFactory(
+    // Install the fully-configured SDK factory, overwriting any no-op API
+    // factory installed before now. Using a fresh instance discards any no-op
+    // providers the API factory cached.
+    final createdFactory = factoryFactory(
       apiEndpoint: endpoint,
       apiServiceName: serviceName,
       apiServiceVersion: serviceVersion,
     );
+    // OTelFactoryCreationFunction returns the base OTelFactory type, but SDK
+    // initialization requires the concrete SDK factory implementation.
+    if (createdFactory is! OTelSDKFactory) {
+      throw StateError(
+        'oTelFactoryCreationFunction must create an OTelSDKFactory, got '
+        '${createdFactory.runtimeType}.',
+      );
+    }
+    OTelFactory.otelFactory = createdFactory;
+    _otelFactory = createdFactory;
+    _userInitialized = true;
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
@@ -512,7 +561,7 @@ class OTel {
   /// @param schemaUrl Optional URL of the schema defining the attributes
   /// @return A new Resource instance
   static Resource resource(Attributes? attributes, [String? schemaUrl]) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return (_otelFactory as OTelSDKFactory).resource(
       attributes ?? OTel.attributes(),
       schemaUrl,
@@ -533,7 +582,7 @@ class OTel {
   /// @return A new ContextKey instance
   static ContextKey<T> contextKey<T>(String name,
       {bool isTransferable = false}) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.contextKey<T>(
       name,
       ContextKey.generateContextKeyId(),
@@ -550,7 +599,7 @@ class OTel {
   /// @param spanContext Optional span context to include in the context
   /// @return A new Context instance
   static Context context({Baggage? baggage, SpanContext? spanContext}) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     var context = OTelFactory.otelFactory!.context(baggage: baggage);
     if (spanContext != null) {
       context = context.copyWithSpanContext(spanContext);
@@ -571,6 +620,7 @@ class OTel {
   /// @param name Optional name of a specific TracerProvider
   /// @return The TracerProvider instance
   static TracerProvider tracerProvider({String? name}) {
+    _ensureSDKFactory();
     final tracerProvider = OTelAPI.tracerProvider(name) as TracerProvider;
     // Ensure the resource is properly set
     if (tracerProvider.resource == null && defaultResource != null) {
@@ -604,6 +654,7 @@ class OTel {
   /// @param name Optional name of a specific MeterProvider
   /// @return The MeterProvider instance
   static MeterProvider meterProvider({String? name}) {
+    _ensureSDKFactory();
     final meterProvider = OTelAPI.meterProvider(name) as MeterProvider;
     meterProvider.resource ??= defaultResource;
     return meterProvider;
@@ -630,6 +681,7 @@ class OTel {
     Resource? resource,
     Sampler? sampler,
   }) {
+    _ensureSDKFactory();
     final sdkTracerProvider = OTelAPI.addTracerProvider(name) as TracerProvider;
     sdkTracerProvider.resource = resource ?? defaultResource;
     sdkTracerProvider.sampler = sampler ?? _defaultSampler;
@@ -695,7 +747,7 @@ class OTel {
     String? serviceVersion,
     Resource? resource,
   }) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     final mp = _otelFactory!.addMeterProvider(
       name,
       endpoint: endpoint,
@@ -736,6 +788,7 @@ class OTel {
   /// @param name Optional name of a specific LoggerProvider
   /// @return The LoggerProvider instance
   static LoggerProvider loggerProvider({String? name}) {
+    _ensureSDKFactory();
     final logProvider = OTelAPI.loggerProvider(name) as LoggerProvider;
     logProvider.resource ??= defaultResource;
     return logProvider;
@@ -760,7 +813,7 @@ class OTel {
     String? serviceVersion,
     Resource? resource,
   }) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     final lp = _otelFactory!.addLogProvider(name,
         endpoint: endpoint,
         serviceName: serviceName,
@@ -879,7 +932,7 @@ class OTel {
   /// @param parent The parent SpanContext
   /// @return A new child SpanContext
   static SpanContext spanContextFromParent(SpanContext parent) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return OTelFactory.otelFactory!.spanContextFromParent(parent);
   }
 
@@ -889,7 +942,7 @@ class OTel {
   ///
   /// @return An invalid SpanContext instance
   static SpanContext spanContextInvalid() {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return OTelFactory.otelFactory!.spanContextInvalid();
   }
 
@@ -902,7 +955,7 @@ class OTel {
   /// @param attributes Attributes to associate with the event
   /// @return A new SpanEvent instance with the current timestamp
   static SpanEvent spanEventNow(String name, Attributes attributes) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return spanEvent(name, attributes, DateTime.now());
   }
 
@@ -920,7 +973,7 @@ class OTel {
     Attributes? attributes,
     DateTime? timestamp,
   ]) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.spanEvent(name, attributes, timestamp);
   }
 
@@ -932,7 +985,7 @@ class OTel {
   /// @param keyValuePairs A map of key-value pairs to include in the baggage
   /// @return A new Baggage instance
   static Baggage baggageForMap(Map<String, String> keyValuePairs) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.baggageForMap(keyValuePairs);
   }
 
@@ -942,7 +995,7 @@ class OTel {
   /// @param metadata Optional metadata for the baggage entry
   /// @return A new BaggageEntry instance
   static BaggageEntry baggageEntry(String value, [String? metadata]) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.baggageEntry(value, metadata);
   }
 
@@ -951,7 +1004,7 @@ class OTel {
   /// @param entries Optional map of baggage entries
   /// @return A new Baggage instance
   static Baggage baggage([Map<String, BaggageEntry>? entries]) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.baggage(entries);
   }
 
@@ -969,7 +1022,7 @@ class OTel {
   /// @param value The string value of the attribute
   /// @return A new Attribute instance
   static Attribute<String> attributeString(String name, String value) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeString(name, value);
   }
 
@@ -979,7 +1032,7 @@ class OTel {
   /// @param value The boolean value of the attribute
   /// @return A new Attribute instance
   static Attribute<bool> attributeBool(String name, bool value) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeBool(name, value);
   }
 
@@ -989,7 +1042,7 @@ class OTel {
   /// @param value The integer value of the attribute
   /// @return A new Attribute instance
   static Attribute<int> attributeInt(String name, int value) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeInt(name, value);
   }
 
@@ -999,7 +1052,7 @@ class OTel {
   /// @param value The double value of the attribute
   /// @return A new Attribute instance
   static Attribute<double> attributeDouble(String name, double value) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeDouble(name, value);
   }
 
@@ -1012,7 +1065,7 @@ class OTel {
     String name,
     List<String> value,
   ) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeStringList(name, value);
   }
 
@@ -1025,7 +1078,7 @@ class OTel {
     String name,
     List<bool> value,
   ) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeBoolList(name, value);
   }
 
@@ -1035,7 +1088,7 @@ class OTel {
   /// @param value The list of integer values
   /// @return A new Attribute instance
   static Attribute<List<int>> attributeIntList(String name, List<int> value) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeIntList(name, value);
   }
 
@@ -1048,7 +1101,7 @@ class OTel {
     String name,
     List<double> value,
   ) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributeDoubleList(name, value);
   }
 
@@ -1056,7 +1109,7 @@ class OTel {
   ///
   /// @return A new empty Attributes collection
   static Attributes createAttributes() {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributes();
   }
 
@@ -1163,7 +1216,7 @@ class OTel {
   /// @param attributeList List of Attribute objects
   /// @return A new Attributes collection
   static Attributes attributesFromList(List<Attribute> attributeList) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.attributesFromList(attributeList);
   }
 
@@ -1174,7 +1227,7 @@ class OTel {
   /// @param entries Optional map of key-value pairs for the trace state
   /// @return A new TraceState instance
   static TraceState traceState(Map<String, String>? entries) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.traceState(entries);
   }
 
@@ -1187,7 +1240,7 @@ class OTel {
   /// @param flags Optional flags value (default: NONE_FLAG)
   /// @return A new TraceFlags instance
   static TraceFlags traceFlags([int? flags]) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.traceFlags(flags ?? TraceFlags.NONE_FLAG);
   }
 
@@ -1204,7 +1257,7 @@ class OTel {
   /// @return A new TraceId instance
   /// @throws ArgumentError if traceId is not exactly 16 bytes
   static TraceId traceIdOf(Uint8List traceId) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     if (traceId.length != TraceId.traceIdLength) {
       throw ArgumentError(
         'Trace ID must be exactly ${TraceId.traceIdLength} bytes, got ${traceId.length} bytes',
@@ -1241,7 +1294,7 @@ class OTel {
   /// @return A new SpanId instance
   /// @throws ArgumentError if spanId is not exactly 8 bytes
   static SpanId spanIdOf(Uint8List spanId) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     if (spanId.length != 8) {
       throw ArgumentError(
         'Span ID must be exactly 8 bytes, got ${spanId.length} bytes',
@@ -1274,23 +1327,43 @@ class OTel {
   /// @param attributes Optional attributes to associate with the link
   /// @return A new SpanLink instance
   static SpanLink spanLink(SpanContext spanContext, {Attributes? attributes}) {
-    _getAndCacheOtelFactory();
+    _ensureSDKFactory();
     return _otelFactory!.spanLink(spanContext, attributes: attributes);
   }
 
-  /// Retrieves and caches the OTelFactory instance.
+  /// Ensures an [OTelSDKFactory] is installed as the global factory.
   ///
-  /// @return The OTelFactory instance
-  /// @throws StateError if initialize() has not been called
-  static OTelFactory _getAndCacheOtelFactory() {
-    if (_otelFactory != null) {
-      return _otelFactory!;
+  /// The API may auto-install a no-op [OTelAPIFactory] before [initialize]
+  /// runs. [initialize] is responsible for replacing that no-op factory with
+  /// the configured SDK factory. SDK accessors do not create a temporary SDK
+  /// factory before initialization, because any provider returned from such a
+  /// factory would not automatically become configured when [initialize]
+  /// replaces the global factory later.
+  static OTelSDKFactory _ensureSDKFactory() {
+    final installedFactory = OTelFactory.otelFactory;
+    if (installedFactory is OTelSDKFactory) {
+      // The global factory is the source of truth. Keep the local SDK cache
+      // aligned in case tests or advanced users replaced OTelFactory.otelFactory
+      // directly, or after any other global factory swap.
+      _otelFactory = installedFactory;
+      return installedFactory;
     }
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('initialize() must be called first.');
+    if (installedFactory == null || installedFactory is OTelAPIFactory) {
+      throw StateError('OTel.initialize() must be called first.');
     }
-    return _otelFactory = OTelFactory.otelFactory! as OTelSDKFactory;
+    // A foreign factory (neither the API no-op nor an SDK factory) is
+    // installed; we must not silently discard a caller-supplied factory.
+    throw _foreignFactoryError(installedFactory);
   }
+
+  /// Error thrown when a non-API, non-SDK [OTelFactory] is already installed
+  /// and therefore cannot be upgraded to an SDK factory.
+  static StateError _foreignFactoryError(OTelFactory installed) => StateError(
+        'A non-SDK OpenTelemetry factory (${installed.runtimeType}) is already '
+        'installed, so OTel cannot upgrade it to an SDK factory. Install the '
+        'SDK factory before any other factory, or call OTel.reset() first '
+        '(for example between tests).',
+      );
 
   /// Initializes logging based on environment variables.
   ///
@@ -1410,6 +1483,7 @@ class OTel {
 
     // Reset all static fields
     _otelFactory = null;
+    _userInitialized = false;
     _defaultSampler = null;
     _defaultTimeProvider = null;
     defaultResource = null;

--- a/test/unit/otel_initialization_error_test.dart
+++ b/test/unit/otel_initialization_error_test.dart
@@ -1,0 +1,147 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Regression coverage for the factory-upgrade lifecycle (issue #50).
+//
+// The API auto-installs a spec-mandated no-op factory the first time any API
+// call runs. When that happens before OTel.initialize(), initialize() must
+// replace that no-op factory with a real SDK factory rather than refuse to run.
+// SDK accessors still require explicit initialization, so they do not hand out
+// unconfigured providers before initialize() has applied resources, processors,
+// exporters, samplers, and endpoint configuration.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    as api;
+import 'package:test/test.dart';
+
+void main() {
+  tearDown(() async {
+    await OTel.reset();
+  });
+
+  group('SDK accessors preserve the initialize-first lifecycle', () {
+    final throwsInitializeFirst = throwsA(isA<StateError>().having(
+      (e) => e.message,
+      'message',
+      contains('OTel.initialize() must be called first'),
+    ));
+
+    test('tracerProvider() throws if no factory exists', () {
+      expect(OTel.tracerProvider, throwsInitializeFirst);
+      expect(OTelFactory.otelFactory, isNull);
+      expect(OTel.isInitialized, isFalse);
+    });
+
+    test('SDK tracerProvider() throws clearly after API auto-install', () {
+      // API accessor: allowed before SDK initialization; installs the API
+      // package's no-op factory.
+      final apiProvider = api.OTelAPI.tracerProvider();
+      expect(apiProvider, isA<api.APITracerProvider>());
+      expect(OTelFactory.otelFactory, isA<api.OTelAPIFactory>());
+      expect(OTelFactory.otelFactory, isNot(isA<OTelSDKFactory>()));
+
+      // SDK accessor: still requires OTel.initialize(); should not cast-crash
+      // or install an unconfigured temporary SDK provider.
+      expect(OTel.tracerProvider, throwsInitializeFirst);
+      expect(OTel.isInitialized, isFalse);
+      expect(OTelFactory.otelFactory, isA<api.OTelAPIFactory>());
+    });
+
+    test('SDK meterProvider() throws clearly after API auto-install', () {
+      // API accessor: allowed before SDK initialization; installs the API
+      // package's no-op factory.
+      api.OTelAPI.meterProvider();
+      expect(OTelFactory.otelFactory, isNot(isA<OTelSDKFactory>()));
+
+      // SDK accessor: still requires OTel.initialize(); should not cast-crash
+      // or install an unconfigured temporary SDK provider.
+      expect(OTel.meterProvider, throwsInitializeFirst);
+      expect(OTelFactory.otelFactory, isA<api.OTelAPIFactory>());
+    });
+
+    test('SDK loggerProvider() throws clearly after API auto-install', () {
+      // API accessor: allowed before SDK initialization; installs the API
+      // package's no-op factory.
+      api.OTelAPI.loggerProvider();
+      expect(OTelFactory.otelFactory, isNot(isA<OTelSDKFactory>()));
+
+      // SDK accessor: still requires OTel.initialize(); should not cast-crash
+      // or install an unconfigured temporary SDK provider.
+      expect(OTel.loggerProvider, throwsInitializeFirst);
+      expect(OTelFactory.otelFactory, isA<api.OTelAPIFactory>());
+    });
+
+    test('SDK addTracerProvider() throws clearly after API auto-install', () {
+      // API accessor: allowed before SDK initialization; installs the API
+      // package's no-op factory.
+      api.OTelAPI.tracerProvider();
+
+      // SDK accessor: still requires OTel.initialize(); should not cast-crash
+      // or install an unconfigured temporary SDK provider.
+      expect(() => OTel.addTracerProvider('named'), throwsInitializeFirst);
+      expect(OTelFactory.otelFactory, isA<api.OTelAPIFactory>());
+    });
+  });
+
+  group('initialize() upgrades an already-installed API no-op factory', () {
+    test('initialize() succeeds after API tracerProvider()', () async {
+      api.OTelAPI.tracerProvider();
+      await OTel.initialize(serviceName: 'svc-a');
+      expect(OTel.isInitialized, isTrue);
+      expect(OTelFactory.otelFactory, isA<OTelSDKFactory>());
+      expect(OTel.tracerProvider(), isA<TracerProvider>());
+    });
+
+    test('initialize() succeeds after API meterProvider()', () async {
+      api.OTelAPI.meterProvider();
+      await OTel.initialize(serviceName: 'svc-b');
+      expect(OTel.isInitialized, isTrue);
+      expect(OTel.meterProvider(), isA<MeterProvider>());
+    });
+
+    test('initialize() succeeds after API loggerProvider()', () async {
+      api.OTelAPI.loggerProvider();
+      await OTel.initialize(serviceName: 'svc-c');
+      expect(OTel.isInitialized, isTrue);
+      expect(OTel.loggerProvider(), isA<LoggerProvider>());
+    });
+
+    test('initialize() applies configured resource after replacing API no-op',
+        () async {
+      api.OTelAPI.tracerProvider();
+
+      await OTel.initialize(serviceName: 'configured-service');
+
+      final hasServiceName = OTel.defaultResource!.attributes.toList().any(
+            (a) => a.key == 'service.name' && a.value == 'configured-service',
+          );
+      expect(hasServiceName, isTrue);
+      expect(OTel.isInitialized, isTrue);
+      expect(OTel.tracerProvider(), isA<TracerProvider>());
+    });
+  });
+
+  group('re-initialization is keyed on an explicit initialize() call', () {
+    test('calling initialize() twice throws a clear StateError', () async {
+      await OTel.initialize(serviceName: 'first');
+      await expectLater(
+        OTel.initialize(serviceName: 'second'),
+        throwsA(isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('can only be called once'),
+        )),
+      );
+    });
+
+    test('initialize() works again after reset()', () async {
+      await OTel.initialize(serviceName: 'first');
+      expect(OTel.isInitialized, isTrue);
+      await OTel.reset();
+      expect(OTel.isInitialized, isFalse);
+      await OTel.initialize(serviceName: 'second');
+      expect(OTel.isInitialized, isTrue);
+    });
+  });
+}

--- a/test/unit/otel_sdk_test.dart
+++ b/test/unit/otel_sdk_test.dart
@@ -651,9 +651,12 @@ void main() {
       await OTel.reset();
     });
 
-    test('_getAndCacheOtelFactory throws when not initialized', () {
-      // Exercises the StateError thrown when OTel is not initialized
+    test('SDK accessor throws when no factory has been installed', () {
+      // SDK entry points require OTel.initialize(); API-only no-op behavior is
+      // available through OTelAPI, not through concrete SDK accessors.
       expect(() => OTel.contextKey<String>('test-key'), throwsStateError);
+      expect(OTel.isInitialized, isFalse);
+      expect(OTelFactory.otelFactory, isNull);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #50.

The API package can auto-install its no-op `OTelAPIFactory` before the SDK is initialized, for example when API-only/resource-related code runs first. Previously, `OTel.initialize()` treated any installed factory as "already initialized", so the API no-op factory blocked SDK initialization. Later SDK provider access could then fail with API-provider-to-SDK-provider cast errors.

This change lets `OTel.initialize()` replace an installed API no-op factory with the configured SDK factory, while preserving the SDK initialize-first lifecycle for concrete SDK accessors.

## Changes

- Track explicit SDK initialization separately from `OTelFactory.otelFactory` via `OTel.isInitialized`.
- Allow `OTel.initialize()` to replace an installed API no-op `OTelAPIFactory`.
- Preserve clear initialize-first errors for SDK accessors before `OTel.initialize()`, even if the API no-op factory exists.
- Add validation that custom SDK factory creation returns an `OTelSDKFactory`.
- Keep a defensive error for foreign non-API/non-SDK factories.
- Add regression coverage for tracer, meter, logger, and `addTracerProvider` API-first scenarios.

## Notes

This intentionally distinguishes API and SDK lifecycle behavior:

- `OTelAPI.*` may be used before SDK initialization and can install no-op API providers.
- Concrete SDK access through `OTel.*` still requires `OTel.initialize()` first.
- `OTel.initialize()` is responsible for upgrading/replacing the API no-op factory with the configured SDK factory.

This avoids returning temporary/unconfigured SDK providers before initialization.

This follows the same initialize-first principle used by OpenTelemetry Java's global SDK registration: concrete SDK/global access is expected after SDK registration, rather than returning temporary SDK objects that later need to be reconfigured. JS/Python handle early API access with proxy objects that later delegate to the real SDK; this package does not have that proxy layer, so this PR avoids returning unconfigured provisional SDK providers before `OTel.initialize()`.

## Validation

- `dart analyze`
- `dart test test/unit/otel_initialization_error_test.dart test/unit/otel_sdk_test.dart`
- `dart analyze && dart test`
