### PR TITLE
Redact OTLP header values in debug logs behind an allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,49 @@ Constants are defined for all 74 OpenTelemetry environment variables. See `lib/s
 | `otelExporterOtlpHeaders`     | `OTEL_EXPORTER_OTLP_HEADERS`   | Headers (key=value,...)  | None                   | `api-key=secret,tenant=acme`     |
 | `otelExporterOtlpTimeout`     | `OTEL_EXPORTER_OTLP_TIMEOUT`   | Timeout in milliseconds  | `10000`                | `5000`                           |
 | `otelExporterOtlpCompression` | `OTEL_EXPORTER_OTLP_COMPRESSION` | Compression algorithm  | None                   | `gzip`                           |
+| `darOtlpHeaderLogAllowlist`   | `DAR_OTLP_HEADER_LOG_ALLOWLIST` | Header names whose values may be written to the debug log (comma-separated) | None (every value redacted) | `x-trace-id,x-tenant` |
+
+#### Header Value Redaction in Debug Logs
+
+OTLP headers carry credentials, so at debug level the SDK **redacts every header
+value by default**. Header names and the header count are still logged, so the
+output still tells you which headers are configured:
+
+```
+OTelEnv: Parsed 3 header(s)
+  authorization: [REDACTED]
+  x-api-key: [REDACTED]
+  x-trace-id: [REDACTED]
+```
+
+If redaction hides something you need while debugging, opt that header in by
+name. This is an allowlist rather than a list of names to hide: which header
+holds a credential depends on the backend (`x-api-key`, `x-honeycomb-team`,
+`dd-api-key`, and whatever the next vendor invents), so a list of names to hide
+would leak anything nobody thought of.
+
+```sh
+export DAR_OTLP_HEADER_LOG_ALLOWLIST=x-trace-id,x-tenant
+```
+
+or in code, which overrides the environment variable rather than adding to it:
+
+```dart
+await OTel.initialize(
+  otlpHeaderLogAllowlist: ['x-trace-id', 'x-tenant'],
+);
+```
+
+Details worth knowing:
+
+- The allowlist opts in **values** only. Nothing you do hides a header name.
+- Names are matched **exactly**, case insensitively. Prefixes and globs are not
+  supported on purpose: `x-*` would opt in `x-api-key`.
+- `authorization` and `proxy-authorization` are **never** logged, even if you
+  list them. If you really need one, log it yourself.
+- Entries are trimmed and deduplicated, and empty entries are ignored.
+- The name is `DAR_`-prefixed rather than `OTEL_` because it is not part of the
+  OpenTelemetry specification.
 
 #### Signal-Specific Configuration
 

--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ Constants are defined for all 74 OpenTelemetry environment variables. See `lib/s
 | `otelExporterOtlpHeaders`     | `OTEL_EXPORTER_OTLP_HEADERS`   | Headers (key=value,...)  | None                   | `api-key=secret,tenant=acme`     |
 | `otelExporterOtlpTimeout`     | `OTEL_EXPORTER_OTLP_TIMEOUT`   | Timeout in milliseconds  | `10000`                | `5000`                           |
 | `otelExporterOtlpCompression` | `OTEL_EXPORTER_OTLP_COMPRESSION` | Compression algorithm  | None                   | `gzip`                           |
-| `darOtlpHeaderLogAllowlist`   | `DAR_OTLP_HEADER_LOG_ALLOWLIST` | Header names whose values may be written to the debug log (comma-separated) | None (every value redacted) | `x-trace-id,x-tenant` |
+| `otelDartHeaderLogAllowlist`  | `OTEL_DART_HEADER_LOG_ALLOWLIST` | Header names whose values may be written to the debug log (comma-separated) | None (every value redacted) | `x-trace-id,x-tenant` |
 
 #### Header Value Redaction in Debug Logs
 
