### PR TITLE
fix: OTLP/JSON enum fields encode as integers per spec, not proto3 names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.10-wip]
 
+### Fixed
+- **OTLP/JSON enum fields are now encoded as integers per the OTLP spec**,
+  not proto3-JSON's default enum names: span `kind`, status `code`, log
+  `severityNumber`, metric `aggregationTemporality`. Same origin story as
+  the 1.1.0-beta.7 hex-id fix — `toProto3Json()`'s defaults deviate from
+  the OTLP spec, lenient receivers masked it, and a strict
+  cross-implementation check (the Dartastic engine wire-parity harness)
+  caught it. Conversion is field-keyed and prefix-guarded, so attribute
+  string values that merely resemble enum names are never touched.
+
 ### Added
 - **Public `MetricTransformer.transformMetrics` one-shot** — the metrics
   analogue of `OtlpLogRecordTransformer.transformLogRecords`: converts a

--- a/lib/src/export/otlp_json.dart
+++ b/lib/src/export/otlp_json.dart
@@ -9,7 +9,8 @@ import 'package:protobuf/protobuf.dart';
 
 import '../../proto/logs/v1/logs.pb.dart' show SeverityNumber;
 import '../../proto/metrics/v1/metrics.pb.dart' show AggregationTemporality;
-import '../../proto/trace/v1/trace.pb.dart' show Span_SpanKind, Status_StatusCode;
+import '../../proto/trace/v1/trace.pb.dart'
+    show Span_SpanKind, Status_StatusCode;
 
 /// OTLP/JSON encoding of an OTLP request message.
 ///

--- a/lib/src/export/otlp_json.dart
+++ b/lib/src/export/otlp_json.dart
@@ -7,6 +7,10 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show IdGenerator;
 import 'package:protobuf/protobuf.dart';
 
+import '../../proto/logs/v1/logs.pb.dart' show SeverityNumber;
+import '../../proto/metrics/v1/metrics.pb.dart' show AggregationTemporality;
+import '../../proto/trace/v1/trace.pb.dart' show Span_SpanKind, Status_StatusCode;
+
 /// OTLP/JSON encoding of an OTLP request message.
 ///
 /// OTLP/JSON is proto3-JSON **with explicit deviations** — the one that bites
@@ -21,27 +25,59 @@ import 'package:protobuf/protobuf.dart';
 /// collectors happened to tolerate base64, which is how this survived in the
 /// wild until the first strict endpoint (Dartastic Cloud, 2026-07-10).
 ///
+/// The second deviation, same origin story: the OTLP spec requires enum
+/// fields to be encoded as their **integer** values, while `toProto3Json()`
+/// emits proto3-JSON's default enum **names** (`"SPAN_KIND_SERVER"`).
+/// Lenient receivers accept both; the spec (and the engine wire-parity
+/// harness in dartastic-pro#140, which found this) says integers.
+///
 /// This helper converts the proto3-JSON tree, hex-encoding every ID field
-/// wherever it appears (spans, span links, log records, metric exemplars).
+/// wherever it appears (spans, span links, log records, metric exemplars)
+/// and int-encoding every enum field (span `kind`, status `code`, log
+/// `severityNumber`, metric `aggregationTemporality`).
 Object? otlpProto3JsonWithHexIds(GeneratedMessage request) =>
-    _hexifyIds(request.toProto3Json());
+    _fixupOtlpJson(request.toProto3Json());
 
 const _idKeys = {'traceId', 'spanId', 'parentSpanId'};
 
