### PR TITLE
fix: OTEL_RESOURCE_ATTRIBUTES no longer overrides higher-precedence service.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.13-wip]
 
+### Fixed
+- **`OTEL_RESOURCE_ATTRIBUTES` no longer overrides `service.name` set by
+  higher-precedence sources** (#103). `OTel.initialize` applied that
+  variable twice: once through `EnvVarResourceDetector`, correctly ranked
+  below the service resource, and once folded into `resourceAttributes`
+  and merged last at the highest precedence. The second copy overrode
+  everything above it, so `OTEL_SERVICE_NAME` lost to `service.name` in
+  `OTEL_RESOURCE_ATTRIBUTES` (contradicting the spec, and the behaviour
+  `OTelEnv.getServiceConfig` already implemented correctly), and — more
+  seriously — an explicit `serviceName:` argument silently lost to an
+  environment variable. The precedence is now, highest first: explicit
+  argument, `OTEL_SERVICE_NAME`, `service.name` in
+  `OTEL_RESOURCE_ATTRIBUTES`, default. `service.version` follows the same
+  ordering. Non-service attributes from `OTEL_RESOURCE_ATTRIBUTES` are
+  unaffected and keep their existing precedence.
+
 ## [1.1.0-beta.12] - 2026-07-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Thanks to @abidiahmedcom; reported by @yuzurihaaa (#213, #220, #228).
 
+- **`OTEL_RESOURCE_ATTRIBUTES` no longer overrides `service.name` set by
+  higher-precedence sources** (#103). `OTel.initialize` applied that
+  variable twice: once through `EnvVarResourceDetector`, correctly ranked
+  below the service resource, and once folded into `resourceAttributes`
+  and merged last at the highest precedence. The second copy overrode
+  everything above it, so `OTEL_SERVICE_NAME` lost to `service.name` in
+  `OTEL_RESOURCE_ATTRIBUTES` (contradicting the spec, and the behaviour
+  `OTelEnv.getServiceConfig` already implemented correctly), and — more
+  seriously — an explicit `serviceName:` argument silently lost to an
+  environment variable. The precedence is now, highest first: explicit
+  argument, `OTEL_SERVICE_NAME`, `service.name` in
+  `OTEL_RESOURCE_ATTRIBUTES`, default. `service.version` follows the same
+  ordering. Non-service attributes from `OTEL_RESOURCE_ATTRIBUTES` are
+  unaffected and keep their existing precedence.
+
 ## [1.1.0-beta.13] - 2026-08-13
 
 ### Security
@@ -82,22 +97,6 @@ Thanks to @abidiahmedcom; reported by @yuzurihaaa (#213, #220, #228).
   since it narrows the search space for the token. Header names and the header count are
   still logged. A header value you relied on seeing at debug level now has to be listed
   in `OTEL_DART_HEADER_LOG_ALLOWLIST`.
-
-### Fixed
-- **`OTEL_RESOURCE_ATTRIBUTES` no longer overrides `service.name` set by
-  higher-precedence sources** (#103). `OTel.initialize` applied that
-  variable twice: once through `EnvVarResourceDetector`, correctly ranked
-  below the service resource, and once folded into `resourceAttributes`
-  and merged last at the highest precedence. The second copy overrode
-  everything above it, so `OTEL_SERVICE_NAME` lost to `service.name` in
-  `OTEL_RESOURCE_ATTRIBUTES` (contradicting the spec, and the behaviour
-  `OTelEnv.getServiceConfig` already implemented correctly), and — more
-  seriously — an explicit `serviceName:` argument silently lost to an
-  environment variable. The precedence is now, highest first: explicit
-  argument, `OTEL_SERVICE_NAME`, `service.name` in
-  `OTEL_RESOURCE_ATTRIBUTES`, default. `service.version` follows the same
-  ordering. Non-service attributes from `OTEL_RESOURCE_ATTRIBUTES` are
-  unaffected and keep their existing precedence.
 
 ## [1.1.0-beta.12] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,22 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   empty strings to `null`, so every consumer (endpoint, protocol, service
   name, log level, …) reads an empty value as unset (#213).
 
-Thanks to @abidiahmedcom; reported by @yuzurihaaa (#213, #220, #228).
+  Thanks to @abidiahmedcom; reported by @yuzurihaaa (#213, #220, #228).
 
-- **`OTEL_RESOURCE_ATTRIBUTES` no longer overrides `service.name` set by
-  higher-precedence sources** (#103). `OTel.initialize` applied that
-  variable twice: once through `EnvVarResourceDetector`, correctly ranked
-  below the service resource, and once folded into `resourceAttributes`
-  and merged last at the highest precedence. The second copy overrode
-  everything above it, so `OTEL_SERVICE_NAME` lost to `service.name` in
-  `OTEL_RESOURCE_ATTRIBUTES` (contradicting the spec, and the behaviour
-  `OTelEnv.getServiceConfig` already implemented correctly), and — more
-  seriously — an explicit `serviceName:` argument silently lost to an
-  environment variable. The precedence is now, highest first: explicit
-  argument, `OTEL_SERVICE_NAME`, `service.name` in
+- **`service.name` in `OTEL_RESOURCE_ATTRIBUTES` no longer overrides an
+  explicit `serviceName:` argument or `OTEL_SERVICE_NAME`** (#103).
+  Precedence is now, highest first: explicit argument, `OTEL_SERVICE_NAME`,
   `OTEL_RESOURCE_ATTRIBUTES`, default. `service.version` follows the same
-  ordering. Non-service attributes from `OTEL_RESOURCE_ATTRIBUTES` are
-  unaffected and keep their existing precedence.
+  order.
+
+- `OTEL_LOG_LEVEL` now takes effect at the start of `OTel.initialize`, so
+  debug logging covers the environment parsing itself.
 
 ## [1.1.0-beta.13] - 2026-08-13
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -160,6 +160,10 @@ class OTel {
   }) async {
     // Has to run before anything logs OTLP headers.
     OTelEnv.applyHeaderLogAllowlist(otlpHeaderLogAllowlist);
+    // Apply OTEL_LOG_LEVEL before the env parsing below emits its debug
+    // output — otherwise an env-configured debug level misses exactly the
+    // lines that diagnose env configuration.
+    initializeLogging();
 
     // Apply environment variables only if parameters are not provided
     final envServiceName = serviceName == null
@@ -277,8 +281,6 @@ class OTel {
     _defaultTimeProvider = timeProvider;
     OTel.defaultTracerName = tracerName ?? _defaultTracerName;
     OTel.defaultTracerVersion = tracerVersion ?? defaultTracerVersion;
-    // Initialize logging from environment variables if needed
-    initializeLogging();
 
     final createdFactory = factoryFactory(
       apiEndpoint: endpoint ?? defaultEndpoint,

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -200,8 +200,20 @@ class OTel {
     // Get otlpConfig for exporter creation later
     final otlpConfigForExporter = OTelEnv.getOtlpConfig(signal: 'traces');
 
-    // Get resource attributes from environment and merge with provided ones
-    final envResourceAttrs = OTelEnv.getResourceAttributes();
+    // Get resource attributes from environment and merge with provided ones.
+    //
+    // service.name and service.version are deliberately excluded here. They
+    // were already resolved into serviceName/serviceVersion above by
+    // getServiceConfig(), which applies the spec precedence -- OTEL_SERVICE_NAME
+    // outranks service.name in OTEL_RESOURCE_ATTRIBUTES -- and an explicit
+    // argument outranks both. These attributes are merged last, at the highest
+    // precedence, so leaving the service keys in would let
+    // OTEL_RESOURCE_ATTRIBUTES override the resolved values and silently beat
+    // programmatic configuration.
+    final envResourceAttrs =
+        Map<String, Object>.from(OTelEnv.getResourceAttributes())
+          ..remove(Service.serviceName.key)
+          ..remove(Service.serviceVersion.key);
     if (envResourceAttrs.isNotEmpty) {
       if (resourceAttributes != null) {
         // Merge with provided attributes - provided ones take precedence

--- a/test/integration/resource_attributes_test.dart
+++ b/test/integration/resource_attributes_test.dart
@@ -22,6 +22,9 @@ void main() {
 
         // Test only runs if OTEL_RESOURCE_ATTRIBUTES is set
         if (resourceAttrs != null && resourceAttrs.isNotEmpty) {
+          // detect() requires an installed factory; without this the body
+          // throws StateError the moment the guard above is satisfied.
+          await OTel.initialize();
           final detector = EnvVarResourceDetector(envService);
           final resource = await detector.detect();
           final attrs = resource.attributes.toMap();
@@ -38,6 +41,9 @@ void main() {
 
       // This test expects: OTEL_RESOURCE_ATTRIBUTES="key3=value%20with%20spaces"
       if (resourceAttrs != null && resourceAttrs.contains('%20')) {
+        // detect() requires an installed factory; without this the body
+        // throws StateError the moment the guard above is satisfied.
+        await OTel.initialize();
         final detector = EnvVarResourceDetector(envService);
         final resource = await detector.detect();
         final attrs = resource.attributes.toMap();
@@ -56,6 +62,9 @@ void main() {
 
       // This test expects: OTEL_RESOURCE_ATTRIBUTES="key1=value1\\,part2"
       if (resourceAttrs != null && resourceAttrs.contains('\\,')) {
+        // detect() requires an installed factory; without this the body
+        // throws StateError the moment the guard above is satisfied.
+        await OTel.initialize();
         final detector = EnvVarResourceDetector(envService);
         final resource = await detector.detect();
         final attrs = resource.attributes.toMap();

--- a/test/unit/otel_service_precedence_test.dart
+++ b/test/unit/otel_service_precedence_test.dart
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Precedence of service.name and service.version at initialization.
+//
+// The spec requires, highest to lowest:
+//   explicit argument
+//     > OTEL_SERVICE_NAME
+//       > service.name in OTEL_RESOURCE_ATTRIBUTES
+//         > default
+//
+// Regression coverage for #103: OTEL_RESOURCE_ATTRIBUTES was applied twice,
+// once via EnvVarResourceDetector (correctly, below the service resource) and
+// once folded into resourceAttributes and merged last at the highest
+// precedence. The second copy overrode both rungs above it, so an explicit
+// serviceName argument silently lost to an environment variable.
+//
+// Both merge paths are covered: detectPlatformResources true routes
+// OTEL_RESOURCE_ATTRIBUTES through EnvVarResourceDetector, false does not.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+/// The value of [key] in [resource], or null when absent.
+String? attributeOf(Resource resource, String key) {
+  for (final attribute in resource.attributes.toList()) {
+    if (attribute.key == key) return '${attribute.value}';
+  }
+  return null;
+}
+
+void main() {
+  group('service.name / service.version precedence', () {
+    tearDown(() async {
+      try {
+        await OTel.shutdown();
+      } catch (_) {}
+      await OTel.reset();
+      EnvironmentService.testOverrides = null;
+    });
+
+    /// Initializes with [vars] as the entire environment and returns the
+    /// resulting default resource.
+    Future<Resource> initWith(
+      Map<String, String> vars, {
+      String? serviceName,
+      String? serviceVersion,
+      Attributes? resourceAttributes,
+      bool detectPlatformResources = false,
+    }) async {
+      EnvironmentService.testOverrides = {
+        'OTEL_TRACES_EXPORTER': 'none',
+        'OTEL_METRICS_EXPORTER': 'none',
+        'OTEL_LOGS_EXPORTER': 'none',
+        ...vars,
+      };
+      await OTel.initialize(
+        serviceName: serviceName,
+        serviceVersion: serviceVersion,
+        resourceAttributes: resourceAttributes,
+        detectPlatformResources: detectPlatformResources,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      return OTel.defaultResource!;
+    }
+
+    for (final detectPlatformResources in [false, true]) {
+      final suffix = ' (detectPlatformResources: $detectPlatformResources)';
+
+      test('explicit serviceName beats OTEL_RESOURCE_ATTRIBUTES$suffix',
+          () async {
+        final resource = await initWith(
+          {'OTEL_RESOURCE_ATTRIBUTES': 'service.name=from-resource-attrs'},
+          serviceName: 'explicit-service',
+          detectPlatformResources: detectPlatformResources,
+        );
+        expect(
+          attributeOf(resource, 'service.name'),
+          equals('explicit-service'),
+        );
+      });
+
+      test('explicit serviceVersion beats OTEL_RESOURCE_ATTRIBUTES$suffix',
+          () async {
+        final resource = await initWith(
+          {'OTEL_RESOURCE_ATTRIBUTES': 'service.version=8.8.8'},
+          serviceVersion: '9.9.9',
+          detectPlatformResources: detectPlatformResources,
+        );
+        expect(attributeOf(resource, 'service.version'), equals('9.9.9'));
+      });
+
+      test('OTEL_SERVICE_NAME beats OTEL_RESOURCE_ATTRIBUTES$suffix', () async {
+        final resource = await initWith(
+          {
+            'OTEL_SERVICE_NAME': 'from-service-name',
+            'OTEL_RESOURCE_ATTRIBUTES': 'service.name=from-resource-attrs',
+          },
+          detectPlatformResources: detectPlatformResources,
+        );
+        expect(
+          attributeOf(resource, 'service.name'),
+          equals('from-service-name'),
+        );
+      });
+
+      test('OTEL_RESOURCE_ATTRIBUTES applies when nothing outranks it$suffix',
+          () async {
+        final resource = await initWith(
+          {
+            'OTEL_RESOURCE_ATTRIBUTES':
+                'service.name=from-resource-attrs,service.version=8.8.8',
+          },
+          detectPlatformResources: detectPlatformResources,
+        );
+        expect(
+          attributeOf(resource, 'service.name'),
+          equals('from-resource-attrs'),
+        );
+        expect(attributeOf(resource, 'service.version'), equals('8.8.8'));
+      });
+
+      test('non-service attributes still come through$suffix', () async {
+        final resource = await initWith(
+          {
+            'OTEL_RESOURCE_ATTRIBUTES':
+                'service.name=from-resource-attrs,deployment.environment=staging',
+          },
+          serviceName: 'explicit-service',
+          detectPlatformResources: detectPlatformResources,
+        );
+        // The service key is overridden, everything else is preserved.
+        expect(
+          attributeOf(resource, 'service.name'),
+          equals('explicit-service'),
+        );
+        expect(
+          attributeOf(resource, 'deployment.environment'),
+          equals('staging'),
+        );
+      });
+    }
+
+    test('explicit resourceAttributes still beat the environment', () async {
+      final resource = await initWith(
+        {
+          'OTEL_RESOURCE_ATTRIBUTES':
+              'deployment.environment=staging,service.name=from-resource-attrs',
+        },
+        resourceAttributes: OTel.attributesFromMap({
+          'deployment.environment': 'production',
+        }),
+      );
+      expect(
+        attributeOf(resource, 'deployment.environment'),
+        equals('production'),
+      );
+    });
+
+    test('defaults apply with an empty environment', () async {
+      final resource = await initWith({});
+      expect(attributeOf(resource, 'service.name'), isNotNull);
+      expect(attributeOf(resource, 'service.name'), isNotEmpty);
+      expect(attributeOf(resource, 'service.version'), equals('1.0.0'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #103. Split out of #99, which stays test-infrastructure-only.

## The bug

`OTel.initialize` applies `OTEL_RESOURCE_ATTRIBUTES` **twice**:

1. through `EnvVarResourceDetector`, correctly ranked *below* the service resource (`otel.dart:293`); and
2. folded into `resourceAttributes` (`otel.dart:204-216`) and merged **last**, at the highest precedence (`otel.dart:307`).

The second copy overrode everything above it:

- **`OTEL_SERVICE_NAME` lost to `service.name` in `OTEL_RESOURCE_ATTRIBUTES`** — contradicting the spec, and contradicting `OTelEnv.getServiceConfig`, which already implements the ordering correctly and documents it at `otel_env.dart:312`.
- **An explicit `serviceName:` argument silently lost to an environment variable.** Programmatic configuration must outrank the environment; this is the more serious of the two.

## The fix

`getServiceConfig` already resolves `service.name`/`service.version` with the correct precedence, and `initialize` materialises both into the service resource — so the env-derived copy of *those two keys* is pure duplication. Excluding them from the attributes merged last restores the ladder. Every other key keeps its existing precedence, including non-service entries of the same variable.

Resulting order, highest first: **explicit argument → `OTEL_SERVICE_NAME` → `service.name` in `OTEL_RESOURCE_ATTRIBUTES` → default.**

| Case | Before | After |
|---|---|---|
| explicit `serviceName:` vs `OTEL_RESOURCE_ATTRIBUTES` | `from-ra` ❌ | `explicit-service` ✅ |
| `OTEL_SERVICE_NAME` vs `OTEL_RESOURCE_ATTRIBUTES` | `from-ra` ❌ | `from-env-svc` ✅ |
| `OTEL_RESOURCE_ATTRIBUTES` alone | `from-ra` ✅ | `from-ra` ✅ |
| clean environment | default ✅ | default ✅ |
| `deployment.environment` (non-service key) | preserved ✅ | preserved ✅ |

## Why CI never caught it

CI runs with a clean environment, so `OTEL_RESOURCE_ATTRIBUTES` is unset and the clobber never happens. It only surfaced for developers with the variable exported — which is exactly why it first looked like the tests were making bad assumptions.

## Tests

New `test/unit/otel_service_precedence_test.dart`: 12 tests covering each rung across **both** `detectPlatformResources` paths (true routes the variable through `EnvVarResourceDetector`, false does not). Confirmed they bite — with the fix reverted, **8 of the 12 fail**.

Also fixes three tests in `test/integration/resource_attributes_test.dart` that called `detect()` with no factory installed and threw `StateError` the moment their environment guard was satisfied. CI's clean environment meant those guards never fired, so the bodies had never actually run.

| Check | Result |
|---|---|
| Full suite, clean environment | 2016 passed, 13 skipped, 0 failed |
| `basic_test` + both integration files, dirty environment | 10 passed (was 5 failing) |
| New precedence tests with fix reverted | 8 of 12 fail, as intended |
| `dart analyze --fatal-infos` / `dart format` | clean |

Behaviour change is user-visible, so it carries a CHANGELOG entry under `1.1.0-beta.13-wip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)