### PR TITLE
Stop logging the raw OTEL_EXPORTER_OTLP_HEADERS value

### DIFF
--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -161,7 +161,9 @@ class OTelEnv {
     }
     if (headers != null) {
       if (OTelLog.isDebug()) {
-        OTelLog.debug('OTelEnv: Parsing $signal headers from env: $headers');
+        // The raw value is not logged: it carries the Authorization header,
+        // which the per-header loop below is careful to redact.
+        OTelLog.debug('OTelEnv: Parsing $signal headers from env');
       }
       final parsedHeaders = _parseHeaders(headers);
       if (OTelLog.isDebug()) {

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -499,6 +499,30 @@ void main() {
       expect(result.containsKey('key'), isFalse);
     });
 
+    test('does not log the raw header string, which carries the token',
+        () async {
+      // The per-header loop redacts the Authorization value, but the line above
+      // it used to log the whole raw env var, which defeated that redaction.
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_header_logging.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS':
+              'authorization=Bearer s3cr3t-token-value,x-api=notasecret',
+        },
+      );
+      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+
+      expect(lines, isNotEmpty,
+          reason: 'debug logging should have produced output to inspect');
+      expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse,
+          reason: 'the Authorization value must never reach the log');
+      expect(lines.any((l) => l.contains('REDACTED')), isTrue,
+          reason: 'the Authorization header should still be reported, redacted');
+      expect(lines.any((l) => l.contains('notasecret')), isTrue,
+          reason: 'non-secret headers are still logged, so the diagnostic '
+              'value of the debug output is unchanged');
+    });
+
     test('handles header with no equals sign', () async {
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_parse_headers.dart',

--- a/test/unit/environment/helpers/check_header_logging.dart
+++ b/test/unit/environment/helpers/check_header_logging.dart
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Helper script: prints a JSON array of every log line emitted while
+// OTelEnv.getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS at debug level.
+// Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS set.
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() {
+  final captured = <String>[];
+  OTelLog.logFunction = captured.add;
+  OTelLog.currentLevel = LogLevel.debug;
+
+  OTelEnv.getOtlpConfig(signal: 'traces');
+
+  print(jsonEncode(captured));
+}


### PR DESCRIPTION
## What this fixes

`OTelEnv.getOtlpConfig` logs the raw `OTEL_EXPORTER_OTLP_HEADERS` value at debug level:

```dart
OTelLog.debug('OTelEnv: Parsing $signal headers from env: $headers');
```

Five lines below it, the per-header loop is careful to keep the credential out of the log:

```dart
if (key.toLowerCase() == 'authorization') {
  OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
}
```

The raw string logged above contains that same value, so the redaction never had any effect. With debug logging on, `authorization=Bearer <token>` reached the log regardless. This is the shape where a guard exists and something upstream of it makes the guard moot, so it reads as protected while it is not.

The fix keeps the message and drops the value. The loop underneath still reports every header, still redacts Authorization, and still prints non-secret values, so nothing diagnostic is lost.

## Relationship to #96

#96 asks for a configurable redaction list for OTLP headers. This is not that, and it does not close it. It is the narrower point that the redaction already in the file is bypassed today, which seemed worth fixing on its own rather than folding into the broader design. Happy to help with #96 separately if the list approach is the direction you want.

## Test

`test/unit/environment/helpers/check_header_logging.dart` captures `OTelLog` output in a subprocess with the env var set, following the existing `runWithEnv` pattern in this suite, and prints it as JSON. The test asserts three things: the token never appears, the `REDACTED` marker still does, and the non-secret header value still does, so a regression that simply silenced all header logging would fail it too.

Without the change the test fails on the first assertion:

```
the Authorization value must never reach the log
test/unit/environment/env_coverage_test.dart 517:7
00:02 +0 -1: Some tests failed.
```

With it, `dart test test/unit/environment/` is green at 282 passed, and `dart analyze` reports no issues.

## Note on tooling

I used AI assistance while investigating this. I read the file, made the change and ran the tests above myself, including the failing run, so the output quoted here is from runs I did rather than reasoning about.
