### PR TITLE
feat: adopt dartastic_opentelemetry_api 1.0.0-beta.10 (weaver semconv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.8-wip]
 
+### Changed
+- **Depends on `dartastic_opentelemetry_api` 1.0.0-beta.10** and re-exports
+  its surface: the Weaver-generated semantic-convention enums (90 registry
+  namespaces incl. entities/metrics/events), `NonRecordingSpan`, and the
+  global `TextMapPropagator`. SDK consumers referencing renamed semconv
+  enums through this package inherit the API's breaking renames — the
+  complete old→new tables are in the API package's 1.0.0-beta.10
+  CHANGELOG. SDK span creation is unaffected (the API's no-SDK span
+  behavior only applies without an SDK factory installed).
+- Examples and tests migrated to the new names (`Db`, `Server`, `Code`,
+  `Http.httpRequestMethod`/`httpResponseStatusCode`/`httpResponseBodySize`)
+  and off registry-deprecated keys: the database examples now emit
+  `db.system.name`, `db.namespace`, `db.operation.name`, and
+  `db.query.text` instead of the deprecated `db.system`/`db.name`/
+  `db.operation`/`db.statement`, and drop the deprecated `db.user`.
+- `CompositePropagator` is constructed via `OTelAPI.compositePropagator`
+  (its constructor is factory-only as of the API's beta.10).
+
 ## [1.1.0-beta.7] - 2026-07-11
 
 ### Fixed

--- a/example/example.dart
+++ b/example/example.dart
@@ -91,9 +91,9 @@ Future<void> performDatabaseQuery(Tracer tracer, Span parentSpan) async {
     // Link to parent span via context
     context: OTel.context(spanContext: parentSpan.spanContext),
     attributes: OTel.attributesFromSemanticMap({
-      Database.dbSystem: 'postgresql',
-      Database.dbOperation: 'SELECT',
-      Database.dbName: 'users',
+      Db.dbSystemName: 'postgresql',
+      Db.dbOperationName: 'SELECT',
+      Db.dbNamespace: 'users',
     }),
   );
 
@@ -118,7 +118,7 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
     kind: SpanKind.client,
     context: OTel.context(spanContext: parentSpan.spanContext),
     attributes: OTel.attributesFromSemanticMap({
-      Http.requestMethod: 'GET',
+      Http.httpRequestMethod: 'GET',
       Url.urlFull: 'https://api.example.com/data',
       Url.urlPath: '/data',
     }),
@@ -131,8 +131,8 @@ Future<void> callExternalService(Tracer tracer, Span parentSpan) async {
     // Add response attributes.
     span.addAttributes(
       OTel.attributesFromSemanticMap({
-        Http.responseStatusCode: 200,
-        Http.responseBodySize: 1024,
+        Http.httpResponseStatusCode: 200,
+        Http.httpResponseBodySize: 1024,
       }),
     );
   } catch (e, stackTrace) {

--- a/example/grafana/grafana_cloud_env_example.dart
+++ b/example/grafana/grafana_cloud_env_example.dart
@@ -126,7 +126,7 @@ Future<void> traceHttpRequest(Tracer tracer) async {
   // `attributesOf<E>` is the single-enum form — every key is checked
   // against `Http` at compile time, and Dart 3.10's static dot-shorthand
   // can shorten each entry to `.requestMethod`, `.urlFull`, etc.
-  // `ServerResource` (which keeps its suffix because plain `Server`
+  // `Server` (which keeps its suffix because plain `Server`
   // clashes with `package:grpc`'s `Server`) is mixed in via a map spread
   // — Dart widens the literal's type to `Map<OTelSemantic, Object>`
   // automatically, so `attributesFromSemanticMap` accepts it.
@@ -135,15 +135,15 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     kind: SpanKind.client,
     attributes: OTel.attributesFromSemanticMap({
       ...<Http, Object>{
-        Http.requestMethod: 'GET',
+        Http.httpRequestMethod: 'GET',
       },
       ...<Url, Object>{
         Url.urlFull: 'https://api.example.com/users/123',
         Url.urlPath: '/users/123',
       },
-      ...<ServerResource, Object>{
-        ServerResource.serverAddress: 'api.example.com',
-        ServerResource.serverPort: 443,
+      ...<Server, Object>{
+        Server.serverAddress: 'api.example.com',
+        Server.serverPort: 443,
       },
     }),
   );
@@ -156,12 +156,13 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     // `attributesOf<Http>` form.
     span.addAttributes(
       OTel.attributesOf<Http>({
-        Http.responseStatusCode: 200,
-        Http.responseBodySize: 1234,
+        Http.httpResponseStatusCode: 200,
+        Http.httpResponseBodySize: 1234,
       }),
     );
   } catch (e, stackTrace) {
-    span.addAttributes(OTel.attributesOf<Http>({Http.responseStatusCode: 500}));
+    span.addAttributes(
+        OTel.attributesOf<Http>({Http.httpResponseStatusCode: 500}));
     // The span has a status of SpanStatus.Ok on creation, set it to
     // Error when an error occurs in the span.
     span.recordException(e, stackTrace: stackTrace);
@@ -178,15 +179,14 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
     'db.query',
     kind: SpanKind.client,
     attributes: OTel.attributesFromSemanticMap({
-      Database.dbSystem: 'postgresql',
-      Database.dbName: 'users_db',
-      Database.dbOperation: 'SELECT',
-      Database.dbStatement: 'SELECT * FROM users WHERE active = true LIMIT 100',
-      Database.dbUser: 'app_user',
+      Db.dbSystemName: DbSystemName.postgresql.value,
+      Db.dbNamespace: 'users_db',
+      Db.dbOperationName: 'SELECT',
+      Db.dbQueryText: 'SELECT * FROM users WHERE active = true LIMIT 100',
       // server.address / server.port replace the deprecated net.peer.*
       // per OTel semconv.
-      ServerResource.serverAddress: 'postgres.example.com',
-      ServerResource.serverPort: 5432,
+      Server.serverAddress: 'postgres.example.com',
+      Server.serverPort: 5432,
     }),
   );
 
@@ -195,8 +195,7 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
     await Future<void>.delayed(const Duration(milliseconds: 50));
 
     // Add result metadata.
-    span.addAttributes(
-        Attributes.of({Database.dbResponseReturnedRows.key: 42}));
+    span.addAttributes(Attributes.of({Db.dbResponseReturnedRows.key: 42}));
   } catch (e, stackTrace) {
     // The span has a status of SpanStatus.Ok on creation, set it to
     // Error when an error occurs in the span.

--- a/example/grafana_cloud_env_example.dart
+++ b/example/grafana_cloud_env_example.dart
@@ -126,7 +126,7 @@ Future<void> traceHttpRequest(Tracer tracer) async {
   // `attributesOf<E>` is the single-enum form — every key is checked
   // against `Http` at compile time, and Dart 3.10's static dot-shorthand
   // can shorten each entry to `.requestMethod`, `.urlFull`, etc.
-  // `ServerResource` (which keeps its suffix because plain `Server`
+  // `Server` (which keeps its suffix because plain `Server`
   // clashes with `package:grpc`'s `Server`) is mixed in via a map spread
   // — Dart widens the literal's type to `Map<OTelSemantic, Object>`
   // automatically, so `attributesFromSemanticMap` accepts it.
@@ -135,15 +135,15 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     kind: SpanKind.client,
     attributes: OTel.attributesFromSemanticMap({
       ...<Http, Object>{
-        Http.requestMethod: 'GET',
+        Http.httpRequestMethod: 'GET',
       },
       ...<Url, Object>{
         Url.urlFull: 'https://api.example.com/users/123',
         Url.urlPath: '/users/123',
       },
-      ...<ServerResource, Object>{
-        ServerResource.serverAddress: 'api.example.com',
-        ServerResource.serverPort: 443,
+      ...<Server, Object>{
+        Server.serverAddress: 'api.example.com',
+        Server.serverPort: 443,
       },
     }),
   );
@@ -156,12 +156,13 @@ Future<void> traceHttpRequest(Tracer tracer) async {
     // `attributesOf<Http>` form.
     span.addAttributes(
       OTel.attributesOf<Http>({
-        Http.responseStatusCode: 200,
-        Http.responseBodySize: 1234,
+        Http.httpResponseStatusCode: 200,
+        Http.httpResponseBodySize: 1234,
       }),
     );
   } catch (e, stackTrace) {
-    span.addAttributes(OTel.attributesOf<Http>({Http.responseStatusCode: 500}));
+    span.addAttributes(
+        OTel.attributesOf<Http>({Http.httpResponseStatusCode: 500}));
     // The span has a status of SpanStatus.Ok on creation, set it to
     // Error when an error occurs in the span.
     span.recordException(e, stackTrace: stackTrace);
@@ -178,15 +179,14 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
     'db.query',
     kind: SpanKind.client,
     attributes: OTel.attributesFromSemanticMap({
-      Database.dbSystem: 'postgresql',
-      Database.dbName: 'users_db',
-      Database.dbOperation: 'SELECT',
-      Database.dbStatement: 'SELECT * FROM users WHERE active = true LIMIT 100',
-      Database.dbUser: 'app_user',
+      Db.dbSystemName: DbSystemName.postgresql.value,
+      Db.dbNamespace: 'users_db',
+      Db.dbOperationName: 'SELECT',
+      Db.dbQueryText: 'SELECT * FROM users WHERE active = true LIMIT 100',
       // server.address / server.port replace the deprecated net.peer.*
       // per OTel semconv.
-      ServerResource.serverAddress: 'postgres.example.com',
-      ServerResource.serverPort: 5432,
+      Server.serverAddress: 'postgres.example.com',
+      Server.serverPort: 5432,
     }),
   );
 
@@ -195,8 +195,7 @@ Future<void> traceDatabaseOperation(Tracer tracer) async {
     await Future<void>.delayed(const Duration(milliseconds: 50));
 
     // Add result metadata.
-    span.addAttributes(
-        Attributes.of({Database.dbResponseReturnedRows.key: 42}));
+    span.addAttributes(Attributes.of({Db.dbResponseReturnedRows.key: 42}));
   } catch (e, stackTrace) {
     // The span has a status of SpanStatus.Ok on creation, set it to
     // Error when an error occurs in the span.

--- a/example/otlp_grpc_example.dart
+++ b/example/otlp_grpc_example.dart
@@ -48,7 +48,7 @@ void main() async {
   // convention name for an attribute:
   // https://opentelemetry.io/docs/specs/semconv/general/attributes/
   tracer.attributes = OTel.attributesFromSemanticMap({
-    SourceCode.codeFunctionName: 'main',
+    Code.codeFunctionName: 'main',
   });
 
   // Create a new root span. Prefer typed enum keys over raw strings.

--- a/example/propagator_example.dart
+++ b/example/propagator_example.dart
@@ -22,7 +22,7 @@ void main() async {
   print('=== W3C Trace Context Propagator Example ===\n');
 
   // Create a composite propagator that handles both trace context and baggage
-  final propagator = CompositePropagator<Map<String, String>, String>([
+  final propagator = OTelAPI.compositePropagator<Map<String, String>, String>([
     W3CTraceContextPropagator(),
     W3CBaggagePropagator(),
   ]);

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -1149,17 +1149,17 @@ class OTel {
   }
 
   /// Creates an [Attributes] from a map keyed by [OTelSemantic] enum values
-  /// (e.g. `Http.requestMethod`). Each enum's `.key` is used as the
+  /// (e.g. `Http.httpRequestMethod`). Each enum's `.key` is used as the
   /// attribute name. Lets you write
   ///
   /// ```dart
   /// OTel.attributesFromSemanticMap({
-  ///   Http.requestMethod: 'GET',
-  ///   Http.responseStatusCode: 200,
+  ///   Http.httpRequestMethod: 'GET',
+  ///   Http.httpResponseStatusCode: 200,
   /// })
   /// ```
   ///
-  /// instead of `attributesFromMap({Http.requestMethod.key: 'GET', …})`.
+  /// instead of `attributesFromMap({Http.httpRequestMethod.key: 'GET', …})`.
   /// Mixing enum types in one map is fine — the param is `Map<OTelSemantic, Object>`,
   /// and every semconv enum implements `OTelSemantic`.
   ///
@@ -1179,8 +1179,8 @@ class OTel {
   /// ```dart
   /// // Today and forever:
   /// OTel.attributesOf<Http>({
-  ///   Http.requestMethod: 'GET',
-  ///   Http.responseStatusCode: 200,
+  ///   Http.httpRequestMethod: 'GET',
+  ///   Http.httpResponseStatusCode: 200,
   /// });
   ///
   /// // With Dart 3.10+ static dot-shorthand enabled:
@@ -1198,11 +1198,11 @@ class OTel {
   /// ```dart
   /// OTel.attributesFromSemanticMap({
   ///   ...<Http, Object>{
-  ///     Http.requestMethod: 'GET',
-  ///     Http.responseStatusCode: 200,
+  ///     Http.httpRequestMethod: 'GET',
+  ///     Http.httpResponseStatusCode: 200,
   ///   },
   ///   ...<Database, Object>{
-  ///     Database.dbSystemName: DbSystem.postgresql.value,
+  ///     Db.dbSystemName: DbSystem.postgresql.value,
   ///   },
   /// });
   /// ```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-beta.9
+  dartastic_opentelemetry_api: ^1.0.0-beta.10
   fixnum: ^1.1.1
   grpc: ^5.1.0
   http: ^1.5.0

--- a/test/unit/context/context_propagator_test.dart
+++ b/test/unit/context/context_propagator_test.dart
@@ -110,7 +110,7 @@ void main() {
 
     test('composite propagator combines multiple propagators', () {
       final context = Context.root;
-      final propagator = CompositePropagator([
+      final propagator = OTelAPI.compositePropagator([
         TestPropagator(),
         TestPropagator(),
       ]);
@@ -126,7 +126,7 @@ void main() {
     });
 
     test('returns all fields from propagators', () {
-      final propagator = CompositePropagator([
+      final propagator = OTelAPI.compositePropagator([
         TestPropagator(),
         TestPropagator(),
       ]);

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
@@ -4,7 +4,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'
+    hide Server;
 import 'package:dartastic_opentelemetry/proto/collector/logs/v1/logs_service.pbgrpc.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';

--- a/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
@@ -3,7 +3,8 @@
 
 import 'dart:async';
 
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'
+    hide Server;
 import 'package:dartastic_opentelemetry/proto/collector/metrics/v1/metrics_service.pbgrpc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
@@ -4,7 +4,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'
+    hide Server;
 import 'package:dartastic_opentelemetry/proto/collector/trace/v1/trace_service.pbgrpc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:test/test.dart';

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
@@ -3,7 +3,8 @@
 
 import 'dart:async';
 
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'
+    hide Server;
 import 'package:dartastic_opentelemetry/proto/collector/trace/v1/trace_service.pbgrpc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Adopts the API's 1.0.0-beta.10 release — the Weaver-generated semantic conventions (MindfulSoftwareLLC/dartastic_opentelemetry_api#52) plus the spec-compliance wave.

**Changes:**
- API dependency `^1.0.0-beta.10`; the SDK barrel now transitively re-exports the registry-generated enums (90 namespaces, entities, metrics, events), `NonRecordingSpan`, and the global `TextMapPropagator`.
- Rename migration in examples/tests: `Database`→`Db`, `ServerResource`→`Server`, `SourceCode`→`Code`, `Http.requestMethod`/`responseStatusCode`/`responseBodySize` → `http*`-prefixed members.
- OTLP gRPC tests `hide Server` from the SDK barrel import (the new semconv `Server` enum collides with `package:grpc`'s `Server`).
- `CompositePropagator` construction goes through `OTelAPI.compositePropagator` (constructor is factory-only as of beta.10).
- Database examples modernized off registry-deprecated keys: `db.system.name`, `db.namespace`, `db.operation.name`, `db.query.text`; deprecated `db.user` dropped.

**Notes:**
- `lib/` needed zero code changes — the SDK core was already clean against beta.10; SDK span creation is unaffected by the API's new no-SDK behavior (gated on `isAPIFactory`).
- Follow-up (separate PR): set the global `TextMapPropagator` to the SDK's W3C composite in `OTel.initialize()` and honor `OTEL_PROPAGATORS` (MindfulSoftwareLLC/dartastic_opentelemetry_api#42 SDK side).

**Verification:** `dart analyze` zero issues (errors *and* warnings), `dart format` clean, full suite 1,850 tests green (with the local `otelcol` binary present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)