### PR TITLE
test: make env subprocess tests independent of the working directory and the ambient environment

### DIFF
--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -22,16 +22,6 @@ import 'package:test/test.dart';
 import '../../testing_utils/memory_log_record_exporter.dart';
 import 'helpers/subprocess_env.dart';
 
-/// Runs a Dart script in a subprocess with specific environment variables set.
-/// Returns the stdout output as a string.
-///
-/// Any ambient `OTEL_` variables are cleared so the child sees only [envVars].
-Future<String> runWithEnv(
-  String scriptPath,
-  Map<String, String> envVars,
-) =>
-    runScriptWithEnv(scriptPath, envVars, clearOtelVars: true);
-
 /// A detector that throws a non-Exception type to exercise
 /// the catch block in CompositeResourceDetector.
 class _StringThrowingDetector implements ResourceDetector {
@@ -1015,7 +1005,12 @@ void main() {
 
     test('EnvVarResourceDetector returns empty resource when no env var set',
         () async {
-      // The default env in tests typically has no OTEL_RESOURCE_ATTRIBUTES
+      // Pin an empty environment rather than assuming the ambient one has no
+      // OTEL_RESOURCE_ATTRIBUTES. This runs in-process, so an exported
+      // OTEL_RESOURCE_ATTRIBUTES would otherwise fail it locally while CI,
+      // which has a clean environment, stayed green.
+      EnvironmentService.testOverrides = {};
+      addTearDown(() => EnvironmentService.testOverrides = null);
       final detector = EnvVarResourceDetector();
       final resource = await detector.detect();
       expect(resource.attributes.isEmpty, isTrue);

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -14,39 +14,23 @@
 //      addMeterProvider, addLoggerProvider
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:dartastic_opentelemetry/src/resource/resource.dart';
 import 'package:test/test.dart';
 
 import '../../testing_utils/memory_log_record_exporter.dart';
+import 'helpers/subprocess_env.dart';
 
 /// Runs a Dart script in a subprocess with specific environment variables set.
 /// Returns the stdout output as a string.
+///
+/// Any ambient `OTEL_` variables are cleared so the child sees only [envVars].
 Future<String> runWithEnv(
   String scriptPath,
   Map<String, String> envVars,
-) async {
-  final env = Map<String, String>.from(Platform.environment);
-  // Clear any existing OTEL env vars that might interfere
-  env.removeWhere((key, _) => key.startsWith('OTEL_'));
-  env.addAll(envVars);
-  final result = await Process.run(
-    Platform.executable,
-    ['run', scriptPath],
-    environment: env,
-    workingDirectory: Directory.current.path,
-  );
-  if (result.exitCode != 0) {
-    throw Exception(
-      'Script failed with exit code ${result.exitCode}:\n'
-      'stdout: ${result.stdout}\n'
-      'stderr: ${result.stderr}',
-    );
-  }
-  return result.stdout as String;
-}
+) =>
+    runScriptWithEnv(scriptPath, envVars, clearOtelVars: true);
 
 /// A detector that throws a non-Exception type to exercise
 /// the catch block in CompositeResourceDetector.

--- a/test/unit/environment/helpers/subprocess_env.dart
+++ b/test/unit/environment/helpers/subprocess_env.dart
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:io';
+import 'dart:isolate';
+
+/// Cached result of [packageRoot].
+String? _packageRootCache;
+
+/// The absolute path of the package root, resolved from the package URI
+/// rather than from [Directory.current].
+///
+/// The subprocess helper scripts are addressed by paths relative to the
+/// package root. Resolving those against the working directory only works
+/// when the runner starts at the root, which `dart test` does but IDEs
+/// generally do not: IntelliJ and Android Studio default a Dart test run
+/// configuration's working directory to the directory holding the test file,
+/// and every subprocess test then fails with `Could not find file ...`.
+/// Resolving through the package config makes the location of the runner
+/// irrelevant.
+Future<String> packageRoot() async {
+  final cached = _packageRootCache;
+  if (cached != null) return cached;
+  final libUri = await Isolate.resolvePackageUri(
+    Uri.parse('package:dartastic_opentelemetry/dartastic_opentelemetry.dart'),
+  );
+  if (libUri == null) {
+    throw StateError(
+      'Could not resolve package:dartastic_opentelemetry. '
+      'Run `dart pub get` to regenerate .dart_tool/package_config.json.',
+    );
+  }
+  // libUri is <root>/lib/dartastic_opentelemetry.dart.
+  return _packageRootCache = File.fromUri(libUri).parent.parent.path;
+}
+
+/// Runs [scriptPath] in a subprocess with [envVars] applied, returning stdout.
+///
+/// [scriptPath] is relative to the package root. A subprocess is the only
+/// reliable way to test code that reads `Platform.environment`, since that
+/// map is unmodifiable in-process.
+///
+/// When [clearOtelVars] is true, `OTEL_`-prefixed variables inherited from
+/// the ambient environment are dropped before [envVars] is applied, so the
+/// child sees only the variables the test asked for.
+///
+/// Throws if the script exits non-zero, including its stdout and stderr.
+Future<String> runScriptWithEnv(
+  String scriptPath,
+  Map<String, String> envVars, {
+  bool clearOtelVars = false,
+}) async {
+  final root = await packageRoot();
+  final env = Map<String, String>.from(Platform.environment);
+  if (clearOtelVars) {
+    env.removeWhere((key, _) => key.startsWith('OTEL_'));
+  }
+  env.addAll(envVars);
+  final result = await Process.run(
+    Platform.executable,
+    ['run', File.fromUri(Directory(root).uri.resolve(scriptPath)).path],
+    environment: env,
+    workingDirectory: root,
+  );
+  if (result.exitCode != 0) {
+    throw Exception(
+      'Script failed with exit code ${result.exitCode}:\n'
+      'stdout: ${result.stdout}\n'
+      'stderr: ${result.stderr}',
+    );
+  }
+  return result.stdout as String;
+}

--- a/test/unit/environment/helpers/subprocess_env.dart
+++ b/test/unit/environment/helpers/subprocess_env.dart
@@ -40,26 +40,31 @@ Future<String> packageRoot() async {
 /// reliable way to test code that reads `Platform.environment`, since that
 /// map is unmodifiable in-process.
 ///
-/// When [clearOtelVars] is true, `OTEL_`-prefixed variables inherited from
-/// the ambient environment are dropped before [envVars] is applied, so the
-/// child sees only the variables the test asked for.
+/// `OTEL_`-prefixed variables inherited from the ambient environment are
+/// dropped before [envVars] is applied, so the child sees exactly the
+/// variables the test asked for and nothing else. Without that, a developer
+/// with `OTEL_` variables exported gets failures CI never reproduces.
+///
+/// Note [Process.run]'s `includeParentEnvironment` must be false for that
+/// removal to mean anything: it defaults to true, which merges `environment`
+/// *on top of* the parent's, so dropping a key from the map leaves the
+/// parent's value visible to the child. `env` below is a full copy of the
+/// parent environment, so the child still gets `PATH`, `HOME` and the rest.
 ///
 /// Throws if the script exits non-zero, including its stdout and stderr.
-Future<String> runScriptWithEnv(
+Future<String> runWithEnv(
   String scriptPath,
-  Map<String, String> envVars, {
-  bool clearOtelVars = false,
-}) async {
+  Map<String, String> envVars,
+) async {
   final root = await packageRoot();
-  final env = Map<String, String>.from(Platform.environment);
-  if (clearOtelVars) {
-    env.removeWhere((key, _) => key.startsWith('OTEL_'));
-  }
-  env.addAll(envVars);
+  final env = Map<String, String>.from(Platform.environment)
+    ..removeWhere((key, _) => key.startsWith('OTEL_'))
+    ..addAll(envVars);
   final result = await Process.run(
     Platform.executable,
     ['run', File.fromUri(Directory(root).uri.resolve(scriptPath)).path],
     environment: env,
+    includeParentEnvironment: false,
     workingDirectory: root,
   );
   if (result.exitCode != 0) {

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -8,17 +8,6 @@ import 'package:test/test.dart';
 
 import 'helpers/subprocess_env.dart';
 
-/// Runs a Dart script in a subprocess with specific environment variables set.
-///
-/// Returns the stdout output as a string.
-/// This is the only reliable way to test code that reads from
-/// Platform.environment, since Platform.environment is an unmodifiable map.
-Future<String> runWithEnv(
-  String scriptPath,
-  Map<String, String> envVars,
-) =>
-    runScriptWithEnv(scriptPath, envVars);
-
 void main() {
   group('OTelEnv', () {
     // Save and restore OTelLog state around each test.

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';
+
+import 'helpers/subprocess_env.dart';
 
 /// Runs a Dart script in a subprocess with specific environment variables set.
 ///
@@ -15,24 +16,8 @@ import 'package:test/test.dart';
 Future<String> runWithEnv(
   String scriptPath,
   Map<String, String> envVars,
-) async {
-  final env = Map<String, String>.from(Platform.environment);
-  env.addAll(envVars);
-  final result = await Process.run(
-    Platform.executable,
-    ['run', scriptPath],
-    environment: env,
-    workingDirectory: Directory.current.path,
-  );
-  if (result.exitCode != 0) {
-    throw Exception(
-      'Script failed with exit code ${result.exitCode}:\n'
-      'stdout: ${result.stdout}\n'
-      'stderr: ${result.stderr}',
-    );
-  }
-  return result.stdout as String;
-}
+) =>
+    runScriptWithEnv(scriptPath, envVars);
 
 void main() {
   group('OTelEnv', () {

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_edge_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_edge_test.dart
@@ -135,7 +135,8 @@ void main() {
       final exporter = exporterFor(server.port!, maxRetries: 1);
 
       final result = await exporter
-          .export([record('generic')]).then<ExportResult?>((r) => r, onError: (_) => null);
+          .export([record('generic')]).then<ExportResult?>((r) => r,
+              onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
 
       await exporter.shutdown();
@@ -162,7 +163,8 @@ void main() {
       final exporter = exporterFor(server.port!, maxRetries: 2);
 
       final result = await exporter
-          .export([record('doomed')]).then<ExportResult?>((r) => r, onError: (_) => null);
+          .export([record('doomed')]).then<ExportResult?>((r) => r,
+              onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
       expect(service.callCount, greaterThanOrEqualTo(2));
 
@@ -173,7 +175,8 @@ void main() {
     test('connection refused fails the export', () async {
       final exporter = exporterFor(1, maxRetries: 1); // nothing listens on 1
       final result = await exporter
-          .export([record('refused')]).then<ExportResult?>((r) => r, onError: (_) => null);
+          .export([record('refused')]).then<ExportResult?>((r) => r,
+              onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
       await exporter.shutdown();
     });
@@ -182,8 +185,8 @@ void main() {
         () async {
       final exporter = exporterFor(1);
       await exporter.shutdown();
-      final result = await exporter
-          .export([record('late')]).then<ExportResult?>((r) => r, onError: (_) => null);
+      final result = await exporter.export(
+          [record('late')]).then<ExportResult?>((r) => r, onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
       await exporter.forceFlush();
       await exporter.shutdown();

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_edge_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_edge_test.dart
@@ -135,7 +135,7 @@ void main() {
       final exporter = exporterFor(server.port!, maxRetries: 1);
 
       final result = await exporter
-          .export([record('generic')]).then((r) => r, onError: (_) => null);
+          .export([record('generic')]).then<ExportResult?>((r) => r, onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
 
       await exporter.shutdown();
@@ -162,7 +162,7 @@ void main() {
       final exporter = exporterFor(server.port!, maxRetries: 2);
 
       final result = await exporter
-          .export([record('doomed')]).then((r) => r, onError: (_) => null);
+          .export([record('doomed')]).then<ExportResult?>((r) => r, onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
       expect(service.callCount, greaterThanOrEqualTo(2));
 
@@ -173,7 +173,7 @@ void main() {
     test('connection refused fails the export', () async {
       final exporter = exporterFor(1, maxRetries: 1); // nothing listens on 1
       final result = await exporter
-          .export([record('refused')]).then((r) => r, onError: (_) => null);
+          .export([record('refused')]).then<ExportResult?>((r) => r, onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
       await exporter.shutdown();
     });
@@ -183,7 +183,7 @@ void main() {
       final exporter = exporterFor(1);
       await exporter.shutdown();
       final result = await exporter
-          .export([record('late')]).then((r) => r, onError: (_) => null);
+          .export([record('late')]).then<ExportResult?>((r) => r, onError: (_) => null);
       expect(result, isNot(equals(ExportResult.success)));
       await exporter.forceFlush();
       await exporter.shutdown();


### PR DESCRIPTION
Fixes #98. Follow-up for the rest of the suite: #103.

Two bugs that made the environment tests pass in CI while failing on a developer's machine.

## 1. Helper scripts resolved against the working directory

The env tests spawn subprocesses to exercise code reading `Platform.environment` — the only reliable way, since that map is unmodifiable in-process. The helper scripts were addressed by **repo-root-relative** paths resolved against `Directory.current`, so they only resolve when the runner starts at the repo root.

`dart test` does. IDEs do not — IntelliJ/Android Studio default a Dart test run configuration's working directory to the directory holding the test file:

```
Exception: Script failed with exit code 255:
stderr: Could not find file `test/unit/environment/helpers/check_blrp_config.dart`
```

```bash
cd test/unit/environment && dart test env_coverage_test.dart   # 17 failures
```

Resolved via `Isolate.resolvePackageUri` instead, so the runner's location is irrelevant.

## 2. The `OTEL_` clearing was a no-op

`env_coverage_test.dart` stripped `OTEL_` variables from the map it handed `Process.run` — but `includeParentEnvironment` defaults to **true**, which merges `environment` *on top of* the parent's. Dropping a key from the map leaves the parent's value visible to the child. The isolation its comment claimed never existed.

With `OTEL_BLRP_SCHEDULE_DELAY=999` exported, on `main`:

```
OTelEnv.getBlrpConfig (subprocess) returns empty map when no BLRP env vars set [E]
  Expected: empty
    Actual: {'scheduleDelay_ms': 999}
```

`includeParentEnvironment: false` makes the removal take effect. The map is already a full copy of the parent, so the child keeps `PATH`, `HOME` and the rest. `otel_env_test.dart`, which never cleared `OTEL_` at all, gains the same isolation.

One in-process test (`EnvVarResourceDetector returns empty resource when no env var set`) asserted an empty ambient environment, which no subprocess flag can fix; it now pins `EnvironmentService.testOverrides = {}` with `addTearDown` to restore.

## Consolidation

Both files carried near-duplicate `runWithEnv` copies — which is how one ended up with the (broken) clearing and the other with none. They now import a single shared `runWithEnv` from `helpers/subprocess_env.dart`; the per-file wrappers are gone and **all 135 call sites are unchanged**.

## Verification

| Check | Result |
|---|---|
| `dart test` from repo root | 2004 passed, 13 skipped — unchanged |
| `dart test` from `test/unit/environment/` | 222 passed (**was 17 failures**) |
| Env files with 9 `OTEL_` vars exported | **0 failures (was 7)** |
| `dart analyze` (whole repo) | No issues found |

The 12 remaining dirty-environment failures elsewhere (`basic_test.dart`, `integration/environment_variables_test.dart`, `integration/resource_attributes_test.dart`) are **pre-existing** — reproduced on clean `main` (`07745d5`) in a detached worktree — and are tracked separately in #103.

Test-only change; no library code touched, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)