### PR TITLE
feat: public MetricTransformer.transformMetrics one-shot; exporters use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.10-wip]
 
+### Added
+- **Public `MetricTransformer.transformMetrics` one-shot** — the metrics
+  analogue of `OtlpLogRecordTransformer.transformLogRecords`: converts a
+  whole `MetricData` batch to a ready-to-serialize OTLP
+  `ExportMetricsServiceRequest` (`transformMetrics(data).writeToBuffer()`),
+  so alternative exporters and sinks can reuse the transform instead of
+  re-implementing the per-metric mapping. Both bundled OTLP metric
+  exporters (HTTP and gRPC) now build their requests through it, removing
+  two hand-rolled copies of the same assembly; wire output is unchanged
+  (same instrumentation-scope constant, same `OTel.resource(null)`
+  fallback, resolved by the caller so the transformer stays a pure leaf).
+
 ## [1.1.0-beta.9] - 2026-07-18
 
 ### Changed

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
@@ -9,9 +9,6 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 
 import '../../../../../dartastic_opentelemetry.dart';
-import '../../../../../proto/collector/metrics/v1/metrics_service.pb.dart';
-import '../../../../../proto/common/v1/common.pb.dart' as common_pb;
-import '../../../../../proto/metrics/v1/metrics.pb.dart' as metrics_pb;
 import '../../../../export/otlp_json.dart';
 import '../../../../trace/export/otlp/http/http_client_factory.dart';
 import '../../../../util/zip/gzip.dart';
@@ -254,41 +251,13 @@ class OtlpHttpMetricExporter implements MetricExporter {
       OTelLog.debug('OtlpHttpMetricExporter: Transforming metrics');
     }
 
