### PR TITLE
feat: adopt api 1.0.0-rc.1; self-hosted coverage badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the coverage badge to the badges branch
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       
@@ -55,11 +59,23 @@ jobs:
           </html>
           EOF
       
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          file: coverage/lcov.info
-          fail_ci_if_error: false
+      - name: Build coverage badge
+        run: python3 tool/make_coverage_badge.py coverage/lcov.info coverage-badge.svg
+
+      - name: Publish coverage badge
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git clone --depth 1 --branch badges "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" /tmp/badges
+          cp coverage-badge.svg /tmp/badges/coverage.svg
+          cd /tmp/badges
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "Update coverage badge"
+            git push
+          fi
       
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.9-wip]
 
+### Changed
+- Adopt `dartastic_opentelemetry_api` 1.0.0-rc.1 (constraint
+  `^1.0.0-rc.1`). No SDK code changes were needed: the SDK never used
+  the removed vendor/RUM enums, and it implements the now-abstract
+  `APIObservableResult` interface.
+- CI: self-hosted coverage badge built from lcov.info and published to
+  the `badges` branch; Codecov upload removed (uploads had failed since
+  branch protection was enabled). The README coverage badge is now live
+  data instead of a hardcoded percentage.
+
 ## [1.1.0-beta.8] - 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenTelemetry Specification](https://img.shields.io/badge/OpenTelemetry-Specification-blueviolet)](https://opentelemetry.io/docs/specs/otel/)
-[![Coverage](https://img.shields.io/badge/coverage-90%25-brightgreen.svg)](https://dartastic.github.io/dartastic_opentelemetry/)
+[![Coverage](https://raw.githubusercontent.com/MindfulSoftwareLLC/dartastic_opentelemetry/badges/coverage.svg)](https://mindfulsoftwarellc.github.io/dartastic_opentelemetry/)
 
 Dartastic is an [OpenTelemetry](https://opentelemetry.io/) SDK to add standard observability to Dart applications.
 Dartastic can be used with any OTel backend since it's standards-compliant.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  dartastic_opentelemetry_api: ^1.0.0-beta.10
+  dartastic_opentelemetry_api: ^1.0.0-rc.1
   fixnum: ^1.1.1
   grpc: ^5.1.0
   http: ^1.5.0

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -3,6 +3,9 @@
 
 set -e  # Exit on any error
 
+# Always operate from the repo root, wherever the script is invoked from.
+cd "$(dirname "$0")/.." || exit 1
+
 # Parse command line arguments
 # Need trace logging for coverage of debug and trace logs
 LOG_LEVEL="trace"

--- a/tool/make_coverage_badge.py
+++ b/tool/make_coverage_badge.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Generate a shields-style coverage badge SVG from an lcov tracefile.
+
+Usage: make_coverage_badge.py <lcov.info> <out.svg>
+
+Self-hosted replacement for the codecov badge: CI runs this against
+coverage/lcov.info and publishes the SVG to the `badges` branch, which
+the README references via raw.githubusercontent.com.
+"""
+
+import sys
+
+
+def line_rate(lcov_path):
+    total = hit = 0
+    with open(lcov_path) as f:
+        for line in f:
+            if line.startswith('DA:'):
+                total += 1
+                if int(line.strip().split(',')[1]) > 0:
+                    hit += 1
+    if total == 0:
+        raise SystemExit(f'no DA records found in {lcov_path}')
+    return 100.0 * hit / total
+
+
+def color_for(pct):
+    if pct >= 96:
+        return '#4c1'  # brightgreen
+    if pct >= 90:
+        return '#97ca00'  # green
+    if pct >= 75:
+        return '#dfb317'  # yellow
+    return '#e05d44'  # red
+
+
+def badge(label, value, color):
+    # Shields "flat" look: 6.5px per character plus 10px padding per side.
+    lw = round(len(label) * 6.5) + 20
+    vw = round(len(value) * 6.5) + 20
+    w = lw + vw
+    lx = lw * 5  # text coordinates are in 10x scale units
+    vx = lw * 10 + vw * 5
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="20" role="img" aria-label="{label}: {value}">
+  <title>{label}: {value}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="{w}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{lw}" height="20" fill="#555"/>
+    <rect x="{lw}" width="{vw}" height="20" fill="{color}"/>
+    <rect width="{w}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="{lx}" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3">{label}</text>
+    <text x="{lx}" y="140" transform="scale(.1)">{label}</text>
+    <text x="{vx}" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3">{value}</text>
+    <text x="{vx}" y="140" transform="scale(.1)">{value}</text>
+  </g>
+</svg>
+'''
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__)
+    pct = line_rate(sys.argv[1])
+    value = f'{pct:.1f}%'.replace('.0%', '%')
+    with open(sys.argv[2], 'w') as f:
+        f.write(badge('coverage', value, color_for(pct)))
+    print(f'coverage {value} -> {sys.argv[2]}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

1. **Adopt `dartastic_opentelemetry_api` 1.0.0-rc.1** (`^1.0.0-rc.1`). This also defuses a live resolver hazard: the old `^1.0.0-beta.10` constraint already resolves rc.1 on any fresh `pub get`, so main was one `pub get` away from an unpinned API bump. No SDK code changes were needed — the SDK never used the removed vendor/RUM enums, and its `ObservableResult` implements the now-abstract `APIObservableResult`.
2. **Self-hosted coverage badge**, mirroring the API repo: the coverage workflow builds a shields-style SVG from `lcov.info` via `tool/make_coverage_badge.py` and publishes it to the `badges` branch using only the built-in `GITHUB_TOKEN`; the Codecov upload is removed (Codecov has rejected every main upload since branch protection was enabled). The README's **hardcoded** "coverage 90%" badge is replaced with the live one, seeded at the honest current 88.1%. The GitHub Pages coverage-report deploy is unchanged.
3. **`tool/coverage.sh` anchors at the repo root**, so `rm -rf coverage` and friends behave identically wherever the script is invoked from.

## Verification

- `dart analyze --fatal-infos` clean
- `./tool/test.sh` against rc.1: 1873 passed, 13 skipped
- Badge pipeline already proven end to end on the API repo; `badges` branch seeded and serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)