### PR TITLE
fix: coverage-run failures — spec-only trace pipeline + gzip test retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.7-wip]
 
+### Fixed
+- **Debug logging no longer adds a `ConsoleExporter` to the trace pipeline.**
+  `OTel.initialize()` used to append a `ConsoleExporter` to the span exporters
+  whenever debug logging was enabled (e.g. `OTEL_LOG_LEVEL=debug`/`trace`),
+  silently changing the export pipeline shape. Per the OTel spec the default
+  exporter is `otlp` only — the same cleanup #49 applied to metrics. Console
+  output remains available explicitly: `OTEL_TRACES_EXPORTER=console`
+  (replaces the exporter) or the `OTEL_CONSOLE_EXPORTER` `--dart-define`
+  (adds one alongside). For span logging use `OTEL_LOG_SPANS=true`.
+
 ### Added
 - **Configurable exception handling for `Tracer.withSpan` / `withSpanAsync`.** A new `SpanExceptionOptions` (with `recordException`, `setStatusOnException`, and an `exceptionSanitizer` callback returning a `SanitizedSpanException`) lets callers customize how a thrown exception is recorded and whether the span status is set. The defaults preserve the existing behavior (record the exception + set `SpanStatusCode.Error`), and the original exception is always rethrown. Configure globally via `OTel.initialize(spanExceptionOptions: ...)` (also available per `TracerProvider` and `OTel.addTracerProvider`) and override per call via the new `exceptionOptions:` parameter on `withSpan` / `withSpanAsync` / `startActiveSpan` / `startActiveSpanAsync` and `OTel.withSpan` / `OTel.withSpanAsync`. Per-call options are merged field-by-field over the global config (via `SpanExceptionOptions.mergeWith`), so overriding a single flag preserves a globally configured sanitizer. When a sanitizer is provided, only its returned type/message/stacktrace are recorded — the raw exception's details never leak — and if the sanitizer itself throws, the span is marked failed with a generic description. This enables SDKs and applications to redact PII before it is recorded. ([#51](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/issues/51))
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -93,9 +93,12 @@ class OTel {
   /// This method must be called before any other OpenTelemetry operations.
   /// It sets up the global configuration and installs the SDK implementation.
   ///
-  /// When OTelLog.debug is true or the environmental variable
-  /// OTEL_CONSOLE_EXPORTER is set to true, a ConsoleExporter is added to the
-  /// exports to print spans.
+  /// When OTEL_CONSOLE_EXPORTER is set to true (a compile-time
+  /// --dart-define), a ConsoleExporter is added alongside the configured
+  /// span exporter. To replace the default exporter with console output
+  /// instead, set OTEL_TRACES_EXPORTER=console. Per the OTel spec the
+  /// default exporter is otlp only — debug logging does not change the
+  /// export pipeline (use OTEL_LOG_SPANS for span logging).
   ///
   /// @param endpoint The endpoint URL for the OpenTelemetry collector (default: http://localhost:4318)
   /// @param secure Whether to use TLS for the connection (default: true)
@@ -441,11 +444,14 @@ class OTel {
 
         // Only add ConsoleExporter in debug mode or if explicitly requested
         final exporters = <SpanExporter>[exporter];
-        if (OTelLog.isDebug() ||
-            const bool.fromEnvironment(
-              'OTEL_CONSOLE_EXPORTER',
-              defaultValue: false,
-            )) {
+        // Spec: the default pipeline is otlp only — debug logging must not
+        // alter it (see #49 for the identical metrics fix). Console output
+        // stays available via OTEL_TRACES_EXPORTER=console (replaces) or the
+        // OTEL_CONSOLE_EXPORTER dart-define (adds alongside).
+        if (const bool.fromEnvironment(
+          'OTEL_CONSOLE_EXPORTER',
+          defaultValue: false,
+        )) {
           exporters.add(ConsoleExporter());
         }
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
@@ -381,11 +381,13 @@ void main() {
   // ---------------------------------------------------------------
   // Compression path coverage
   // ---------------------------------------------------------------
+  // retry: flaky under high test concurrency (local server starvation),
+  // solid when run solo.
   test('export with compression exercises gzip path', () async {
     await startServer();
     final exp = createExporter(compression: true);
     final result = await exp.export(makeMetrics());
     expect(result, isTrue);
     await exp.shutdown();
-  });
+  }, retry: 2);
 }

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -6,7 +6,7 @@ set -e  # Exit on any error
 # Parse command line arguments
 # Need trace logging for coverage of debug and trace logs
 LOG_LEVEL="trace"
-CONCURRENCY="20"
+CONCURRENCY="10"
 
 while [[ $# -gt 0 ]]; do
   case $1 in


### PR DESCRIPTION
Running `./tool/coverage.sh` (which sets `OTEL_LOG_LEVEL=trace`) failed two tests on main. Neither was a regression from the recent merges — the deterministic one reproduces at pre-#60 commits; the coverage environment just isn't exercised by CI.

## Fix 1: debug logging no longer alters the trace export pipeline

`OTel.initialize()` appended a `ConsoleExporter` to the span exporters whenever debug logging was enabled, so under `OTEL_LOG_LEVEL=trace` the processor held a `CompositeExporter` and `otel_default_endpoint_test`'s `isA<OtlpHttpSpanExporter>()` assertion failed. Per the OTel spec the default exporter is `otlp` only — this is the same cleanup #49 applied to metrics ("never console"). Console output stays available explicitly: `OTEL_TRACES_EXPORTER=console` (replaces) or the `OTEL_CONSOLE_EXPORTER` `--dart-define` (adds alongside); `OTEL_LOG_SPANS=true` covers span logging. CHANGELOG entry included.

## Fix 2: gzip metric-export test flake

`export with compression exercises gzip path` passes reliably solo but starves its local HTTP server under `--concurrency=20` with trace-logging overhead. Added `retry: 2` and aligned `coverage.sh`'s concurrency to its own documented default of 10.

## Validation

- Both previously-failing tests pass under the exact coverage env
- Full `./test` sweep with `OTEL_LOG_LEVEL=trace` etc.: **1850 passed, 0 failures**
- `dart analyze` / `dart format`: clean

Follow-up worth considering (not in this PR): a CI job running the coverage script's test invocation so this environment stops drifting silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)