### PR TITLE
test: deterministic retry-count asserts (kills the 503-retry flake)

### DIFF
--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
@@ -99,11 +99,11 @@ void main() {
       final exporter = createExporter(maxRetries: 2);
       final spans = createTestSpans();
 
-      // Should throw after exhausting all retries
-      expect(() => exporter.export(spans), throwsA(anything));
-
-      // Allow async operations to settle
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      // Should throw after exhausting all retries. Awaiting the export
+      // future (instead of sleeping a fixed settle window) makes the
+      // attempt-count assertion deterministic: the future only completes
+      // after every retry has run, however slow the runner.
+      await expectLater(exporter.export(spans), throwsA(anything));
       expect(requestCount, equals(3));
       await exporter.shutdown();
     });
@@ -114,9 +114,7 @@ void main() {
       final spans = createTestSpans();
 
       // 400 is not retryable - should throw after single attempt
-      expect(() => exporter.export(spans), throwsA(anything));
-
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await expectLater(exporter.export(spans), throwsA(anything));
       expect(requestCount, equals(1));
       await exporter.shutdown();
     });
@@ -126,9 +124,7 @@ void main() {
       final exporter = createExporter();
       final spans = createTestSpans();
 
-      expect(() => exporter.export(spans), throwsA(anything));
-
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await expectLater(exporter.export(spans), throwsA(anything));
       expect(requestCount, equals(1));
       await exporter.shutdown();
     });


### PR DESCRIPTION
The `otlp_http_span_exporter_retry_test.dart` "gives up after max retries on 503" test failed three times today across three branches and both Dart channels (#75 stable, #76 stable, #68 beta), each time passing on rerun — it fires `export()` unawaited, sleeps a fixed 100 ms, then asserts `requestCount == 3`, so any runner slow enough to push the third backoff attempt past the window fails it.

Fix: `await expectLater(exporter.export(spans), throwsA(anything))` — the future only completes after every retry has run, making the count deterministic with zero timing dependence. Same treatment for the 400/404 single-attempt tests. The shutdown-mid-retry test keeps its delay (it's intentionally shutting down between attempts).

Verified: the file passes 5/5 consecutive local runs; analyze and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)