-Object? _hexifyIds(Object? node) {
+/// Enum fields keyed by their JSON field name, each with its own
+/// name→int table built from the generated protos (drift-proof) and
+/// guarded by the enum's name prefix so an attribute value that merely
+/// resembles an enum name can never be corrupted (attribute values live
+/// under `stringValue` keys, never these).
+final Map<String, Map<String, int>> _enumFields = {
+  'kind': {for (final v in Span_SpanKind.values) v.name: v.value},
+  'code': {for (final v in Status_StatusCode.values) v.name: v.value},
+  'severityNumber': {for (final v in SeverityNumber.values) v.name: v.value},
+  'aggregationTemporality': {
+    for (final v in AggregationTemporality.values) v.name: v.value,
+  },
+};
+
+Object? _fixupOtlpJson(Object? node) {
   if (node is Map) {
     return <String, Object?>{
       for (final entry in node.entries)
-        entry.key as String:
-            _idKeys.contains(entry.key) && entry.value is String
-                ? _base64ToHex(entry.value as String)
-                : _hexifyIds(entry.value),
+        entry.key as String: _fixupValue(entry.key as String, entry.value),
     };
   }
   if (node is List) {
-    return <Object?>[for (final item in node) _hexifyIds(item)];
+    return <Object?>[for (final item in node) _fixupOtlpJson(item)];
   }
   return node;
+}
+
+Object? _fixupValue(String key, Object? value) {
+  if (_idKeys.contains(key) && value is String) {
+    return _base64ToHex(value);
+  }
+  final enumTable = _enumFields[key];
+  if (enumTable != null && value is String) {
+    // Defensive like _base64ToHex: an unknown name passes through
+    // unchanged (never corrupt a payload we don't understand).
+    return enumTable[value] ?? value;
+  }
+  return _fixupOtlpJson(value);
 }
 
 /// Base64 → lowercase hex, via the same codec that formats

--- a/test/unit/otlp_json_hex_ids_test.dart
+++ b/test/unit/otlp_json_hex_ids_test.dart
@@ -150,8 +150,7 @@ void main() {
     expect((s['status'] as Map)['code'], 2);
   });
 
