### PR TITLE
chore: CNCF headers — Copyright The OpenTelemetry Authors + SPDX (#57)

### DIFF
--- a/example/baggage_error_handling_example.dart
+++ b/example/baggage_error_handling_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 

--- a/example/baggage_example.dart
+++ b/example/baggage_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Example helpers below `main()` are illustrative entry points for other
 // scenarios — readers can call them in their own `main()`.

--- a/example/console_exporter_sanity_check.dart
+++ b/example/console_exporter_sanity_check.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 
 /// App-specific attribute keys as a typed enum. Prefer enums over raw

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Example demonstrating basic usage of Dartastic OpenTelemetry SDK.
 ///

--- a/example/grafana/grafana_cloud_env_example.dart
+++ b/example/grafana/grafana_cloud_env_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper functions below `main()` show alternate initialization paths;
 // they aren't all reachable from this file's `main()`.

--- a/example/grafana/grafana_smoke_test.dart
+++ b/example/grafana/grafana_smoke_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import 'dart:async';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 

--- a/example/grafana_cloud_env_example.dart
+++ b/example/grafana_cloud_env_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper functions below `main()` show alternate initialization paths;
 // they aren't all reachable from this file's `main()`.

--- a/example/isolate_context_example.dart
+++ b/example/isolate_context_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Alternate Zone-based examples below `main()` are illustrative entry points
 // readers can call from their own `main()`.

--- a/example/otlp_grpc_example.dart
+++ b/example/otlp_grpc_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 

--- a/example/otlp_grpc_simple_sync_example.dart
+++ b/example/otlp_grpc_simple_sync_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 

--- a/example/propagator_example.dart
+++ b/example/propagator_example.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Example demonstrating W3C Trace Context Propagator usage
 ///

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Re-exports the full OpenTelemetry API surface. The previous
 /// curated `show` list was dropped because the OTel semconv registry

--- a/lib/src/context/propagation/w3c_baggage_propagator.dart
+++ b/lib/src/context/propagation/w3c_baggage_propagator.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/environment/env_constants.dart
+++ b/lib/src/environment/env_constants.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// OpenTelemetry environment variable constants.
 ///

--- a/lib/src/environment/env_from_define.dart
+++ b/lib/src/environment/env_from_define.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'env_constants.dart';
 

--- a/lib/src/environment/environment_service.dart
+++ b/lib/src/environment/environment_service.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 export 'environment_service_io.dart'
     if (dart.library.js_interop) 'environment_service_web.dart';

--- a/lib/src/environment/environment_service_io.dart
+++ b/lib/src/environment/environment_service_io.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io' as io;
 

--- a/lib/src/environment/environment_service_web.dart
+++ b/lib/src/environment/environment_service_web.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'env_constants.dart';
 import 'environment_service.dart';

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'env_constants.dart';

--- a/lib/src/export/export_result.dart
+++ b/lib/src/export/export_result.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Result of an export operation.
 ///

--- a/lib/src/export/otlp_http_protocol.dart
+++ b/lib/src/export/otlp_http_protocol.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Wire-format protocol for OTLP/HTTP exporters.
 ///

--- a/lib/src/export/otlp_json.dart
+++ b/lib/src/export/otlp_json.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2026, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 

--- a/lib/src/factory/otel_sdk_factory.dart
+++ b/lib/src/factory/otel_sdk_factory.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
 import '../logs/logger_provider.dart';

--- a/lib/src/logs/bridge/dart_log_bridge.dart
+++ b/lib/src/logs/bridge/dart_log_bridge.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:developer' as developer;

--- a/lib/src/logs/export/batch_log_record_processor.dart
+++ b/lib/src/logs/export/batch_log_record_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:collection';

--- a/lib/src/logs/export/console_log_record_exporter.dart
+++ b/lib/src/logs/export/console_log_record_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../dartastic_opentelemetry.dart';
 

--- a/lib/src/logs/export/log_record_exporter.dart
+++ b/lib/src/logs/export/log_record_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../export/export_result.dart';
 import '../readable_log_record.dart';

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../../export/otlp_http_protocol.dart';
 import '../../../../trace/export/otlp/certificate_utils.dart';

--- a/lib/src/logs/export/otlp/log_record_transformer.dart
+++ b/lib/src/logs/export/otlp/log_record_transformer.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:fixnum/fixnum.dart';

--- a/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:math';

--- a/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter_config.dart
+++ b/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../trace/export/otlp/certificate_utils.dart';
 

--- a/lib/src/logs/export/simple_log_record_processor.dart
+++ b/lib/src/logs/export/simple_log_record_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/logs/log_record_processor.dart
+++ b/lib/src/logs/log_record_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/logs/logger.dart
+++ b/lib/src/logs/logger.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/logs/logger_create.dart
+++ b/lib/src/logs/logger_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'logger.dart';
 

--- a/lib/src/logs/logger_provider.dart
+++ b/lib/src/logs/logger_provider.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/logs/logger_provider_create.dart
+++ b/lib/src/logs/logger_provider_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'logger_provider.dart';
 

--- a/lib/src/logs/readable_log_record.dart
+++ b/lib/src/logs/readable_log_record.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:fixnum/fixnum.dart';
 

--- a/lib/src/metrics/data/exemplar.dart
+++ b/lib/src/metrics/data/exemplar.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/data/metric.dart
+++ b/lib/src/metrics/data/metric.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'metric_point.dart';

--- a/lib/src/metrics/data/metric_data.dart
+++ b/lib/src/metrics/data/metric_data.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../resource/resource.dart';
 import 'metric.dart';

--- a/lib/src/metrics/data/metric_point.dart
+++ b/lib/src/metrics/data/metric_point.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/export/composite_metric_exporter.dart
+++ b/lib/src/metrics/export/composite_metric_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter_config.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../../export/otlp_http_protocol.dart';
 import '../../../../trace/export/otlp/certificate_utils.dart';

--- a/lib/src/metrics/export/otlp/metric_transformer.dart
+++ b/lib/src/metrics/export/otlp/metric_transformer.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter_config.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../trace/export/otlp/certificate_utils.dart';
 

--- a/lib/src/metrics/export/prometheus/prometheus_exporter.dart
+++ b/lib/src/metrics/export/prometheus/prometheus_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/src/metrics/instruments/base_instrument.dart
+++ b/lib/src/metrics/instruments/base_instrument.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../dartastic_opentelemetry.dart';
 

--- a/lib/src/metrics/instruments/counter.dart
+++ b/lib/src/metrics/instruments/counter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/instruments/gauge.dart
+++ b/lib/src/metrics/instruments/gauge.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/instruments/histogram.dart
+++ b/lib/src/metrics/instruments/histogram.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/instruments/observable_counter.dart
+++ b/lib/src/metrics/instruments/observable_counter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../dartastic_opentelemetry.dart';
 

--- a/lib/src/metrics/instruments/observable_gauge.dart
+++ b/lib/src/metrics/instruments/observable_gauge.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../dartastic_opentelemetry.dart';
 

--- a/lib/src/metrics/instruments/observable_up_down_counter.dart
+++ b/lib/src/metrics/instruments/observable_up_down_counter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../dartastic_opentelemetry.dart';
 

--- a/lib/src/metrics/instruments/up_down_counter.dart
+++ b/lib/src/metrics/instruments/up_down_counter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/meter.dart
+++ b/lib/src/metrics/meter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/metrics/meter_create.dart
+++ b/lib/src/metrics/meter_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'meter.dart';
 

--- a/lib/src/metrics/meter_provider.dart
+++ b/lib/src/metrics/meter_provider.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/src/metrics/meter_provider_create.dart
+++ b/lib/src/metrics/meter_provider_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'meter_provider.dart';
 

--- a/lib/src/metrics/metric_exporter.dart
+++ b/lib/src/metrics/metric_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/src/metrics/metric_reader.dart
+++ b/lib/src/metrics/metric_reader.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/src/metrics/observe/observable_result.dart
+++ b/lib/src/metrics/observe/observable_result.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/storage/gauge_storage.dart
+++ b/lib/src/metrics/storage/gauge_storage.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/storage/histogram_storage.dart
+++ b/lib/src/metrics/storage/histogram_storage.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/storage/metric_storage.dart
+++ b/lib/src/metrics/storage/metric_storage.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/storage/point_storage.dart
+++ b/lib/src/metrics/storage/point_storage.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/storage/sum_storage.dart
+++ b/lib/src/metrics/storage/sum_storage.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/metrics/view.dart
+++ b/lib/src/metrics/view.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:typed_data';

--- a/lib/src/resource/native_detectors.dart
+++ b/lib/src/resource/native_detectors.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Conditional facade for the native (`dart:io`-using) resource detectors.
 // On native platforms this exports the real implementations; on web it

--- a/lib/src/resource/native_detectors_io.dart
+++ b/lib/src/resource/native_detectors_io.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Native (VM / Flutter mobile / Flutter desktop) implementations of the
 // resource detectors that read from `dart:io`. Imported only on

--- a/lib/src/resource/native_detectors_stub.dart
+++ b/lib/src/resource/native_detectors_stub.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Stub implementations of the native resource detectors for web /
 // any platform without `dart:io`. The classes still implement

--- a/lib/src/resource/resource.dart
+++ b/lib/src/resource/resource.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/resource/resource_create.dart
+++ b/lib/src/resource/resource_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'resource.dart';
 

--- a/lib/src/resource/resource_detector.dart
+++ b/lib/src/resource/resource_detector.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/resource/web_detector.dart
+++ b/lib/src/resource/web_detector.dart
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 export 'web_detector_impl.dart' if (dart.library.io) 'web_detector_stub.dart';

--- a/lib/src/resource/web_detector_impl.dart
+++ b/lib/src/resource/web_detector_impl.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Implementation file for web platforms
 // This file won't be directly imported on non-web platforms

--- a/lib/src/resource/web_detector_stub.dart
+++ b/lib/src/resource/web_detector_stub.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // This is a stub implementation for non-web platforms
 // It doesn't import dart:js_interop

--- a/lib/src/trace/export/baggage_span_processor.dart
+++ b/lib/src/trace/export/baggage_span_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/trace/export/batch_span_processor.dart
+++ b/lib/src/trace/export/batch_span_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:collection';

--- a/lib/src/trace/export/composite_exporter.dart
+++ b/lib/src/trace/export/composite_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../span.dart';
 import 'span_exporter.dart';

--- a/lib/src/trace/export/console_exporter.dart
+++ b/lib/src/trace/export/console_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../span.dart';
 import 'span_exporter.dart';

--- a/lib/src/trace/export/otlp/certificate_utils.dart
+++ b/lib/src/trace/export/otlp/certificate_utils.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Conditional facade for [CertificateUtils]. On native targets exports
 // the IO implementation (with `createSecurityContext`); on web exports

--- a/lib/src/trace/export/otlp/certificate_utils_io.dart
+++ b/lib/src/trace/export/otlp/certificate_utils_io.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Native (`dart:io`) implementation of certificate utilities. Imported
 // via the facade `certificate_utils.dart`, which falls back to a stub
 // on web.

--- a/lib/src/trace/export/otlp/certificate_utils_stub.dart
+++ b/lib/src/trace/export/otlp/certificate_utils_stub.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Web / non-`dart:io` stub for certificate utilities.
 //
 // Browsers do TLS themselves — there is no equivalent of `SecurityContext`

--- a/lib/src/trace/export/otlp/http/http_client_factory.dart
+++ b/lib/src/trace/export/otlp/http/http_client_factory.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Conditional facade for the platform-specific HTTP client factory used
 // by the OTLP/HTTP exporters. Native targets get an `IOClient`; web

--- a/lib/src/trace/export/otlp/http/http_client_factory_io.dart
+++ b/lib/src/trace/export/otlp/http/http_client_factory_io.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Native (`dart:io`) implementation of the HTTP client factory used by
 // the OTLP/HTTP exporters. Builds an `IOClient` wrapping an `HttpClient`

--- a/lib/src/trace/export/otlp/http/http_client_factory_web.dart
+++ b/lib/src/trace/export/otlp/http/http_client_factory_web.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Web implementation of the HTTP client factory used by the OTLP/HTTP
 // exporters. Browsers handle TLS themselves — there is no equivalent

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter_config.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../../../export/otlp_http_protocol.dart';
 import '../certificate_utils.dart';

--- a/lib/src/trace/export/otlp/otlp_grpc_span_exporter.dart
+++ b/lib/src/trace/export/otlp/otlp_grpc_span_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:math';

--- a/lib/src/trace/export/otlp/otlp_grpc_span_exporter_config.dart
+++ b/lib/src/trace/export/otlp/otlp_grpc_span_exporter_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'certificate_utils.dart';
 

--- a/lib/src/trace/export/otlp/span_transformer.dart
+++ b/lib/src/trace/export/otlp/span_transformer.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 

--- a/lib/src/trace/export/simple_span_processor.dart
+++ b/lib/src/trace/export/simple_span_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/trace/export/span_exporter.dart
+++ b/lib/src/trace/export/span_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../span.dart';
 

--- a/lib/src/trace/export/test_file_exporter.dart
+++ b/lib/src/trace/export/test_file_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/trace/sampling/always_off_sampler.dart
+++ b/lib/src/trace/sampling/always_off_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'sampler.dart';

--- a/lib/src/trace/sampling/always_on_sampler.dart
+++ b/lib/src/trace/sampling/always_on_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'sampler.dart';

--- a/lib/src/trace/sampling/composite_sampler.dart
+++ b/lib/src/trace/sampling/composite_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import '../../otel.dart';

--- a/lib/src/trace/sampling/counting_sampler.dart
+++ b/lib/src/trace/sampling/counting_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'sampler.dart';

--- a/lib/src/trace/sampling/parent_based_sampler.dart
+++ b/lib/src/trace/sampling/parent_based_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/trace/sampling/probability_sampler.dart
+++ b/lib/src/trace/sampling/probability_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:math';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/lib/src/trace/sampling/rate_limiting_sampler.dart
+++ b/lib/src/trace/sampling/rate_limiting_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/lib/src/trace/sampling/root_span_id_fix.dart
+++ b/lib/src/trace/sampling/root_span_id_fix.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/trace/sampling/sampler.dart
+++ b/lib/src/trace/sampling/sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/trace/sampling/trace_id_ratio_sampler.dart
+++ b/lib/src/trace/sampling/trace_id_ratio_sampler.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:math' as math;
 

--- a/lib/src/trace/span.dart
+++ b/lib/src/trace/span.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/trace/span_create.dart
+++ b/lib/src/trace/span_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'span.dart';
 

--- a/lib/src/trace/span_exception_options.dart
+++ b/lib/src/trace/span_exception_options.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Callback that transforms a raw exception into sanitized span data.
 ///

--- a/lib/src/trace/span_logger.dart
+++ b/lib/src/trace/span_logger.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../dartastic_opentelemetry.dart' show OTelLog, Span;
 

--- a/lib/src/trace/span_processor.dart
+++ b/lib/src/trace/span_processor.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/trace/tracer_create.dart
+++ b/lib/src/trace/tracer_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'tracer.dart';
 

--- a/lib/src/trace/tracer_provider.dart
+++ b/lib/src/trace/tracer_provider.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/trace/tracer_provider_create.dart
+++ b/lib/src/trace/tracer_provider_create.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'tracer_provider.dart';
 

--- a/lib/src/trace/w3c_trace_context_propagator.dart
+++ b/lib/src/trace/w3c_trace_context_propagator.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/lib/src/util/zip/gzip.dart
+++ b/lib/src/util/zip/gzip.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 export 'gzip_mock.dart'
     if (dart.library.io) 'gzip_io.dart'

--- a/lib/src/util/zip/gzip_io.dart
+++ b/lib/src/util/zip/gzip_io.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 import 'dart:typed_data';

--- a/lib/src/util/zip/gzip_mock.dart
+++ b/lib/src/util/zip/gzip_mock.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/lib/src/util/zip/gzip_web.dart
+++ b/lib/src/util/zip/gzip_web.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:js_interop';
 import 'dart:typed_data';

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2025, Dartastic.io, All rights reserved.
 
 /// Test helpers for the Dartastic OpenTelemetry SDK.

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';
 

--- a/test/integration/cert_test.dart
+++ b/test/integration/cert_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';

--- a/test/integration/environment_variables_test.dart
+++ b/test/integration/environment_variables_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Integration test for environment variable behavior
 // This test should be run with actual environment variables or --dart-define flags
 // via the tool/test_env_vars.sh script

--- a/test/integration/metrics/auto_collection_test.dart
+++ b/test/integration/metrics/auto_collection_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: unused_field, unused_local_variable, unreachable_from_main
 

--- a/test/integration/resource_attributes_test.dart
+++ b/test/integration/resource_attributes_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Integration tests for OTEL_RESOURCE_ATTRIBUTES environment variable
 // Run with actual environment variables or --dart-define flags

--- a/test/performance/baggage/baggage_benchmarks.dart
+++ b/test/performance/baggage/baggage_benchmarks.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/test/performance/benchmark_runner.dart
+++ b/test/performance/benchmark_runner.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 

--- a/test/performance/core/api_benchmarks.dart
+++ b/test/performance/core/api_benchmarks.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:dartastic_opentelemetry/src/otel.dart';

--- a/test/performance/transformer_performance_test.dart
+++ b/test/performance/transformer_performance_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry/src/trace/export/otlp/span_transformer.dart';

--- a/test/performance/utils/attributes.dart
+++ b/test/performance/utils/attributes.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/test/testing_utils/in_memory_span_exporter.dart
+++ b/test/testing_utils/in_memory_span_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';

--- a/test/testing_utils/memory_log_record_exporter.dart
+++ b/test/testing_utils/memory_log_record_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 

--- a/test/testing_utils/memory_metric_exporter.dart
+++ b/test/testing_utils/memory_metric_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/testing_utils/network_proxy.dart
+++ b/test/testing_utils/network_proxy.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/testing_utils/real_collector.dart
+++ b/test/testing_utils/real_collector.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // This file walks decoded JSON payloads from the OTel Collector, where
 // the natural structure is `dynamic`-typed and `Map<String, dynamic>`.

--- a/test/testing_utils/test_file_exporter.dart
+++ b/test/testing_utils/test_file_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/baggage/w3c_baggage_propagator_test.dart
+++ b/test/unit/baggage/w3c_baggage_propagator_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/context/propagation/w3c_baggage_propagator.dart';
 import 'package:dartastic_opentelemetry/src/otel.dart';

--- a/test/unit/common/attributes_test.dart
+++ b/test/unit/common/attributes_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/common/resource_tenant_id_test.dart
+++ b/test/unit/common/resource_tenant_id_test.dart
@@ -1,8 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 @Tags(['fail'])
 library;
-
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/context/context_propagation_test.dart
+++ b/test/unit/context/context_propagation_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/context/context_propagation_tests.dart
+++ b/test/unit/context/context_propagation_tests.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry/src/trace/tracer.dart';

--- a/test/unit/context/context_propagator_test.dart
+++ b/test/unit/context/context_propagator_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/test/unit/context/context_test.dart
+++ b/test/unit/context/context_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/context/context_utils_test.dart
+++ b/test/unit/context/context_utils_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests for environment configuration, resource detection, and OTel
 // initialization exercising error paths and edge cases.

--- a/test/unit/environment/helpers/check_blrp_config.dart
+++ b/test/unit/environment/helpers/check_blrp_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON of OTelEnv.getBlrpConfig() result.
 // Run via subprocess with OTEL_BLRP_* env vars set.

--- a/test/unit/environment/helpers/check_envvar_resource_detector.dart
+++ b/test/unit/environment/helpers/check_envvar_resource_detector.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: initializes OTel and runs EnvVarResourceDetector, prints
 // the detected attributes as JSON.

--- a/test/unit/environment/helpers/check_exporter.dart
+++ b/test/unit/environment/helpers/check_exporter.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints the result of OTelEnv.getExporter().
 // Run via subprocess with OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER,

--- a/test/unit/environment/helpers/check_initialized_pipeline.dart
+++ b/test/unit/environment/helpers/check_initialized_pipeline.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: calls OTel.initialize() with no parameters and prints a
 // JSON snapshot of the resulting pipeline (span processors, metric readers,

--- a/test/unit/environment/helpers/check_log_bools.dart
+++ b/test/unit/environment/helpers/check_log_bools.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON with boolean log function status after
 // OTelEnv.initializeLogging().

--- a/test/unit/environment/helpers/check_log_level.dart
+++ b/test/unit/environment/helpers/check_log_level.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints the log level after OTelEnv.initializeLogging().
 // Run via subprocess with OTEL_LOG_LEVEL env var set.

--- a/test/unit/environment/helpers/check_logrecord_limits.dart
+++ b/test/unit/environment/helpers/check_logrecord_limits.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON of OTelEnv.getLogRecordLimits() result.
 // Run via subprocess with OTEL_LOGRECORD_* env vars set.

--- a/test/unit/environment/helpers/check_otlp_config.dart
+++ b/test/unit/environment/helpers/check_otlp_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON of OTelEnv.getOtlpConfig() result.
 // Run via subprocess with OTEL_EXPORTER_OTLP_* env vars set.

--- a/test/unit/environment/helpers/check_parse_headers.dart
+++ b/test/unit/environment/helpers/check_parse_headers.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON of parsed headers from OTEL_EXPORTER_OTLP_HEADERS.
 // Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS env var set.

--- a/test/unit/environment/helpers/check_resource_attrs.dart
+++ b/test/unit/environment/helpers/check_resource_attrs.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON of OTelEnv.getResourceAttributes() result.
 // Run via subprocess with OTEL_RESOURCE_ATTRIBUTES env var set.

--- a/test/unit/environment/helpers/check_service_config.dart
+++ b/test/unit/environment/helpers/check_service_config.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper script: prints JSON of OTelEnv.getServiceConfig() result.
 // Run via subprocess with OTEL_RESOURCE_ATTRIBUTES and/or OTEL_SERVICE_NAME

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/export/console_exporter_test.dart
+++ b/test/unit/export/console_exporter_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Unit tests for ConsoleExporter that capture and verify console output
 // Tests the fix for: SimpleSpanProcessor.onEnd() is never called because Span.end()
 // doesn't notify span processors

--- a/test/unit/export/otlp_config_test.dart
+++ b/test/unit/export/otlp_config_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/trace/export/otlp/otlp_grpc_span_exporter_config.dart';
 import 'package:test/test.dart';

--- a/test/unit/export/otlp_http_metric_exporter_config_test.dart
+++ b/test/unit/export/otlp_http_metric_exporter_config_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/export/otlp_http_span_exporter_config_test.dart
+++ b/test/unit/export/otlp_http_span_exporter_config_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/export/span_transformer_test.dart
+++ b/test/unit/export/span_transformer_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/proto/opentelemetry_proto_dart.dart'
     as proto;

--- a/test/unit/exporters_coverage_test.dart
+++ b/test/unit/exporters_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Comprehensive test file targeting ~90 additional uncovered lines across
 // multiple source files to push overall coverage from 87.7% toward 90%.

--- a/test/unit/factory/factory_pattern_test.dart
+++ b/test/unit/factory/factory_pattern_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/fixed_scope_test.dart
+++ b/test/unit/fixed_scope_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/infrastructure_coverage_test.dart
+++ b/test/unit/infrastructure_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Comprehensive test file that covers remaining small coverage gaps across
 // multiple source files, with trace-level logging enabled to exercise

--- a/test/unit/logs/bridge/dart_log_bridge_test.dart
+++ b/test/unit/logs/bridge/dart_log_bridge_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/logs/export/batch_log_record_processor_test.dart
+++ b/test/unit/logs/export/batch_log_record_processor_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/logs/export/console_log_record_exporter_test.dart
+++ b/test/unit/logs/export/console_log_record_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:fixnum/fixnum.dart';

--- a/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
+++ b/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests the `protocol` config on `OtlpHttpLogRecordExporter` — the
 // http/protobuf default keeps existing behaviour; opting into

--- a/test/unit/logs/export/otlp/log_record_transformer_test.dart
+++ b/test/unit/logs/export/otlp/log_record_transformer_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:fixnum/fixnum.dart';

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:io';

--- a/test/unit/logs/export/simple_log_record_processor_test.dart
+++ b/test/unit/logs/export/simple_log_record_processor_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/logs/logger_provider_test.dart
+++ b/test/unit/logs/logger_provider_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/logs/logger_test.dart
+++ b/test/unit/logs/logger_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/logs/logs_config_test.dart
+++ b/test/unit/logs/logs_config_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/logs/logs_coverage_test.dart
+++ b/test/unit/logs/logs_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests for logs-related source files exercising error paths, edge cases,
 // and configuration branches.

--- a/test/unit/logs/print_interception_test.dart
+++ b/test/unit/logs/print_interception_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/logs/sdk_log_record_test.dart
+++ b/test/unit/logs/sdk_log_record_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:fixnum/fixnum.dart';

--- a/test/unit/metrics/attributes_equality_test.dart
+++ b/test/unit/metrics/attributes_equality_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/data/exemplar_test.dart
+++ b/test/unit/metrics/data/exemplar_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/data/metric_data_test.dart
+++ b/test/unit/metrics/data/metric_data_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/data/metric_factory_test.dart
+++ b/test/unit/metrics/data/metric_factory_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/data/metric_point_test.dart
+++ b/test/unit/metrics/data/metric_point_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/export/composite_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/composite_metric_exporter_full_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/export/composite_metric_exporter_test.dart
+++ b/test/unit/metrics/export/composite_metric_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/export/metric_exporter_shutdown_test.dart
+++ b/test/unit/metrics/export/metric_exporter_shutdown_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: unreachable_from_main
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:io';

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_retry_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_retry_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:io';

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/export/otlp/metric_transformer_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/metric_transformer_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry/proto/metrics/v1/metrics.pb.dart'

--- a/test/unit/metrics/export/otlp/metric_transformer_test.dart
+++ b/test/unit/metrics/export/otlp/metric_transformer_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry/proto/metrics/v1/metrics.pb.dart'

--- a/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_config_test.dart
+++ b/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_config_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/metrics/export/prometheus/prometheus_exporter_test.dart
+++ b/test/unit/metrics/export/prometheus/prometheus_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/generic_types_test.dart
+++ b/test/unit/metrics/generic_types_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/counter_test.dart
+++ b/test/unit/metrics/instruments/counter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/counter_test_update.dart
+++ b/test/unit/metrics/instruments/counter_test_update.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/gauge_extended_test.dart
+++ b/test/unit/metrics/instruments/gauge_extended_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/gauge_test.dart
+++ b/test/unit/metrics/instruments/gauge_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/histogram_extended_test.dart
+++ b/test/unit/metrics/instruments/histogram_extended_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/histogram_test.dart
+++ b/test/unit/metrics/instruments/histogram_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
+++ b/test/unit/metrics/instruments/observable_collect_metrics_fires_callback_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Regression for #155 — the OTel spec requires observable instruments
 // to invoke their registered callbacks on every collection cycle. Pre-

--- a/test/unit/metrics/instruments/observable_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_counter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/observable_gauge_test.dart
+++ b/test/unit/metrics/instruments/observable_gauge_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/observable_instruments_coverage_test.dart
+++ b/test/unit/metrics/instruments/observable_instruments_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/observable_instruments_full_test.dart
+++ b/test/unit/metrics/instruments/observable_instruments_full_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/observable_up_down_counter_test.dart
+++ b/test/unit/metrics/instruments/observable_up_down_counter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/instruments/up_down_counter_extended_test.dart
+++ b/test/unit/metrics/instruments/up_down_counter_extended_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/meter_coverage_test.dart
+++ b/test/unit/metrics/meter_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/meter_provider_test.dart
+++ b/test/unit/metrics/meter_provider_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // For runZonedGuarded
 

--- a/test/unit/metrics/meter_test.dart
+++ b/test/unit/metrics/meter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/metric_reader_test.dart
+++ b/test/unit/metrics/metric_reader_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/noop_meter_test.dart
+++ b/test/unit/metrics/noop_meter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/observe/observable_result_test.dart
+++ b/test/unit/metrics/observe/observable_result_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/storage/gauge_storage_test.dart
+++ b/test/unit/metrics/storage/gauge_storage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/storage/histogram_storage_test.dart
+++ b/test/unit/metrics/storage/histogram_storage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/storage/storage_null_attributes_test.dart
+++ b/test/unit/metrics/storage/storage_null_attributes_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/sum_storage_test.dart
+++ b/test/unit/metrics/sum_storage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/up_down_counter_test.dart
+++ b/test/unit/metrics/up_down_counter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/metrics/view_test.dart
+++ b/test/unit/metrics/view_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/named_logger_provider_shutdown_test.dart
+++ b/test/unit/named_logger_provider_shutdown_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Regression test for the documented gap in `1.1.0-beta.1`'s fix for
 /// issue #33. That release shut down the *default* `LoggerProvider` in

--- a/test/unit/otel_api_first_test.dart
+++ b/test/unit/otel_api_first_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2026, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Regression tests for #50: API-first usage must not wedge SDK initialization.
 //

--- a/test/unit/otel_default_endpoint_test.dart
+++ b/test/unit/otel_default_endpoint_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/otel_initialization_error_test.dart
+++ b/test/unit/otel_initialization_error_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2026, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Regression coverage for the factory-upgrade lifecycle (issue #50).
 // Test suite contributed by Robert Magnusson in PR #53, adapted to the

--- a/test/unit/otel_sdk_test.dart
+++ b/test/unit/otel_sdk_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Combined test file for OTel SDK initialization, configuration, factory
 // methods, shutdown handling, and SimpleSpanProcessor error paths.

--- a/test/unit/otlp_json_hex_ids_test.dart
+++ b/test/unit/otlp_json_hex_ids_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // OTLP/JSON id-encoding regression (Dartastic Cloud incident, 2026-07-10).
 //
 // OTLP/JSON is proto3-JSON PLUS the spec's deviations: traceId/spanId/

--- a/test/unit/sdk/resource_detector_test.dart
+++ b/test/unit/sdk/resource_detector_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io' as io;
 

--- a/test/unit/sdk/resource_test.dart
+++ b/test/unit/sdk/resource_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/sdk_edge_cases_test.dart
+++ b/test/unit/sdk_edge_cases_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Tests for SDK edge cases across environment config, resource detection,
 /// logging, provider initialization, instruments, and tracing.

--- a/test/unit/shutdown_does_not_hang_test.dart
+++ b/test/unit/shutdown_does_not_hang_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Regression tests for issue #33 — `OTel.shutdown()` hangs in short-lived
 /// Dart CLI binaries.

--- a/test/unit/span_transformer_batch_test.dart
+++ b/test/unit/span_transformer_batch_test.dart
@@ -1,8 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 @Tags(['unit'])
 library;
-
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/spec_defaults_test.dart
+++ b/test/unit/spec_defaults_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Spec-compliance tests for SDK defaults and the OTEL_*_EXPORTER /
 /// OTEL_SDK_DISABLED env vars.

--- a/test/unit/testing_lib_test.dart
+++ b/test/unit/testing_lib_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2025, Mindful Software LLC, All rights reserved.
 //
 // Self-test for `package:dartastic_opentelemetry/testing.dart`.

--- a/test/unit/trace/batch_span_processor_shutdown_test.dart
+++ b/test/unit/trace/batch_span_processor_shutdown_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Regression tests for the `BatchSpanProcessor` shutdown drain bug.
 ///

--- a/test/unit/trace/composite_exporter_test.dart
+++ b/test/unit/trace/composite_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests for CompositeExporter to verify it correctly delegates
 // export, forceFlush, and shutdown to all contained exporters.

--- a/test/unit/trace/console_exporter_edge_test.dart
+++ b/test/unit/trace/console_exporter_edge_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Edge case tests for ConsoleExporter to improve coverage of
 // lib/src/trace/export/console_exporter.dart.

--- a/test/unit/trace/context_propagation_test.dart
+++ b/test/unit/trace/context_propagation_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';

--- a/test/unit/trace/debug_logging_coverage_test.dart
+++ b/test/unit/trace/debug_logging_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests that exercise code paths with debug logging ENABLED.
 //

--- a/test/unit/trace/direct_file_exporter_test.dart
+++ b/test/unit/trace/direct_file_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // This test parses JSON-encoded span output from disk, where the natural
 // structure is `dynamic`/`Map<String, dynamic>`.

--- a/test/unit/trace/export/baggage_span_processor_test.dart
+++ b/test/unit/trace/export/baggage_span_processor_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/otlp/certificate_utils_test.dart
+++ b/test/unit/trace/export/otlp/certificate_utils_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 @TestOn('vm')
 library;

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:io';

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/otlp/otlp_grpc_retry_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_retry_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_config_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_config_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:io';

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_state_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_state_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/simple_span_export_test.dart
+++ b/test/unit/trace/export/simple_span_export_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/file_export_test.dart
+++ b/test/unit/trace/file_export_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/trace/parent_span_id_test.dart
+++ b/test/unit/trace/parent_span_id_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/always_off_sampler_test.dart
+++ b/test/unit/trace/sampling/always_off_sampler_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/always_on_sampler_test.dart
+++ b/test/unit/trace/sampling/always_on_sampler_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/counting_sampler_conditions_test.dart
+++ b/test/unit/trace/sampling/counting_sampler_conditions_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/debug_invalid_parent_id_test.dart
+++ b/test/unit/trace/sampling/debug_invalid_parent_id_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry/src/otel.dart';

--- a/test/unit/trace/sampling/debug_root_span_test.dart
+++ b/test/unit/trace/sampling/debug_root_span_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/debugging_test.dart
+++ b/test/unit/trace/sampling/debugging_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/final_parent_id_test.dart
+++ b/test/unit/trace/sampling/final_parent_id_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/parent_based_sampler_test.dart
+++ b/test/unit/trace/sampling/parent_based_sampler_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/parent_context_test.dart
+++ b/test/unit/trace/sampling/parent_context_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/sampler_test.dart
+++ b/test/unit/trace/sampling/sampler_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/samplers_test.dart
+++ b/test/unit/trace/sampling/samplers_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry/src/trace/sampling/composite_sampler.dart';

--- a/test/unit/trace/sampling/sampling_integration_test.dart
+++ b/test/unit/trace/sampling/sampling_integration_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/sampling/trace_id_ratio_sampler_test.dart
+++ b/test/unit/trace/sampling/trace_id_ratio_sampler_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:math';
 

--- a/test/unit/trace/simple_span_processor_test.dart
+++ b/test/unit/trace/simple_span_processor_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/simple_test_file_exporter_test.dart
+++ b/test/unit/trace/simple_test_file_exporter_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/trace/span_context_test.dart
+++ b/test/unit/trace/span_context_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/src/otel.dart';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/test/unit/trace/span_exception_options_test.dart
+++ b/test/unit/trace/span_exception_options_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/span_lifecycle_test.dart
+++ b/test/unit/trace/span_lifecycle_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/span_processor_test.dart
+++ b/test/unit/trace/span_processor_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/span_test.dart
+++ b/test/unit/trace/span_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/span_transformer_advanced_test.dart
+++ b/test/unit/trace/span_transformer_advanced_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/proto/opentelemetry_proto_dart.dart'
     as proto;

--- a/test/unit/trace/tracer_and_span_coverage_test.dart
+++ b/test/unit/trace/tracer_and_span_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Test file covering remaining small coverage gaps across multiple files.
 library;

--- a/test/unit/trace/tracer_method_test.dart
+++ b/test/unit/trace/tracer_method_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/tracer_methods_test.dart
+++ b/test/unit/trace/tracer_methods_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/tracer_provider_test.dart
+++ b/test/unit/trace/tracer_provider_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/trace/tracer_test.dart
+++ b/test/unit/trace/tracer_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/w3c_trace_context_propagator_coverage_test.dart
+++ b/test/unit/trace/w3c_trace_context_propagator_coverage_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/w3c_trace_context_propagator_test.dart
+++ b/test/unit/trace/w3c_trace_context_propagator_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';

--- a/test/unit/util/otel_env_test.dart
+++ b/test/unit/util/otel_env_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry/src/trace/span_logger.dart';

--- a/test/unit/util/otel_log_test.dart
+++ b/test/unit/util/otel_log_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 

--- a/test/unit/util/time_provider_test.dart
+++ b/test/unit/util/time_provider_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Tests for the pluggable TimeProvider abstraction added in 1.1.0-beta.2.
 //

--- a/test/unit/util/zip/gzip_test.dart
+++ b/test/unit/util/zip/gzip_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
 import 'dart:typed_data';

--- a/test/web/util/zip/gzip_web_test.dart
+++ b/test/web/util/zip/gzip_web_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 @TestOn('browser')
 library;

--- a/test/web/web_compile_smoke_test.dart
+++ b/test/web/web_compile_smoke_test.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 @TestOn('browser')
 library;

--- a/tool/add_header.sh
+++ b/tool/add_header.sh
@@ -4,8 +4,8 @@
 
 # Define the header using a here-document that includes an extra blank line.
 read -r -d '' HEADER << 'EOF'
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 
 EOF
@@ -13,7 +13,7 @@ EOF
 # Find all .dart files in the current directory and subdirectories
 find . -type f -name "*.dart" | while IFS= read -r file; do
     # Check if the header is already present in the file to avoid duplicate headers
-    if ! grep -q "Licensed under the Apache License" "$file"; then
+    if ! grep -q "Copyright The OpenTelemetry Authors" "$file"; then
         echo "Adding header to $file"
         # Create a temporary file to hold the new content
         tmpfile=$(mktemp)

--- a/tool/read_all_env_vars.dart
+++ b/tool/read_all_env_vars.dart
@@ -1,4 +1,6 @@
 #!/usr/bin/env dart
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 // Comprehensive utility to test reading ALL OTel environment variables
 // Used by integration tests to verify both POSIX env vars and --dart-defines work
 

--- a/tool/read_env_vars.dart
+++ b/tool/read_env_vars.dart
@@ -1,4 +1,6 @@
 #!/usr/bin/env dart
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 // Simple utility to read environment variables and output them in a parseable format
 // Used by test_env_vars.sh to verify environment variable reading works correctly
 

--- a/tool/read_otel_config.dart
+++ b/tool/read_otel_config.dart
@@ -1,4 +1,6 @@
 #!/usr/bin/env dart
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 // Utility to read OTelEnv configuration and output in parseable format
 // Used by integration test scripts to verify environment variable parsing
 

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -1,5 +1,5 @@
-// Licensed under the Apache License, Version 2.0
-// Copyright 2025, Michael Bushe, All rights reserved.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Release script — Flutter / Dart team `-wip` pattern.
 ///


### PR DESCRIPTION
Fixes #57 — replaces the per-file `// Licensed under the Apache License, Version 2.0` / `// Copyright 2025, Michael Bushe, All rights reserved.` header with the standard OpenTelemetry form, per the CNCF copyright-notice policy and the OTel community process doc ("We use 'Copyright The OpenTelemetry Authors' notice form"):

```dart
// Copyright The OpenTelemetry Authors
// SPDX-License-Identifier: Apache-2.0
```

- All hand-written Dart sources converted, including files that had no header and variant headers (stray `Copyright 2026` lines, two mid-file license lines), and the files added by #62.
- Generated `lib/proto/**` left as-is — regenerated from upstream `opentelemetry-proto`; CNCF policy says not to alter third-party notices.
- The three `tool/read_*.dart` scripts keep their `#!/usr/bin/env dart` shebang as the first line, header below.
- `tool/add_header.sh` emits and detects the new header.

Rebased onto main after #62 (which superseded #63).

Mirrors dartastic_opentelemetry_api#46.

## Validation

- `dart analyze` / `dart format --set-exit-if-changed .` — clean
- `./tool/test.sh` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)