### PR TITLE
test: pin the Zipkin exporter gap (#80 — up for grabs)

### DIFF
--- a/test/unit/trace/export/zipkin/zipkin_exporter_gap_test.dart
+++ b/test/unit/trace/export/zipkin/zipkin_exporter_gap_test.dart
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:test/test.dart';
+
+// Spec-compliance gap for sdk-environment-variables.md, "Exporter
+// Selection" and trace/sdk_exporters/zipkin.md:
+//
+// - "Known values for OTEL_TRACES_EXPORTER are: ... 'zipkin': Zipkin"
+// - zipkin.md fully specifies the span mapping (hex ids, kind table,
+//   microsecond timestamps, localEndpoint.serviceName, events ->
+//   annotations, attributes -> string tags, otel.status_code/error tags,
+//   remoteEndpoint precedence).
+//
+// The OTEL_EXPORTER_ZIPKIN_ENDPOINT / OTEL_EXPORTER_ZIPKIN_TIMEOUT
+// constants exist (env_constants.dart) but nothing consumes them, and
+// OTEL_TRACES_EXPORTER=zipkin is warned-and-ignored.
+void main() {
+  test('the SDK provides a Zipkin span exporter',
+      skip: 'Not implemented — see #80 (up for grabs, targeted '
+          '1.1.0-beta.11)', () {
+    fail('No ZipkinSpanExporter or ZipkinSpanTransformer exists; '
+        'OTEL_TRACES_EXPORTER=zipkin is ignored with a warning and the '
+        'OTEL_EXPORTER_ZIPKIN_* env vars are unconsumed.');
+  });
+}


### PR DESCRIPTION
Pins the missing-Zipkin-exporter gap in the house TDD style (same shape as #41/#43): one spec-quoting contract, skipped behind #80 so CI stays green until the implementation lands.

**#80 has the full scope, mapping references, and acceptance criteria — comment there to claim it.** The seams are ready: the `OTEL_EXPORTER_ZIPKIN_*` constants already exist, and after #79 the `OTEL_TRACES_EXPORTER` switch has an exact spot where `'zipkin'` currently warns-and-ignores.

Targeted 1.1.0-beta.11. Whoever takes it up: replace this placeholder with the real contracts as you go — transformer mapping tests, a `spec_defaults_test.dart` pipeline contract, and an HTTP capture test (use `await expectLater`, no fixed sleeps — see #77 for why).

🤖 Generated with [Claude Code](https://claude.com/claude-code)