-  test('log severityNumber and metric aggregationTemporality are integers',
-      () {
+  test('log severityNumber and metric aggregationTemporality are integers', () {
     final logs = ExportLogsServiceRequest(resourceLogs: [
       pl.ResourceLogs(scopeLogs: [
         pl.ScopeLogs(logRecords: [

--- a/test/unit/otlp_json_hex_ids_test.dart
+++ b/test/unit/otlp_json_hex_ids_test.dart
@@ -13,6 +13,7 @@
 import 'package:dartastic_opentelemetry/proto/collector/logs/v1/logs_service.pb.dart';
 import 'package:dartastic_opentelemetry/proto/collector/metrics/v1/metrics_service.pb.dart';
 import 'package:dartastic_opentelemetry/proto/collector/trace/v1/trace_service.pb.dart';
+import 'package:dartastic_opentelemetry/proto/common/v1/common.pb.dart' as pc;
 import 'package:dartastic_opentelemetry/proto/logs/v1/logs.pb.dart' as pl;
 import 'package:dartastic_opentelemetry/proto/metrics/v1/metrics.pb.dart' as pm;
 import 'package:dartastic_opentelemetry/proto/trace/v1/trace.pb.dart' as pt;
@@ -120,5 +121,102 @@ void main() {
             .first as Map;
     expect(s['traceId'], IdGenerator.bytesToHex(genTrace));
     expect(s['spanId'], IdGenerator.bytesToHex(genSpan));
+  });
+
+  test('enum fields are integers, never proto3-JSON names', () {
+    final req = ExportTraceServiceRequest(resourceSpans: [
+      pt.ResourceSpans(scopeSpans: [
+        pt.ScopeSpans(spans: [
+          pt.Span(
+            traceId: traceId,
+            spanId: spanId,
+            name: 'GET /forecast',
+            kind: pt.Span_SpanKind.SPAN_KIND_SERVER,
+            status: pt.Status(
+              code: pt.Status_StatusCode.STATUS_CODE_ERROR,
+              message: 'boom',
+            ),
+          ),
+        ]),
+      ]),
+    ]);
+
+    final json = otlpProto3JsonWithHexIds(req) as Map<String, Object?>;
+    final s =
+        (((((json['resourceSpans'] as List).first as Map)['scopeSpans'] as List)
+                .first as Map)['spans'] as List)
+            .first as Map;
+    expect(s['kind'], 2, reason: 'OTLP/JSON requires integer enum values');
+    expect((s['status'] as Map)['code'], 2);
+  });
+
+  test('log severityNumber and metric aggregationTemporality are integers',
+      () {
+    final logs = ExportLogsServiceRequest(resourceLogs: [
+      pl.ResourceLogs(scopeLogs: [
+        pl.ScopeLogs(logRecords: [
+          pl.LogRecord(
+            severityNumber: pl.SeverityNumber.SEVERITY_NUMBER_ERROR,
+            traceId: traceId,
+            spanId: spanId,
+          ),
+        ]),
+      ]),
+    ]);
+    final lj = otlpProto3JsonWithHexIds(logs) as Map<String, Object?>;
+    final lr =
+        (((((lj['resourceLogs'] as List).first as Map)['scopeLogs'] as List)
+                .first as Map)['logRecords'] as List)
+            .first as Map;
+    expect(lr['severityNumber'], 17);
+
+    final metrics = ExportMetricsServiceRequest(resourceMetrics: [
+      pm.ResourceMetrics(scopeMetrics: [
+        pm.ScopeMetrics(metrics: [
+          pm.Metric(
+            name: 'm',
+            sum: pm.Sum(
+              dataPoints: [pm.NumberDataPoint(asDouble: 1.0)],
+              aggregationTemporality:
+                  pm.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA,
+              isMonotonic: true,
+            ),
+          ),
+        ]),
+      ]),
+    ]);
+    final mj = otlpProto3JsonWithHexIds(metrics) as Map<String, Object?>;
+    final metric = (((((mj['resourceMetrics'] as List).first
+                as Map)['scopeMetrics'] as List)
+            .first as Map)['metrics'] as List)
+        .first as Map;
+    expect((metric['sum'] as Map)['aggregationTemporality'], 1);
+  });
+
+  test('attribute string values resembling enum names are never touched', () {
+    final req = ExportTraceServiceRequest(resourceSpans: [
+      pt.ResourceSpans(scopeSpans: [
+        pt.ScopeSpans(spans: [
+          pt.Span(
+            traceId: traceId,
+            spanId: spanId,
+            name: 'attr-collision',
+          )..attributes.add(
+              pc.KeyValue(
+                key: 'suspicious',
+                value: pc.AnyValue(stringValue: 'SPAN_KIND_SERVER'),
+              ),
+            ),
+        ]),
+      ]),
+    ]);
+    final json = otlpProto3JsonWithHexIds(req) as Map<String, Object?>;
+    final s =
+        (((((json['resourceSpans'] as List).first as Map)['scopeSpans'] as List)
+                .first as Map)['spans'] as List)
+            .first as Map;
+    final attr = (s['attributes'] as List).first as Map;
+    expect((attr['value'] as Map)['stringValue'], 'SPAN_KIND_SERVER',
+        reason: 'field-keyed conversion must never rewrite attribute values');
   });
 }


### PR DESCRIPTION
The OTLP spec deviates from proto3 JSON for enums exactly as it does for ids: enum values MUST be encoded as **integers**, but `toProto3Json()` emits proto3-JSON's default enum **names** (`"SPAN_KIND_SERVER"`, `"SEVERITY_NUMBER_ERROR"`, `"AGGREGATION_TEMPORALITY_DELTA"`). Lenient receivers accept both, which is how this survived — the same origin story as the 1.1.0-beta.7 hex-id fix. It was caught by a strict cross-implementation check (the Dartastic engine wire-parity harness diffing this encoder's output against a second OTLP/JSON implementation).

## Fix

`otlpProto3JsonWithHexIds` now repairs both spec deviations in a single walk: hex ids (unchanged) plus int enums — span `kind`, status `code`, log `severityNumber`, metric `aggregationTemporality`.

- Tables are built from the **generated protos** (`Span_SpanKind.values` etc.) so they can never drift from the schema.
- Conversion is **field-keyed and value-guarded**: only string values sitting under those exact JSON field names convert; an attribute whose *value* happens to be `"SPAN_KIND_SERVER"` is untouched (regression-tested).
- Unknown names pass through unchanged — same defensive never-corrupt posture as the base64→hex path.

## Tests

Three new cases in `otlp_json_hex_ids_test.dart` (span kind + status code; log severityNumber + metric aggregationTemporality; attribute-collision guard). Export suites 292/292, analyze clean.

CHANGELOG entry under `[1.1.0-beta.10-wip]`; no version bump (release flow owns it).