### PR TITLE
fix: OTel.initialize() upgrades the API's auto-installed no-op factory (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.7-wip]
 
+### Fixed
+- **`OTel.initialize()` upgrades the API's auto-installed no-op factory
+  (#50).** Against `dartastic_opentelemetry_api` >= 1.0.0-beta.8 the API
+  lazily installs its no-op factory whenever API code runs first —
+  including `OTel.initialize()`'s own `OTEL_RESOURCE_ATTRIBUTES` parsing —
+  so initialization threw 'OTelAPI can only be initialized once' and any
+  app setting `OTEL_RESOURCE_ATTRIBUTES` crashed at startup. initialize()
+  now replaces a factory reporting `isAPIFactory`, `OTelSDKFactory`
+  overrides `isAPIFactory` to false, and SDK accessors report
+  'initialize() must be called first.' instead of a cast TypeError when
+  only the no-op API factory is installed.
+
 ## [1.1.0-beta.6] - 2026-05-18
 - **Bumped `dartastic_opentelemetry_api` to `^1.0.0-beta.7`.** Beta.7 fixes observable metrics and standard env var defaults.
 

--- a/lib/src/factory/otel_sdk_factory.dart
+++ b/lib/src/factory/otel_sdk_factory.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
 import '../logs/logger_provider.dart';
@@ -52,6 +52,10 @@ class OTelSDKFactory extends OTelAPIFactory {
     required super.apiServiceVersion,
     super.factoryFactory = otelSDKFactoryFactoryFunction,
   });
+
+  /// A real SDK implementation, never the replaceable no-op API factory.
+  @override
+  bool get isAPIFactory => false;
 
   /// Creates a new Resource with the specified attributes and schema URL.
   ///

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:typed_data';
@@ -219,9 +219,21 @@ class OTel {
         resourceAttributes = OTel.attributesFromMap(envResourceAttrs);
       }
     }
-    if (OTelFactory.otelFactory != null) {
+    // The API auto-installs its no-op factory when API code runs before the
+    // SDK initializes (per spec) — including the OTEL_RESOURCE_ATTRIBUTES
+    // parsing above. That no-op must not block SDK initialization: replace
+    // exactly it and nothing else.
+    final existingFactory = OTelFactory.otelFactory;
+    if (existingFactory != null && !existingFactory.isAPIFactory) {
       throw StateError(
         'OTelAPI can only be initialized once. If you need multiple endpoints or service names or versions create a named TracerProvider',
+      );
+    }
+    if (existingFactory != null && OTelLog.isDebug()) {
+      OTelLog.debug(
+        'OTel.initialize: replacing the auto-installed no-op API factory '
+        'with the SDK factory. API objects obtained before initialize() '
+        'remain no-ops.',
       );
     }
 
@@ -1286,10 +1298,14 @@ class OTel {
     if (_otelFactory != null) {
       return _otelFactory!;
     }
-    if (OTelFactory.otelFactory == null) {
+    final installed = OTelFactory.otelFactory;
+    // An installed factory that is not SDK-capable is the API's
+    // auto-installed no-op (API-only code ran first) — the SDK still isn't
+    // initialized, and saying so beats the TypeError the cast produced (#50).
+    if (installed == null || installed is! OTelSDKFactory) {
       throw StateError('initialize() must be called first.');
     }
-    return _otelFactory = OTelFactory.otelFactory! as OTelSDKFactory;
+    return _otelFactory = installed;
   }
 
   /// Initializes logging based on environment variables.

--- a/test/unit/metrics/observe/observable_result_test.dart
+++ b/test/unit/metrics/observe/observable_result_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';
@@ -148,7 +148,7 @@ void main() {
       OTelFactory.otelFactory = savedFactory;
     });
 
-    test('observeWithMap with null OTelFactory does not add measurement', () {
+    test('observeWithMap with null OTelFactory records via the no-op API', () {
       // First make observations with valid factory
       intResult.observeWithMap(1, {'key': 'value'});
       expect(intResult.measurements.length, equals(1));
@@ -157,11 +157,11 @@ void main() {
       final savedFactory = OTelFactory.otelFactory;
       OTelFactory.otelFactory = null;
 
-      // Try to observe with null factory
+      // Since dartastic_opentelemetry_api 1.0.0-beta.8, API calls lazily
+      // install the no-op factory instead of failing, so the observation
+      // is recorded
       intResult.observeWithMap(2, {'key': 'value'});
-
-      // Should still have just one measurement
-      expect(intResult.measurements.length, equals(1));
+      expect(intResult.measurements.length, equals(2));
 
       // Restore factory
       OTelFactory.otelFactory = savedFactory;

--- a/test/unit/otel_api_first_initialize_test.dart
+++ b/test/unit/otel_api_first_initialize_test.dart
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    as api;
+import 'package:test/test.dart';
+
+// Regression for #50 against dartastic_opentelemetry_api >= 1.0.0-beta.8:
+// the API lazily installs its no-op factory whenever API code runs before
+// the SDK initializes (e.g. OTel.initialize() itself parses
+// OTEL_RESOURCE_ATTRIBUTES through the API before its once-only guard).
+// The auto-installed no-op reports isAPIFactory == true and must be
+// replaced by initialize(), not treated as prior initialization.
+//
+// This must run before anything else in the process installs a factory, so
+// it lives in its own file — the `test` package runs each test file in its
+// own isolate, giving a pristine (uninitialized) copy of all library statics.
+void main() {
+  tearDown(() async {
+    await OTel.reset();
+  });
+
+  test('OTel.initialize succeeds after API code installs the no-op factory',
+      () async {
+    api.OTelAPI.attributesFromMap({'service.namespace': 'test'});
+    expect(OTelFactory.otelFactory, isNotNull);
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+
+    await OTel.initialize(
+      serviceName: 'api-first-service',
+      detectPlatformResources: false,
+    );
+    expect(OTelFactory.otelFactory, isA<OTelSDKFactory>());
+    expect(OTel.tracerProvider(), isA<TracerProvider>());
+  });
+}


### PR DESCRIPTION
## Summary

**SDK main is currently broken against the released `dartastic_opentelemetry_api` 1.0.0-beta.9**: the API now lazily installs its no-op factory whenever API code runs first — including `OTel.initialize()`'s own `OTEL_RESOURCE_ATTRIBUTES` parsing, which runs *before* the once-only guard. Any app setting `OTEL_RESOURCE_ATTRIBUTES` throws `'OTelAPI can only be initialized once'` at startup, and CI's fresh `pub get` hits the same in 9 env subprocess tests on every PR.

TDD: first commit pins the API-first initialization contract red (failing with the production error signature), second turns it green.

## Changes

This is the design from #53's discussion, finalized with the `isAPIFactory` getter added to the API in beta.8 for exactly this purpose (thanks @robert-northmind for driving #53):

- `OTel.initialize()` replaces an installed factory reporting `isAPIFactory == true`; a real factory still triggers the once-only `StateError`.
- `OTelSDKFactory` overrides `isAPIFactory => false`.
- `_getAndCacheOtelFactory` reports `'initialize() must be called first.'` instead of the opaque `as OTelSDKFactory` cast `TypeError` (#50) when only the no-op is installed.
- `observable_result_test`'s null-factory expectation updated to the beta.8+ lazy-install contract.

Closes #50.

## Validation

- `dart analyze` / `dart format --set-exit-if-changed .` — clean
- `./tool/test.sh` — 1817 tests passing, 19 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)