-    // Create the export request
-    final request = ExportMetricsServiceRequest();
-    final resourceMetrics = metrics_pb.ResourceMetrics();
-
-    // Add resource
-    if (metrics.resource != null) {
-      resourceMetrics.resource = MetricTransformer.transformResource(
-        metrics.resource!,
-      );
-    } else {
-      resourceMetrics.resource = MetricTransformer.transformResource(
-        OTel.resource(null),
-      );
-    }
-
-    // Create scope metrics
-    final scopeMetrics = metrics_pb.ScopeMetrics();
-
-    // Add instrumentation scope - create a new InstrumentationScope
-    // rather than mutating the frozen default returned by scopeMetrics.scope
-    scopeMetrics.scope = common_pb.InstrumentationScope(
-      name: '@dart/dartastic_opentelemetry',
-      version: '1.0.0',
+    // Create the export request — the shared one-shot builds the same
+    // request this exporter used to assemble inline (same scope constant,
+    // same OTel.resource(null) fallback), so the wire output is unchanged.
+    final request = MetricTransformer.transformMetrics(
+      metrics,
+      fallbackResource: OTel.resource(null),
     );
-
-    // Add metrics to scope
-    for (final metric in metrics.metrics) {
-      scopeMetrics.metrics.add(MetricTransformer.transformMetric(metric));
-    }
-
-    // Add scope metrics to resource metrics
-    resourceMetrics.scopeMetrics.add(scopeMetrics);
-
-    // Add resource metrics to request
-    request.resourceMetrics.add(resourceMetrics);
 
     if (OTelLog.isDebug()) {
       OTelLog.debug('OtlpHttpMetricExporter: Successfully transformed metrics');

--- a/lib/src/metrics/export/otlp/metric_transformer.dart
+++ b/lib/src/metrics/export/otlp/metric_transformer.dart
@@ -5,15 +5,57 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;
 import 'package:fixnum/fixnum.dart';
 
+import '../../../../proto/collector/metrics/v1/metrics_service.pb.dart';
 import '../../../../proto/common/v1/common.pb.dart' as common_proto;
 import '../../../../proto/metrics/v1/metrics.pb.dart' as proto;
 import '../../../../proto/resource/v1/resource.pb.dart' as resource_proto;
 import '../../../resource/resource.dart';
 import '../../data/metric.dart';
+import '../../data/metric_data.dart';
 import '../../data/metric_point.dart';
 
 /// Utility class for transforming metric data to OTLP protobuf format.
 class MetricTransformer {
+  /// Convert a whole [MetricData] batch to an OTLP
+  /// [ExportMetricsServiceRequest] — the metrics analogue of
+  /// `OtlpLogRecordTransformer.transformLogRecords`.
+  ///
+  /// This is exactly the request the OTLP metric exporters build before
+  /// they send, factored out so alternative exporters and sinks can reuse
+  /// the transform instead of re-implementing the per-metric mapping.
+  /// Callers get wire bytes via `transformMetrics(data).writeToBuffer()`.
+  ///
+  /// When [MetricData.resource] is null the caller-supplied
+  /// [fallbackResource] is used (the bundled exporters pass
+  /// `OTel.resource(null)`); if that is also null an empty resource proto
+  /// is emitted. The fallback is resolved by the caller so this
+  /// transformer stays a pure leaf (no dependency on `OTel`).
+  static ExportMetricsServiceRequest transformMetrics(
+    MetricData data, {
+    Resource? fallbackResource,
+  }) {
+    final request = ExportMetricsServiceRequest();
+    final resourceMetrics = proto.ResourceMetrics();
+
+    final effectiveResource = data.resource ?? fallbackResource;
+    resourceMetrics.resource = effectiveResource != null
+        ? transformResource(effectiveResource)
+        : resource_proto.Resource();
+
+    final scopeMetrics = proto.ScopeMetrics();
+    scopeMetrics.scope = common_proto.InstrumentationScope(
+      name: '@dart/dartastic_opentelemetry',
+      version: '1.0.0',
+    );
+    for (final metric in data.metrics) {
+      scopeMetrics.metrics.add(transformMetric(metric));
+    }
+
+    resourceMetrics.scopeMetrics.add(scopeMetrics);
+    request.resourceMetrics.add(resourceMetrics);
+    return request;
+  }
+
   /// Transforms a Resource to an OTLP Resource proto.
   static resource_proto.Resource transformResource(Resource resource) {
     final resourceProto = resource_proto.Resource();

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
@@ -7,8 +7,6 @@ import 'package:grpc/grpc.dart';
 
 import '../../../../dartastic_opentelemetry.dart';
 import '../../../../proto/collector/metrics/v1/metrics_service.pbgrpc.dart';
-import '../../../../proto/common/v1/common.pb.dart' as common_proto;
-import '../../../../proto/metrics/v1/metrics.pb.dart' as proto;
 import '../../../trace/export/otlp/certificate_utils_io.dart';
 import 'metric_transformer.dart';
 
@@ -164,40 +162,15 @@ class OtlpGrpcMetricExporter implements MetricExporter {
     }
   }
 
-  /// Builds the export request from the given metrics data.
-  ExportMetricsServiceRequest _buildExportRequest(MetricData data) {
-    final request = ExportMetricsServiceRequest();
-    final resourceMetrics = proto.ResourceMetrics();
-
-    // Add resource
-    if (data.resource != null) {
-      resourceMetrics.resource = MetricTransformer.transformResource(
-        data.resource!,
+  /// Builds the export request from the given metrics data — via the
+  /// shared one-shot, which builds the same request this exporter used to
+  /// assemble inline (same scope constant, same OTel.resource(null)
+  /// fallback), so the wire output is unchanged.
+  ExportMetricsServiceRequest _buildExportRequest(MetricData data) =>
+      MetricTransformer.transformMetrics(
+        data,
+        fallbackResource: OTel.resource(null),
       );
-    } else {
-      // Create empty resource if none provided
-      resourceMetrics.resource = MetricTransformer.transformResource(
-        OTel.resource(null),
-      );
-    }
-
-    // Add scope metrics
-    final scopeMetrics = proto.ScopeMetrics();
-    scopeMetrics.metrics.addAll(
-      data.metrics.map(MetricTransformer.transformMetric),
-    );
-
-    // Add instrumentation scope (hardcoded for now)
-    final scope = common_proto.InstrumentationScope();
-    scope.name = '@dart/dartastic_opentelemetry';
-    scope.version = '1.0.0';
-    scopeMetrics.scope = scope;
-
-    resourceMetrics.scopeMetrics.add(scopeMetrics);
-    request.resourceMetrics.add(resourceMetrics);
-
-    return request;
-  }
 
   @override
   Future<bool> forceFlush() async {

--- a/test/unit/metrics/export/otlp/metric_transformer_test.dart
+++ b/test/unit/metrics/export/otlp/metric_transformer_test.dart
@@ -270,5 +270,106 @@ void main() {
       expect(attributeMap['int_key']!.intValue, equals(Int64(42)));
       expect(attributeMap['double_key']!.doubleValue, equals(3.14));
     });
+
+    group('transformMetrics one-shot', () {
+      Metric gauge(String name, double value) {
+        final now = DateTime.now();
+        return Metric(
+          name: name,
+          description: 'gauge $name',
+          unit: 'items',
+          type: MetricType.gauge,
+          points: [
+            MetricPoint.gauge(
+              attributes: {'dimension': 'value'}.toAttributes(),
+              startTime: now.subtract(const Duration(minutes: 5)),
+              time: now,
+              value: value,
+            ),
+          ],
+        );
+      }
+
+      test('builds a full request: resource, scope, all metrics', () {
+        final resource = OTel.resource(
+          Attributes.of({'service.name': 'one-shot-service'}),
+        );
+        final data = MetricData(
+          resource: resource,
+          metrics: [gauge('m.one', 1.0), gauge('m.two', 2.0)],
+        );
+
+        final request = MetricTransformer.transformMetrics(data);
+
+        expect(request.resourceMetrics.length, equals(1));
+        final rm = request.resourceMetrics.first;
+        final attributeMap = Map.fromEntries(
+          rm.resource.attributes.map((kv) => MapEntry(kv.key, kv.value)),
+        );
+        expect(
+          attributeMap['service.name']!.stringValue,
+          equals('one-shot-service'),
+        );
+        expect(rm.scopeMetrics.length, equals(1));
+        final sm = rm.scopeMetrics.first;
+        // Same scope constant the OTLP exporters have always stamped.
+        expect(sm.scope.name, equals('@dart/dartastic_opentelemetry'));
+        expect(sm.scope.version, equals('1.0.0'));
+        expect(sm.metrics.length, equals(2));
+        expect(sm.metrics.first.name, equals('m.one'));
+        expect(sm.metrics.last.name, equals('m.two'));
+        // The one-shot's output is directly serializable — the byte
+        // contract alternative sinks rely on.
+        expect(request.writeToBuffer(), isNotEmpty);
+      });
+
+      test('null MetricData.resource uses the caller fallback', () {
+        final fallback = OTel.resource(
+          Attributes.of({'service.name': 'fallback-service'}),
+        );
+        final data = MetricData(metrics: [gauge('m.fallback', 3.0)]);
+
+        final request = MetricTransformer.transformMetrics(
+          data,
+          fallbackResource: fallback,
+        );
+
+        final attributeMap = Map.fromEntries(
+          request.resourceMetrics.first.resource.attributes
+              .map((kv) => MapEntry(kv.key, kv.value)),
+        );
+        expect(
+          attributeMap['service.name']!.stringValue,
+          equals('fallback-service'),
+        );
+      });
+
+      test('null resource and null fallback emit an empty resource', () {
+        final data = MetricData(metrics: [gauge('m.bare', 4.0)]);
+
+        final request = MetricTransformer.transformMetrics(data);
+
+        expect(request.resourceMetrics.first.resource.attributes, isEmpty);
+        expect(
+          request.resourceMetrics.first.scopeMetrics.first.metrics.length,
+          equals(1),
+        );
+      });
+
+      test('empty metrics still produce the resource/scope envelope', () {
+        final data = MetricData(
+          resource: OTel.resource(Attributes.of({'service.name': 's'})),
+          metrics: const [],
+        );
+
+        final request = MetricTransformer.transformMetrics(data);
+
+        expect(request.resourceMetrics.length, equals(1));
+        expect(
+          request.resourceMetrics.first.scopeMetrics.first.metrics,
+          isEmpty,
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
Adds the metrics analogue of `OtlpLogRecordTransformer.transformLogRecords`: a public static one-shot that converts a whole `MetricData` batch into a ready-to-serialize OTLP `ExportMetricsServiceRequest` — `transformMetrics(data).writeToBuffer()` — so alternative exporters and sinks can reuse the transform instead of re-implementing the per-metric mapping.

## Why

The log side already has this shape: both bundled OTLP log exporters call the public `transformLogRecords` one-shot. The metric side instead carried two hand-rolled copies of the same request assembly (inline in the HTTP exporter, `_buildExportRequest` in the gRPC exporter), and there was no public way to obtain the exact OTLP request bytes for a `MetricData` batch. Symmetry across the three signals, one less duplicated block, and a public byte contract for alternative sinks.

## What

- `MetricTransformer.transformMetrics(MetricData, {Resource? fallbackResource})` — groups the batch under the same instrumentation-scope constant the exporters have always stamped (`@dart/dartastic_opentelemetry` v1.0.0). When `MetricData.resource` is null the caller-supplied `fallbackResource` is used (the bundled exporters pass `OTel.resource(null)`); if that is also null an empty resource proto is emitted. The fallback is resolved by the caller so the transformer stays a pure leaf with no dependency on `OTel`.
- Both OTLP metric exporters (HTTP + gRPC) now build their requests through the one-shot. **Wire output is unchanged** — same scope constant, same fallback semantics, verified by the existing exporter suites.

## Tests

Four new `transformMetrics` cases (full envelope with resource/scope/all metrics, fallback-resource path, null-resource → empty resource proto, empty batch keeps the envelope). Full metrics unit suite: 409/409 passing; analyze clean.

## Notes

- No version bump — main is `1.1.0-beta.10-wip`; CHANGELOG entry added under that heading.
- No behavior change for existing users; purely additive public API plus internal dedup.