@@ -1015,7 +1015,7 @@ holds a credential depends on the backend (`x-api-key`, `x-honeycomb-team`,
 would leak anything nobody thought of.
 
 ```sh
-export DAR_OTLP_HEADER_LOG_ALLOWLIST=x-trace-id,x-tenant
+export OTEL_DART_HEADER_LOG_ALLOWLIST=x-trace-id,x-tenant
 ```
 
 or in code, which overrides the environment variable rather than adding to it:
@@ -1034,8 +1034,6 @@ Details worth knowing:
 - `authorization` and `proxy-authorization` are **never** logged, even if you
   list them. If you really need one, log it yourself.
 - Entries are trimmed and deduplicated, and empty entries are ignored.
-- The name is `DAR_`-prefixed rather than `OTEL_` because it is not part of the
-  OpenTelemetry specification.
 
 #### Signal-Specific Configuration
 

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -94,3 +94,4 @@ export 'src/trace/span_processor.dart';
 export 'src/trace/tracer.dart' hide SDKTracerCreate;
 export 'src/trace/tracer_provider.dart' hide SDKTracerProviderCreate;
 export 'src/trace/w3c_trace_context_propagator.dart';
+export 'src/util/header_redaction.dart';

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -94,4 +94,3 @@ export 'src/trace/span_processor.dart';
 export 'src/trace/tracer.dart' hide SDKTracerCreate;
 export 'src/trace/tracer_provider.dart' hide SDKTracerProviderCreate;
 export 'src/trace/w3c_trace_context_propagator.dart';
-export 'src/util/header_redaction.dart';

--- a/lib/src/environment/env_constants.dart
+++ b/lib/src/environment/env_constants.dart
@@ -124,6 +124,18 @@ const String otelDartLogExport = 'OTEL_DART_LOG_EXPORT';
 ///
 /// Type: String (URL)
 /// Default: "http://localhost:4318" (HTTP) or "http://localhost:4317" (gRPC)
+/// Comma separated list of OTLP header names whose values may be written to the
+/// debug log.
+///
+/// Not an `OTEL_` name because it is not in the OpenTelemetry specification.
+/// Names are matched exactly, case insensitively. `authorization` and
+/// `proxy-authorization` are never logged even if listed. Any header not listed
+/// has its value replaced with `[REDACTED]`; the name and the header count are
+/// still logged.
+///
+/// Example: `DAR_OTLP_HEADER_LOG_ALLOWLIST=x-trace-id,x-tenant`
+const String darOtlpHeaderLogAllowlist = 'DAR_OTLP_HEADER_LOG_ALLOWLIST';
+
 const String otelExporterOtlpEndpoint = 'OTEL_EXPORTER_OTLP_ENDPOINT';
 
 /// Transport protocol for the OTLP exporter.

--- a/lib/src/environment/env_constants.dart
+++ b/lib/src/environment/env_constants.dart
@@ -110,6 +110,14 @@ const String otelDartLogSpans = 'OTEL_DART_LOG_SPANS';
 /// Default: false
 const String otelDartLogExport = 'OTEL_DART_LOG_EXPORT';
 
+/// Comma separated OTLP header names whose values may appear in the debug log
+/// (Dart-specific). Names are matched case insensitively, and `authorization`
+/// and `proxy-authorization` are redacted even when listed.
+///
+/// Type: String (comma-separated header names)
+/// Default: none, every header value is redacted
+const String otelDartHeaderLogAllowlist = 'OTEL_DART_HEADER_LOG_ALLOWLIST';
+
 // =============================================================================
 // General OTLP Exporter Configuration
 // =============================================================================
@@ -124,18 +132,6 @@ const String otelDartLogExport = 'OTEL_DART_LOG_EXPORT';
 ///
 /// Type: String (URL)
 /// Default: "http://localhost:4318" (HTTP) or "http://localhost:4317" (gRPC)
-/// Comma separated list of OTLP header names whose values may be written to the
-/// debug log.
-///
-/// Not an `OTEL_` name because it is not in the OpenTelemetry specification.
-/// Names are matched exactly, case insensitively. `authorization` and
-/// `proxy-authorization` are never logged even if listed. Any header not listed
-/// has its value replaced with `[REDACTED]`; the name and the header count are
-/// still logged.
-///
-/// Example: `DAR_OTLP_HEADER_LOG_ALLOWLIST=x-trace-id,x-tenant`
-const String darOtlpHeaderLogAllowlist = 'DAR_OTLP_HEADER_LOG_ALLOWLIST';
-
 const String otelExporterOtlpEndpoint = 'OTEL_EXPORTER_OTLP_ENDPOINT';
 
 /// Transport protocol for the OTLP exporter.

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -161,7 +161,9 @@ class OTelEnv {
     }
     if (headers != null) {
       if (OTelLog.isDebug()) {
-        OTelLog.debug('OTelEnv: Parsing $signal headers from env: $headers');
+        // The raw value is not logged: it carries the Authorization header,
+        // which the per-header loop below is careful to redact.
+        OTelLog.debug('OTelEnv: Parsing $signal headers from env');
       }
       final parsedHeaders = _parseHeaders(headers);
       if (OTelLog.isDebug()) {

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -99,20 +99,20 @@ class OTelEnv {
 
   /// Applies the OTLP header log allowlist.
   ///
-  /// [headerNames] is the value passed to `OTel.initialize`. When it is null
-  /// the `DAR_OTLP_HEADER_LOG_ALLOWLIST` environment variable is used instead;
-  /// code overrides configuration, and the two are never combined. When neither
-  /// is set no header value is logged.
+  /// [headerNames] comes from `OTel.initialize`. When null,
+  /// `OTEL_DART_HEADER_LOG_ALLOWLIST` is read instead; code wins over
+  /// configuration and the two are never combined. With neither set, no header
+  /// value is logged.
   ///
-  /// Call this before anything that logs headers, since the allowlist is read
-  /// at log time.
+  /// The allowlist is read at log time, so call this before anything logs
+  /// headers.
   static void applyHeaderLogAllowlist([Iterable<String>? headerNames]) {
     if (headerNames != null) {
       configureHeaderLogAllowlist(headerNames);
       return;
     }
     configureHeaderLogAllowlist(
-      parseHeaderLogAllowlist(_getEnv(darOtlpHeaderLogAllowlist)),
+      parseHeaderLogAllowlist(_getEnv(otelDartHeaderLogAllowlist)),
     );
   }
 
@@ -181,8 +181,7 @@ class OTelEnv {
     }
     if (headers != null) {
       if (OTelLog.isDebug()) {
-        // The raw value is not logged: it carries the Authorization header,
-        // which the per-header loop below is careful to redact.
+        // The raw value holds the Authorization header the loop below redacts.
         OTelLog.debug('OTelEnv: Parsing $signal headers from env');
       }
       final parsedHeaders = _parseHeaders(headers);

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import '../util/header_redaction.dart';
 import 'env_constants.dart';
 import 'environment_service.dart';
 
@@ -96,6 +97,25 @@ class OTelEnv {
     }
   }
 
+  /// Applies the OTLP header log allowlist.
+  ///
+  /// [headerNames] is the value passed to `OTel.initialize`. When it is null
+  /// the `DAR_OTLP_HEADER_LOG_ALLOWLIST` environment variable is used instead;
+  /// code overrides configuration, and the two are never combined. When neither
+  /// is set no header value is logged.
+  ///
+  /// Call this before anything that logs headers, since the allowlist is read
+  /// at log time.
+  static void applyHeaderLogAllowlist([Iterable<String>? headerNames]) {
+    if (headerNames != null) {
+      configureHeaderLogAllowlist(headerNames);
+      return;
+    }
+    configureHeaderLogAllowlist(
+      parseHeaderLogAllowlist(_getEnv(darOtlpHeaderLogAllowlist)),
+    );
+  }
+
   /// Get OTLP configuration from environment variables.
   ///
   /// Returns a map containing the OTLP configuration read from environment variables.
@@ -169,11 +189,7 @@ class OTelEnv {
       if (OTelLog.isDebug()) {
         OTelLog.debug('OTelEnv: Parsed ${parsedHeaders.length} header(s)');
         parsedHeaders.forEach((key, value) {
-          if (key.toLowerCase() == 'authorization') {
-            OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
-          } else {
-            OTelLog.debug('  $key: $value');
-          }
+          OTelLog.debug('  ${formatHeaderForLog(key, value)}');
         });
       }
       config['headers'] = parsedHeaders;

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
@@ -13,6 +13,7 @@ import 'package:http/http.dart' as http;
 import '../../../../export/otlp_http_protocol.dart';
 import '../../../../export/otlp_json.dart';
 import '../../../../trace/export/otlp/http/http_client_factory.dart';
+import '../../../../util/header_redaction.dart';
 import '../../../../util/zip/gzip.dart';
 import '../../../readable_log_record.dart';
 import '../../log_record_exporter.dart';
@@ -44,11 +45,7 @@ class OtlpHttpLogRecordExporter implements LogRecordExporter {
       OTelLog.debug(
           'OtlpHttpLogRecordExporter: Configured headers count: ${_config.headers.length}');
       _config.headers.forEach((key, value) {
-        if (key.toLowerCase() == 'authorization') {
-          OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
-        } else {
-          OTelLog.debug('  $key: $value');
-        }
+        OTelLog.debug('  ${formatHeaderForLog(key, value)}');
       });
     }
     _client = _createHttpClient();
@@ -134,11 +131,7 @@ class OtlpHttpLogRecordExporter implements LogRecordExporter {
           'OtlpHttpLogRecordExporter: Sending export request to $endpointUrl');
       OTelLog.debug('OtlpHttpLogRecordExporter: Request headers:');
       headers.forEach((key, value) {
-        if (key.toLowerCase() == 'authorization') {
-          OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
-        } else {
-          OTelLog.debug('  $key: $value');
-        }
+        OTelLog.debug('  ${formatHeaderForLog(key, value)}');
       });
     }
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -144,10 +144,15 @@ class OTel {
     bool detectPlatformResources = true,
     bool logPrint = false,
     String logPrintLoggerName = 'dart.print',
+    List<String>? otlpHeaderLogAllowlist,
     TimeProvider? timeProvider,
     OTelFactoryCreationFunction? oTelFactoryCreationFunction =
         otelSDKFactoryFactoryFunction,
   }) async {
+    // Before anything reads or logs OTLP headers: an explicit list wins over
+    // DAR_OTLP_HEADER_LOG_ALLOWLIST, and with neither set no value is logged.
+    OTelEnv.applyHeaderLogAllowlist(otlpHeaderLogAllowlist);
+
     // Apply environment variables only if parameters are not provided
     final envServiceName = serviceName == null
         ? OTelEnv.getServiceConfig()['serviceName'] as String?

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -149,8 +149,7 @@ class OTel {
     OTelFactoryCreationFunction? oTelFactoryCreationFunction =
         otelSDKFactoryFactoryFunction,
   }) async {
-    // Before anything reads or logs OTLP headers: an explicit list wins over
-    // DAR_OTLP_HEADER_LOG_ALLOWLIST, and with neither set no value is logged.
+    // Has to run before anything logs OTLP headers.
     OTelEnv.applyHeaderLogAllowlist(otlpHeaderLogAllowlist);
 
     // Apply environment variables only if parameters are not provided

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
@@ -12,6 +12,7 @@ import 'package:http/http.dart' as http;
 
 import '../../../../export/otlp_http_protocol.dart';
 import '../../../../export/otlp_json.dart';
+import '../../../../util/header_redaction.dart';
 import '../../../../util/zip/gzip.dart';
 import '../../../span.dart';
 import '../../../span_logger.dart';
@@ -47,11 +48,7 @@ class OtlpHttpSpanExporter implements SpanExporter {
         'OtlpHttpSpanExporter: Configured headers count: ${_config.headers.length}',
       );
       _config.headers.forEach((key, value) {
-        if (key.toLowerCase() == 'authorization') {
-          OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
-        } else {
-          OTelLog.debug('  $key: $value');
-        }
+        OTelLog.debug('  ${formatHeaderForLog(key, value)}');
       });
     }
     _client = _createHttpClient();
@@ -156,11 +153,7 @@ class OtlpHttpSpanExporter implements SpanExporter {
       OTelLog.debug('OtlpHttpSpanExporter: Request headers:');
       headers.forEach((key, value) {
         // Mask authorization header value for security, but show it exists
-        if (key.toLowerCase() == 'authorization') {
-          OTelLog.debug('  $key: [REDACTED - length: ${value.length}]');
-        } else {
-          OTelLog.debug('  $key: $value');
-        }
+        OTelLog.debug('  ${formatHeaderForLog(key, value)}');
       });
     }
 

--- a/lib/src/util/header_redaction.dart
+++ b/lib/src/util/header_redaction.dart
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Redaction of header values written to the debug log.
+///
+/// OTLP headers carry credentials, and which header name holds one depends on
+/// the backend (`authorization`, `x-api-key`, `x-honeycomb-team`, `dd-api-key`,
+/// and whatever the next vendor invents). A list of names to hide therefore
+/// fails open on anything nobody thought of, so this is an allowlist of names
+/// whose values are safe to print, and everything else is redacted.
+///
+/// The allowlist opts in *values* only. Header names and the header count are
+/// always logged, so an empty allowlist (the default) still shows which headers
+/// are configured, just not what is in them.
+library;
+
+/// Written in place of a header value that is not allowed to be logged.
+///
+/// The value length is deliberately not included: it narrows the search space
+/// for the token behind it.
+const String redactedHeaderPlaceholder = '[REDACTED]';
+
+/// Header names whose values are never logged, whatever the allowlist says.
+const Set<String> alwaysRedactedHeaderNames = <String>{
+  'authorization',
+  'proxy-authorization',
+};
+
+Set<String> _allowedHeaderNames = const <String>{};
+
+/// The header names whose values are currently allowed to be logged.
+///
+/// Lowercased, and never contains a name in [alwaysRedactedHeaderNames].
+Set<String> get allowedHeaderLogNames => _allowedHeaderNames;
+
+/// Sets the header names whose values may be logged.
+///
+/// Names are lowercased once here so that [redactHeaderValue] only has to
+/// lowercase the header it is given. Passing null or an empty iterable restores
+/// the default, which redacts every value.
+///
+/// This replaces any previous allowlist rather than adding to it.
+void configureHeaderLogAllowlist(Iterable<String>? headerNames) {
+  if (headerNames == null) {
+    _allowedHeaderNames = const <String>{};
+    return;
+  }
+  _allowedHeaderNames = <String>{
+    for (final name in headerNames)
+      if (name.trim().isNotEmpty) name.trim().toLowerCase(),
+  }..removeAll(alwaysRedactedHeaderNames);
+}
+
+/// Parses the comma separated form used by the environment variable.
+///
+/// Entries are trimmed, empty ones are dropped, and the result is a set, so
+/// `" x-trace-id , ,X-Trace-Id "` gives `{'x-trace-id'}`.
+Set<String> parseHeaderLogAllowlist(String? value) {
+  if (value == null) {
+    return const <String>{};
+  }
+  return <String>{
+    for (final name in value.split(','))
+      if (name.trim().isNotEmpty) name.trim().toLowerCase(),
+  }..removeAll(alwaysRedactedHeaderNames);
+}
+
+/// Returns [value] when [name] is allowed to be logged, and
+/// [redactedHeaderPlaceholder] otherwise.
+String redactHeaderValue(String name, String value) {
+  return _allowedHeaderNames.contains(name.toLowerCase())
+      ? value
+      : redactedHeaderPlaceholder;
+}
+
+/// Formats one header for the debug log as `name: value-or-placeholder`.
+String formatHeaderForLog(String name, String value) {
+  return '$name: ${redactHeaderValue(name, value)}';
+}

--- a/lib/src/util/header_redaction.dart
+++ b/lib/src/util/header_redaction.dart
@@ -3,21 +3,19 @@
 
 /// Redaction of header values written to the debug log.
 ///
-/// OTLP headers carry credentials, and which header name holds one depends on
-/// the backend (`authorization`, `x-api-key`, `x-honeycomb-team`, `dd-api-key`,
-/// and whatever the next vendor invents). A list of names to hide therefore
-/// fails open on anything nobody thought of, so this is an allowlist of names
-/// whose values are safe to print, and everything else is redacted.
+/// Which OTLP header holds a credential depends on the backend
+/// (`authorization`, `x-api-key`, `x-honeycomb-team`, `dd-api-key`), so a list
+/// of names to hide leaks anything not on it. This is the other way round: an
+/// allowlist of names whose values are safe to print, everything else redacted.
 ///
-/// The allowlist opts in *values* only. Header names and the header count are
-/// always logged, so an empty allowlist (the default) still shows which headers
-/// are configured, just not what is in them.
+/// Only values are opted in. Header names and the header count are always
+/// logged, so the default empty allowlist still shows which headers are
+/// configured.
 library;
 
 /// Written in place of a header value that is not allowed to be logged.
 ///
-/// The value length is deliberately not included: it narrows the search space
-/// for the token behind it.
+/// Without the value length, which would narrow the search space for the token.
 const String redactedHeaderPlaceholder = '[REDACTED]';
 
 /// Header names whose values are never logged, whatever the allowlist says.
@@ -33,13 +31,11 @@ Set<String> _allowedHeaderNames = const <String>{};
 /// Lowercased, and never contains a name in [alwaysRedactedHeaderNames].
 Set<String> get allowedHeaderLogNames => _allowedHeaderNames;
 
-/// Sets the header names whose values may be logged.
+/// Sets the header names whose values may be logged, replacing any previous
+/// allowlist rather than adding to it.
 ///
-/// Names are lowercased once here so that [redactHeaderValue] only has to
-/// lowercase the header it is given. Passing null or an empty iterable restores
-/// the default, which redacts every value.
-///
-/// This replaces any previous allowlist rather than adding to it.
+/// Names are lowercased here so [redactHeaderValue] only has to lowercase its
+/// argument. Null or empty restores the default of redacting every value.
 void configureHeaderLogAllowlist(Iterable<String>? headerNames) {
   if (headerNames == null) {
     _allowedHeaderNames = const <String>{};

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -473,6 +473,30 @@ void main() {
       expect(result.containsKey('key'), isFalse);
     });
 
+    test('does not log the raw header string, which carries the token',
+        () async {
+      // The per-header loop redacts the Authorization value, but the line above
+      // it used to log the whole raw env var, which defeated that redaction.
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_header_logging.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS':
+              'authorization=Bearer s3cr3t-token-value,x-api=notasecret',
+        },
+      );
+      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+
+      expect(lines, isNotEmpty,
+          reason: 'debug logging should have produced output to inspect');
+      expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse,
+          reason: 'the Authorization value must never reach the log');
+      expect(lines.any((l) => l.contains('REDACTED')), isTrue,
+          reason: 'the Authorization header should still be reported, redacted');
+      expect(lines.any((l) => l.contains('notasecret')), isTrue,
+          reason: 'non-secret headers are still logged, so the diagnostic '
+              'value of the debug output is unchanged');
+    });
+
     test('handles header with no equals sign', () async {
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_parse_headers.dart',

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -473,10 +473,9 @@ void main() {
       expect(result.containsKey('key'), isFalse);
     });
 
-    test('does not log the raw header string, which carries the token',
-        () async {
-      // The per-header loop redacts the Authorization value, but the line above
-      // it used to log the whole raw env var, which defeated that redaction.
+    test('does not log the raw header string', () async {
+      // The per-header loop redacted the Authorization value, but the line
+      // above it logged the whole raw env var, which undid that.
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_header_logging.dart',
         {
@@ -486,16 +485,10 @@ void main() {
       );
       final lines = (jsonDecode(output.trim()) as List).cast<String>();
 
-      expect(lines, isNotEmpty,
-          reason: 'debug logging should have produced output to inspect');
-      expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse,
-          reason: 'the Authorization value must never reach the log');
-      expect(lines.any((l) => l.contains('REDACTED')), isTrue,
-          reason:
-              'the Authorization header should still be reported, redacted');
-      expect(lines.any((l) => l.contains('x-api')), isTrue,
-          reason: 'header names are still logged, so the debug output still '
-              'says which headers are configured');
+      expect(lines, isNotEmpty);
+      expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse);
+      expect(lines.any((l) => l.contains('REDACTED')), isTrue);
+      expect(lines.any((l) => l.contains('x-api')), isTrue);
     });
 
     test('redacts every header value when no allowlist is configured',
@@ -510,13 +503,9 @@ void main() {
       final lines = (jsonDecode(output.trim()) as List).cast<String>();
 
       expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
-      expect(lines.any((l) => l.contains('key-value')), isFalse,
-          reason: 'the default fails closed, so a header nobody thought to '
-              'name is redacted too');
+      expect(lines.any((l) => l.contains('key-value')), isFalse);
       expect(lines.any((l) => l.contains('t-1')), isFalse);
-      expect(lines, anyElement(contains('x-api-key: [REDACTED]')),
-          reason: 'names are still logged so the output still says which '
-              'headers are configured');
+      expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
       expect(lines, anyElement(contains('OTelEnv: Parsed 3 header(s)')));
     });
 
@@ -526,7 +515,7 @@ void main() {
         {
           'OTEL_EXPORTER_OTLP_HEADERS':
               'authorization=Bearer s3cr3t,x-api-key=key-value,x-trace-id=t-1',
-          'DAR_OTLP_HEADER_LOG_ALLOWLIST': 'x-trace-id',
+          'OTEL_DART_HEADER_LOG_ALLOWLIST': 'x-trace-id',
         },
       );
       final lines = (jsonDecode(output.trim()) as List).cast<String>();
@@ -543,7 +532,7 @@ void main() {
         'test/unit/environment/helpers/check_header_allowlist_logging.dart',
         {
           'OTEL_EXPORTER_OTLP_HEADERS': 'authorization=Bearer s3cr3t',
-          'DAR_OTLP_HEADER_LOG_ALLOWLIST': 'authorization',
+          'OTEL_DART_HEADER_LOG_ALLOWLIST': 'authorization',
         },
       );
       final lines = (jsonDecode(output.trim()) as List).cast<String>();
@@ -557,16 +546,14 @@ void main() {
         'test/unit/environment/helpers/check_header_allowlist_logging.dart',
         {
           'OTEL_EXPORTER_OTLP_HEADERS': 'x-api-key=key-value,x-trace-id=t-1',
-          'DAR_OTLP_HEADER_LOG_ALLOWLIST': 'x-api-key',
+          'OTEL_DART_HEADER_LOG_ALLOWLIST': 'x-api-key',
         },
         args: ['x-trace-id'],
       );
       final lines = (jsonDecode(output.trim()) as List).cast<String>();
 
-      expect(lines, anyElement(contains('x-trace-id: t-1')),
-          reason: 'code wins over configuration');
-      expect(lines, anyElement(contains('x-api-key: [REDACTED]')),
-          reason: 'the two lists are not combined');
+      expect(lines, anyElement(contains('x-trace-id: t-1')));
+      expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
     });
 
     test('handles header with no equals sign', () async {

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -491,10 +491,82 @@ void main() {
       expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse,
           reason: 'the Authorization value must never reach the log');
       expect(lines.any((l) => l.contains('REDACTED')), isTrue,
-          reason: 'the Authorization header should still be reported, redacted');
-      expect(lines.any((l) => l.contains('notasecret')), isTrue,
-          reason: 'non-secret headers are still logged, so the diagnostic '
-              'value of the debug output is unchanged');
+          reason:
+              'the Authorization header should still be reported, redacted');
+      expect(lines.any((l) => l.contains('x-api')), isTrue,
+          reason: 'header names are still logged, so the debug output still '
+              'says which headers are configured');
+    });
+
+    test('redacts every header value when no allowlist is configured',
+        () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_header_allowlist_logging.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS':
+              'authorization=Bearer s3cr3t,x-api-key=key-value,x-trace-id=t-1',
+        },
+      );
+      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+
+      expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
+      expect(lines.any((l) => l.contains('key-value')), isFalse,
+          reason: 'the default fails closed, so a header nobody thought to '
+              'name is redacted too');
+      expect(lines.any((l) => l.contains('t-1')), isFalse);
+      expect(lines, anyElement(contains('x-api-key: [REDACTED]')),
+          reason: 'names are still logged so the output still says which '
+              'headers are configured');
+      expect(lines, anyElement(contains('OTelEnv: Parsed 3 header(s)')));
+    });
+
+    test('logs the value of an allowlisted header only', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_header_allowlist_logging.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS':
+              'authorization=Bearer s3cr3t,x-api-key=key-value,x-trace-id=t-1',
+          'DAR_OTLP_HEADER_LOG_ALLOWLIST': 'x-trace-id',
+        },
+      );
+      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+
+      expect(lines, anyElement(contains('x-trace-id: t-1')));
+      expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
+      expect(lines, anyElement(contains('authorization: [REDACTED]')));
+      expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
+    });
+
+    test('authorization stays redacted even when the env var names it',
+        () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_header_allowlist_logging.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS': 'authorization=Bearer s3cr3t',
+          'DAR_OTLP_HEADER_LOG_ALLOWLIST': 'authorization',
+        },
+      );
+      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+
+      expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
+      expect(lines, anyElement(contains('authorization: [REDACTED]')));
+    });
+
+    test('an explicit allowlist replaces the environment variable', () async {
+      final output = await runWithEnv(
+        'test/unit/environment/helpers/check_header_allowlist_logging.dart',
+        {
+          'OTEL_EXPORTER_OTLP_HEADERS': 'x-api-key=key-value,x-trace-id=t-1',
+          'DAR_OTLP_HEADER_LOG_ALLOWLIST': 'x-api-key',
+        },
+        args: ['x-trace-id'],
+      );
+      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+
+      expect(lines, anyElement(contains('x-trace-id: t-1')),
+          reason: 'code wins over configuration');
+      expect(lines, anyElement(contains('x-api-key: [REDACTED]')),
+          reason: 'the two lists are not combined');
     });
 
     test('handles header with no equals sign', () async {

--- a/test/unit/environment/helpers/check_header_allowlist_logging.dart
+++ b/test/unit/environment/helpers/check_header_allowlist_logging.dart
@@ -1,14 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Helper script: prints a JSON array of every log line emitted while
-// OTelEnv.getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS at debug level,
-// after the header log allowlist has been applied.
-//
-// Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS set, and optionally
-// DAR_OTLP_HEADER_LOG_ALLOWLIST. Passing names as command line arguments
-// stands in for the OTel.initialize parameter, so that the precedence between
-// the two can be tested.
+// Helper script: prints JSON of the debug log lines emitted while
+// getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS, with the allowlist applied.
+// Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS and optionally
+// OTEL_DART_HEADER_LOG_ALLOWLIST set. Command line arguments stand in for the
+// OTel.initialize parameter, so the precedence between the two can be tested.
 
 import 'dart:convert';
 

--- a/test/unit/environment/helpers/check_header_allowlist_logging.dart
+++ b/test/unit/environment/helpers/check_header_allowlist_logging.dart
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Helper script: prints a JSON array of every log line emitted while
+// OTelEnv.getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS at debug level,
+// after the header log allowlist has been applied.
+//
+// Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS set, and optionally
+// DAR_OTLP_HEADER_LOG_ALLOWLIST. Passing names as command line arguments
+// stands in for the OTel.initialize parameter, so that the precedence between
+// the two can be tested.
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main(List<String> args) {
+  final captured = <String>[];
+  OTelLog.logFunction = captured.add;
+  OTelLog.currentLevel = LogLevel.debug;
+
+  OTelEnv.applyHeaderLogAllowlist(args.isEmpty ? null : args);
+  OTelEnv.getOtlpConfig(signal: 'traces');
+
+  print(jsonEncode(captured));
+}

--- a/test/unit/environment/helpers/check_header_logging.dart
+++ b/test/unit/environment/helpers/check_header_logging.dart
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Helper script: prints a JSON array of every log line emitted while
-// OTelEnv.getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS at debug level.
+// Helper script: prints JSON of the debug log lines emitted while
+// getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS.
 // Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS set.
 
 import 'dart:convert';

--- a/test/unit/environment/helpers/check_header_logging.dart
+++ b/test/unit/environment/helpers/check_header_logging.dart
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Helper script: prints a JSON array of every log line emitted while
+// OTelEnv.getOtlpConfig() parses OTEL_EXPORTER_OTLP_HEADERS at debug level.
+// Run via subprocess with OTEL_EXPORTER_OTLP_HEADERS set.
+
+import 'dart:convert';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+
+void main() {
+  final captured = <String>[];
+  OTelLog.logFunction = captured.add;
+  OTelLog.currentLevel = LogLevel.debug;
+
+  OTelEnv.getOtlpConfig(signal: 'traces');
+
+  print(jsonEncode(captured));
+}

--- a/test/unit/environment/helpers/subprocess_env.dart
+++ b/test/unit/environment/helpers/subprocess_env.dart
@@ -40,10 +40,13 @@ Future<String> packageRoot() async {
 /// reliable way to test code that reads `Platform.environment`, since that
 /// map is unmodifiable in-process.
 ///
-/// `OTEL_`-prefixed variables inherited from the ambient environment are
-/// dropped before [envVars] is applied, so the child sees exactly the
-/// variables the test asked for and nothing else. Without that, a developer
-/// with `OTEL_` variables exported gets failures CI never reproduces.
+/// [args] is passed to the script after its path, for helpers that take the
+/// value under test as an argument rather than an environment variable.
+///
+/// `OTEL_`- and `DAR_`-prefixed variables inherited from the ambient
+/// environment are dropped before [envVars] is applied, so the child sees
+/// exactly the variables the test asked for and nothing else. Without that, a
+/// developer with those variables exported gets failures CI never reproduces.
 ///
 /// Note [Process.run]'s `includeParentEnvironment` must be false for that
 /// removal to mean anything: it defaults to true, which merges `environment`
@@ -54,15 +57,20 @@ Future<String> packageRoot() async {
 /// Throws if the script exits non-zero, including its stdout and stderr.
 Future<String> runWithEnv(
   String scriptPath,
-  Map<String, String> envVars,
-) async {
+  Map<String, String> envVars, {
+  List<String> args = const <String>[],
+}) async {
   final root = await packageRoot();
   final env = Map<String, String>.from(Platform.environment)
-    ..removeWhere((key, _) => key.startsWith('OTEL_'))
+    ..removeWhere((key, _) => key.startsWith('OTEL_') || key.startsWith('DAR_'))
     ..addAll(envVars);
   final result = await Process.run(
     Platform.executable,
-    ['run', File.fromUri(Directory(root).uri.resolve(scriptPath)).path],
+    [
+      'run',
+      File.fromUri(Directory(root).uri.resolve(scriptPath)).path,
+      ...args,
+    ],
     environment: env,
     includeParentEnvironment: false,
     workingDirectory: root,

--- a/test/unit/environment/helpers/subprocess_env.dart
+++ b/test/unit/environment/helpers/subprocess_env.dart
@@ -43,10 +43,10 @@ Future<String> packageRoot() async {
 /// [args] is passed to the script after its path, for helpers that take the
 /// value under test as an argument rather than an environment variable.
 ///
-/// `OTEL_`- and `DAR_`-prefixed variables inherited from the ambient
-/// environment are dropped before [envVars] is applied, so the child sees
-/// exactly the variables the test asked for and nothing else. Without that, a
-/// developer with those variables exported gets failures CI never reproduces.
+/// `OTEL_`-prefixed variables inherited from the ambient environment are
+/// dropped before [envVars] is applied, so the child sees exactly the
+/// variables the test asked for and nothing else. Without that, a developer
+/// with `OTEL_` variables exported gets failures CI never reproduces.
 ///
 /// Note [Process.run]'s `includeParentEnvironment` must be false for that
 /// removal to mean anything: it defaults to true, which merges `environment`
@@ -62,7 +62,7 @@ Future<String> runWithEnv(
 }) async {
   final root = await packageRoot();
   final env = Map<String, String>.from(Platform.environment)
-    ..removeWhere((key, _) => key.startsWith('OTEL_') || key.startsWith('DAR_'))
+    ..removeWhere((key, _) => key.startsWith('OTEL_'))
     ..addAll(envVars);
   final result = await Process.run(
     Platform.executable,

--- a/test/unit/util/header_redaction_test.dart
+++ b/test/unit/util/header_redaction_test.dart
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('header redaction', () {
+    tearDown(() {
+      configureHeaderLogAllowlist(null);
+    });
+
+    test('redacts every value by default', () {
+      expect(redactHeaderValue('x-trace-id', 'abc123'), '[REDACTED]');
+      expect(redactHeaderValue('authorization', 'Bearer token'), '[REDACTED]');
+    });
+
+    test('placeholder does not carry the value length', () {
+      expect(redactHeaderValue('x-api-key', 'short'),
+          redactHeaderValue('x-api-key', 'a-much-longer-secret-value'));
+    });
+
+    test('allowlisted names log their value', () {
+      configureHeaderLogAllowlist(['x-trace-id']);
+
+      expect(redactHeaderValue('x-trace-id', 'abc123'), 'abc123');
+      expect(redactHeaderValue('x-api-key', 'secret'), '[REDACTED]');
+    });
+
+    test('matching is case insensitive on both sides', () {
+      configureHeaderLogAllowlist(['X-Trace-Id']);
+
+      expect(redactHeaderValue('x-trace-id', 'abc123'), 'abc123');
+      expect(redactHeaderValue('X-TRACE-ID', 'abc123'), 'abc123');
+    });
+
+    test('matching is exact, not by prefix', () {
+      configureHeaderLogAllowlist(['x-trace']);
+
+      // the reason prefixes are not supported: 'x-' would opt in 'x-api-key'
+      expect(redactHeaderValue('x-trace-id', 'abc123'), '[REDACTED]');
+      expect(redactHeaderValue('x-trace', 'abc123'), 'abc123');
+    });
+
+    test('authorization headers cannot be allowlisted', () {
+      configureHeaderLogAllowlist(
+          ['authorization', 'Proxy-Authorization', 'x-trace-id']);
+
+      expect(redactHeaderValue('authorization', 'Bearer token'), '[REDACTED]');
+      expect(
+          redactHeaderValue('proxy-authorization', 'Basic abc'), '[REDACTED]');
+      expect(redactHeaderValue('x-trace-id', 'abc123'), 'abc123');
+      expect(allowedHeaderLogNames, {'x-trace-id'});
+    });
+
+    test('a later allowlist replaces the previous one', () {
+      configureHeaderLogAllowlist(['x-trace-id']);
+      configureHeaderLogAllowlist(['x-tenant']);
+
+      expect(redactHeaderValue('x-trace-id', 'abc123'), '[REDACTED]');
+      expect(redactHeaderValue('x-tenant', 'acme'), 'acme');
+    });
+
+    test('formatHeaderForLog keeps the name and redacts the value', () {
+      expect(
+          formatHeaderForLog('X-Api-Key', 'secret'), 'X-Api-Key: [REDACTED]');
+    });
+  });
+
+  group('parseHeaderLogAllowlist', () {
+    test('splits on commas, trims, drops empties and lowercases', () {
+      expect(parseHeaderLogAllowlist(' x-trace-id , ,X-Tenant, '),
+          {'x-trace-id', 'x-tenant'});
+    });
+
+    test('deduplicates', () {
+      expect(parseHeaderLogAllowlist('x-trace-id,X-TRACE-ID,x-trace-id'),
+          {'x-trace-id'});
+    });
+
+    test('null and empty give an empty allowlist', () {
+      expect(parseHeaderLogAllowlist(null), isEmpty);
+      expect(parseHeaderLogAllowlist(''), isEmpty);
+      expect(parseHeaderLogAllowlist(' , , '), isEmpty);
+    });
+
+    test('drops the always redacted names', () {
+      expect(parseHeaderLogAllowlist('authorization,proxy-authorization,x-ok'),
+          {'x-ok'});
+    });
+  });
+}

--- a/test/unit/util/header_redaction_test.dart
+++ b/test/unit/util/header_redaction_test.dart
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/util/header_redaction.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -37,7 +37,7 @@ void main() {
     test('matching is exact, not by prefix', () {
       configureHeaderLogAllowlist(['x-trace']);
 
-      // the reason prefixes are not supported: 'x-' would opt in 'x-api-key'
+      // 'x-' as a prefix would opt in 'x-api-key'
       expect(redactHeaderValue('x-trace-id', 'abc123'), '[REDACTED]');
       expect(redactHeaderValue('x-trace', 'abc123'), 'abc123');
     });


### PR DESCRIPTION
Closes #96.

Built to the scope in your comment. Stacked on #100, so the first commit here is that one-line fix; the diff to review is the second commit. Happy to rebase once #100 lands.

## What it does

A shared helper in `lib/src/util/header_redaction.dart`, applied at every site that logs headers. There were five, all carrying the same `authorization`-only check:

- `environment/otel_env.dart` (env parsing)
- `trace/export/otlp/http/otlp_http_span_exporter.dart`, config and request paths
- `logs/export/otlp/http/otlp_http_log_record_exporter.dart`, config and request paths

The gRPC exporters do not log header values, so nothing to do there.

Following your points:

- **Allowlist, fails closed.** Default redacts every value.
- **Exact match only.** Lowercased once at config time into a `Set<String>`, and the header lowercased at compare time. A test pins the reason prefixes are out: an `x-trace` prefix would opt in `x-api-key`.
- **Env var and `initialize()` param.** `DAR_OTLP_HEADER_LOG_ALLOWLIST` (comma separated, trimmed, empties dropped, deduplicated) and `otlpHeaderLogAllowlist:`. The parameter replaces the env var, no merging.
- **Always denied.** `authorization` and `proxy-authorization` are stripped from the allowlist at config time, so listing them cannot opt them in.
- **No length in the placeholder.** Just `[REDACTED]`.
- **Names and count still logged.**

## What the output looks like

Default:

```
OTelEnv: Parsed 3 header(s)
  authorization: [REDACTED]
  x-api-key: [REDACTED]
  x-trace-id: [REDACTED]
```

With `DAR_OTLP_HEADER_LOG_ALLOWLIST=x-trace-id`, only `x-trace-id` shows its value.

## Behaviour change

As you said, this is a security fix rather than an API break: non-`authorization` values were previously logged in the clear and now are not. It changed one existing assertion, in the test I added in #100, which asserted a non-secret value was still printed. It now asserts the name is still printed instead, which is the property that actually matters for debuggability.

## Docs

README gets a "Header Value Redaction in Debug Logs" section covering the default, why it is an allowlist and not a denylist, that it opts in values and never hides names, the exact-match rule, the always-denied pair, and why the variable is `DAR_` rather than `OTEL_` prefixed. The env var table gets a row.

## Tests

`test/unit/util/header_redaction_test.dart` covers the helper directly: default, allowlisting, case insensitivity on both sides, exact-vs-prefix, the always-denied pair surviving an attempt to allowlist them, replacement rather than accumulation, and the parser's trim/empty/dedupe behaviour.

`env_coverage_test.dart` asserts the actual log output through the subprocess helper, as you asked: everything redacted by default, only the allowlisted header showing a value, `authorization` still redacted when the env var names it, and the parameter beating the env var. I extended `runWithEnv` to pass script arguments and to clear `DAR_` vars alongside `OTEL_` ones.

`dart analyze` clean, `dart format` clean, `dart test` is 2017 passing. The 4 failures in `test/unit/context/context_propagation_test.dart` are pre-existing; I confirmed they fail the same way on a clean `main` checkout.