### PR TITLE
feat: OTEL_PROPAGATORS — initialize() installs the global TextMapPropagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.8-wip]
 
+### Added
+- **`OTEL_PROPAGATORS` support and global propagator wiring.**
+  `OTel.initialize()` now installs the API's global `TextMapPropagator`
+  per the spec ("Global Propagators"): the default is the W3C
+  `tracecontext,baggage` composite; `none` (or no supported values)
+  leaves the API's spec-mandated no-op in place; unsupported names emit
+  an `OTelLog.warn` and are ignored. Supported values: `tracecontext`,
+  `baggage`, `none`. Instrumentation libraries can now obtain "the"
+  propagator via `OTelAPI.textMapPropagator` instead of being handed one
+  explicitly.
+
 ### Changed
 - **Depends on `dartastic_opentelemetry_api` 1.0.0-beta.10** and re-exports
   its surface: the Weaver-generated semantic-convention enums (90 registry

--- a/README.md
+++ b/README.md
@@ -973,6 +973,7 @@ Constants are defined for all 74 OpenTelemetry environment variables. See `lib/s
 | `otelResourceAttributes`   | `OTEL_RESOURCE_ATTRIBUTES`  | Additional resource attributes    | `environment=prod,region=us-west`       |
 | `otelLogLevel`             | `OTEL_LOG_LEVEL`            | SDK internal log level            | `INFO`, `DEBUG`, `WARN`, `ERROR`        |
 | `otelSdkDisabled`          | `OTEL_SDK_DISABLED`         | Global off-switch — when `true`, the SDK installs no span processors, metric readers, or log record processors (true no-op across all three signals, including explicit overrides) | `true` |
+| `otelPropagators`                     | `OTEL_PROPAGATORS`                      | Global propagators: `tracecontext`, `baggage`, `none` (comma-separated) | `tracecontext,baggage` |
 
 #### OTLP Exporter Configuration
 

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -395,6 +395,22 @@ class OTelEnv {
   /// - 'exportTimeout': Duration for the export timeout
   /// - 'maxQueueSize': int for maximum queue size
   /// - 'maxExportBatchSize': int for maximum export batch size
+  /// Reads `OTEL_PROPAGATORS` (sdk-environment-variables.md, "General SDK
+  /// Configuration"): a comma-separated list of propagator names. Returns
+  /// the normalized (trimmed, lowercased) names, defaulting to the spec
+  /// default `[tracecontext, baggage]` when unset or empty.
+  static List<String> getPropagators() {
+    final raw = _getEnv(otelPropagators);
+    if (raw == null || raw.trim().isEmpty) {
+      return const ['tracecontext', 'baggage'];
+    }
+    return raw
+        .split(',')
+        .map((name) => name.trim().toLowerCase())
+        .where((name) => name.isNotEmpty)
+        .toList();
+  }
+
   static Map<String, dynamic> getBlrpConfig() {
     final config = <String, dynamic>{};
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -282,6 +282,10 @@ class OTel {
       _otelFactory = createdFactory;
     }
 
+    // context/api-propagators.md, "Global Propagators": the SDK configures
+    // the API's global propagator at initialization, per OTEL_PROPAGATORS.
+    _installGlobalPropagator();
+
     if (OTelLog.isDebug()) {
       OTelLog.debug(
         'OTel initialized with endpoint: $endpoint, service: $serviceName',
@@ -1355,6 +1359,45 @@ class OTel {
   ///
   /// This can be called separately from initialize(), but initialize() will
   /// call it automatically if not already done.
+
+  /// Installs the global [TextMapPropagator] per `OTEL_PROPAGATORS`
+  /// (default `tracecontext,baggage`). Unsupported names emit an
+  /// [OTelLog.warn] and are ignored; `none` — or a list with no supported
+  /// names — leaves the API's spec-mandated no-op propagator in place.
+  /// Supported: `tracecontext`, `baggage`, `none`.
+  static void _installGlobalPropagator() {
+    final names = OTelEnv.getPropagators();
+    if (names.contains('none')) {
+      if (names.length > 1 && OTelLog.isWarn()) {
+        OTelLog.warn('OTEL_PROPAGATORS contains "none" alongside other '
+            'values; using no propagator per spec.');
+      }
+      return; // The API default is the no-op propagator.
+    }
+    final propagators = <TextMapPropagator<Map<String, String>, String>>[];
+    final seen = <String>{};
+    for (final name in names) {
+      if (!seen.add(name)) continue;
+      switch (name) {
+        case 'tracecontext':
+          propagators.add(W3CTraceContextPropagator());
+        case 'baggage':
+          propagators.add(W3CBaggagePropagator());
+        default:
+          if (OTelLog.isWarn()) {
+            OTelLog.warn('OTEL_PROPAGATORS: unsupported propagator '
+                '"$name" ignored. Supported: tracecontext, baggage, none.');
+          }
+      }
+    }
+    if (propagators.isEmpty) {
+      return; // Nothing supported was requested; keep the no-op default.
+    }
+    OTelAPI.textMapPropagator = propagators.length == 1
+        ? propagators.single
+        : OTelAPI.compositePropagator<Map<String, String>, String>(propagators);
+  }
+
   static void initializeLogging() {
     // Initialize log settings from environment variables
     OTelEnv.initializeLogging();

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -802,6 +802,67 @@ void main() {
   // =========================================================================
   // OTel - print interception methods
   // =========================================================================
+
+  // ==========================================================================
+  // OTEL_PROPAGATORS - subprocess tests for the global propagator install
+  // (context/api-propagators.md, "Global Propagators": the SDK configures
+  // the API's global propagator; the API default is no-op.)
+  // ==========================================================================
+  group('OTEL_PROPAGATORS (subprocess)', () {
+    const helper = 'test/unit/environment/helpers/check_propagators.dart';
+
+    test('default installs tracecontext + baggage composite', () async {
+      final output = await runWithEnv(helper, {});
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['type'], contains('CompositePropagator'));
+      expect(
+          result['fields'], equals(['baggage', 'traceparent', 'tracestate']));
+      expect(result['logs'], isEmpty);
+    });
+
+    test('tracecontext alone installs the W3C trace context propagator',
+        () async {
+      final output =
+          await runWithEnv(helper, {'OTEL_PROPAGATORS': 'tracecontext'});
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['type'], contains('W3CTraceContextPropagator'));
+      expect(result['fields'], equals(['traceparent', 'tracestate']));
+    });
+
+    test('baggage alone installs the W3C baggage propagator', () async {
+      final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'baggage'});
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['type'], contains('W3CBaggagePropagator'));
+      expect(result['fields'], equals(['baggage']));
+    });
+
+    test('none leaves the spec-mandated no-op propagator', () async {
+      final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'none'});
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['type'], contains('NoopTextMapPropagator'));
+      expect(result['fields'], isEmpty);
+    });
+
+    test('unsupported names warn and are ignored', () async {
+      final output = await runWithEnv(
+          helper, {'OTEL_PROPAGATORS': 'tracecontext,b3,xray'});
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['type'], contains('W3CTraceContextPropagator'));
+      final logs = result['logs'] as List<dynamic>;
+      expect(logs.length, equals(2));
+      expect(logs[0].toString(), contains('"b3" ignored'));
+      expect(logs[1].toString(), contains('"xray" ignored'));
+    });
+
+    test('only unsupported names keeps the no-op default and warns', () async {
+      final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'jaeger'});
+      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(result['type'], contains('NoopTextMapPropagator'));
+      expect((result['logs'] as List<dynamic>).single.toString(),
+          contains('"jaeger" ignored'));
+    });
+  });
+
   group('OTel print interception', () {
     setUp(() async {
       await OTel.reset();

--- a/test/unit/environment/helpers/check_propagators.dart
+++ b/test/unit/environment/helpers/check_propagators.dart
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Helper script: initializes the SDK and prints JSON describing the
+// global TextMapPropagator that OTel.initialize() installed per
+// OTEL_PROPAGATORS. Run via subprocess with env vars set.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+Future<void> main() async {
+  final warnings = <String>[];
+  OTelLog.logFunction = warnings.add;
+  OTelLog.currentLevel = LogLevel.warn;
+
+  await OTel.initialize(
+    serviceName: 'propagator-check',
+    serviceVersion: '1.0.0',
+  );
+
+  final propagator = OTelAPI.textMapPropagator;
+  OTelLog.logFunction = null;
+  print(jsonEncode({
+    'type': propagator.runtimeType.toString(),
+    'fields': [...propagator.fields()]..sort(),
+    'logs':
+        warnings.where((line) => line.contains('OTEL_PROPAGATORS')).toList(),
+  }));
+
+  // Force-exit to avoid waiting on background batch/metric timers — we
+  // only want the installed-propagator snapshot.
+  exit(0);
+}


### PR DESCRIPTION
The SDK side of MindfulSoftwareLLC/dartastic_opentelemetry_api#42, completing the Global Propagators spec story started in dartastic_opentelemetry_api#55:

- **"The OpenTelemetry API MUST use no-op propagators unless explicitly configured otherwise"** — the API ships the no-op default; **this PR is the "explicitly configured" half**: `OTel.initialize()` installs the global per `OTEL_PROPAGATORS`.
- Default `tracecontext,baggage` → W3C composite via `OTelAPI.compositePropagator`; single names install the propagator directly; `none` (or a list with no supported names) leaves the no-op; unsupported names (`b3`, `jaeger`, …) emit `OTelLog.warn` and are ignored — graceful per common.md error handling.
- New `OTelEnv.getPropagators()` (normalized, spec default on unset/empty). The `OTEL_PROPAGATORS` constant and dart-define plumbing already existed — nothing consumed it until now.
- Tests follow the repo's subprocess pattern: `check_propagators.dart` helper + six contracts in `env_coverage_test.dart` (default composite fields, single-propagator installs, `none`, unknown-name warnings). README env-table row + CHANGELOG under `1.1.0-beta.8-wip`.

Verification: `dart analyze` clean, `./tool/test.sh` full suite green, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)