### PR TITLE
Release prep for 1.1.0-beta.13: CHANGELOG, README, test script --fail-fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   config. Treat any debug logs collected from an affected build as containing that
   credential and rotate it.
 
+  Tracked as [GHSA-4rh6-c2v5-374w][ghsa] (CWE-532). Affects `>= 1.0.0-alpha` on this
+  line and `>= 0.9.0` on the stable channel; see the 0.9.8 entry.
+
+[ghsa]: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/security/advisories/GHSA-4rh6-c2v5-374w
+
 ### Added
 
 - **`OTEL_DART_HEADER_LOG_ALLOWLIST`**, and `OTel.initialize(otlpHeaderLogAllowlist:)`,
@@ -402,11 +407,24 @@ your pubspec allows prereleases — it is what these entries point at.
 Stable-channel republication of `1.1.0-beta.13`. Depends on
 `dartastic_opentelemetry_api: ^0.9.1`.
 
-Carries the OTLP debug-log header redaction described under `1.1.0-beta.13-wip`
-(#100, #96) — **and** the `1.1.0-beta.12` changes, which never reached this channel:
-the `host.arch` fix (#90), registry-enum attribute keys throughout, and the removal
-of the non-registry `host.processors`, `host.locale`, and `process.num_threads`
-resource attributes. Read both entries before upgrading from 0.9.7.
+### Security
+
+- **Fixes the OTLP debug-log credential leak, [GHSA-4rh6-c2v5-374w][ghsa] (CWE-532).**
+  Every `0.9.x` release from `0.9.0` through `0.9.7` is affected: with debug logging
+  enabled, OTLP header values — including `Authorization`, `api-key`, and whatever
+  name your backend uses — were written to the log. This is the first release on the
+  stable channel that redacts them. See the `1.1.0-beta.13-wip` entry above for the
+  mechanism and for the `OTEL_DART_HEADER_LOG_ALLOWLIST` opt-in.
+
+  **If you ran any 0.9.x release with debug logging enabled and a credential in an
+  OTLP header, rotate that credential.** Upgrading alone does not undo the exposure.
+
+### Also in this release
+
+The `1.1.0-beta.12` changes, which never reached this channel: the `host.arch` fix
+(#90), registry-enum attribute keys throughout, and the removal of the non-registry
+`host.processors`, `host.locale`, and `process.num_threads` resource attributes.
+Read the `1.1.0-beta.12` entry as well before upgrading from 0.9.7.
 
 ## [0.9.7] - 2026-07-20
 Stable-channel republication of `1.1.0-beta.11` — docs only over 0.9.6. Depends on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.13-wip]
 
+### Security
+
+- **OTLP header values are no longer written to the debug log.** Two leaks are fixed:
+  - Debug logging logged the raw values of all `OTEL_EXPORTER_OTLP_HEADERS` and the 
+    signal-specific `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_HEADERS`. The message was
+    emitted above the per-header loop that redacts `Authorization`, so the credential
+    reached the log regardless of that redaction. Thanks to @arpitjain099 (#100).
+  - `OtlpHttpSpanExporter` and `OtlpHttpLogRecordExporter` printed every header value
+    except `Authorization`, at construction and on each export request — including
+    headers configured in code, which never pass through an environment variable.
+
+  **Who is affected:** applications running with `OTEL_LOG_LEVEL=DEBUG` (or `OTelLog` at
+  debug) and a credential in an OTLP header, from the environment or from exporter
+  config. Treat any debug logs collected from an affected build as containing that
+  credential and rotate it.
+
+### Added
+
+- **`OTEL_DART_HEADER_LOG_ALLOWLIST`**, and `OTel.initialize(otlpHeaderLogAllowlist:)`,
+  name the OTLP headers whose values may appear in the debug log (#96). 
+  Names match exactly, case insensitively; the code parameter replaces
+  the environment variable rather than adding to it; `authorization` and
+  `proxy-authorization` are never logged even when listed. Thanks to @arpitjain099 (#101).
+
+### Changed
+
+- Debug logs now print `name: [REDACTED]` for any header value not on the allowlist,
+  replacing `Authorization: [REDACTED - length: N]` — the length is dropped on purpose,
+  since it narrows the search space for the token. Header names and the header count are
+  still logged. A header value you relied on seeing at debug level now has to be listed
+  in `OTEL_DART_HEADER_LOG_ALLOWLIST`.
+
 ## [1.1.0-beta.12] - 2026-07-20
 
 ### Changed
@@ -356,6 +388,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Log Signal SDK implementation
 - Upgraded to dartastic_opentelemetry_api: ^1.0.0-alpha with Log Signal API
+
+## The 0.9.x stable channel
+
+`0.9.4` and up are not a separate line of development. Each one is the current
+`1.1.0-beta.x` code republished under a `0.9.x` version so that users who have not
+opted into prereleases still get the fixes before the v1 release. The code is
+identical to the beta it names; only the version stamp and the
+`dartastic_opentelemetry_api` constraint differ. Prefer the `1.1.0-beta.x` line if
+your pubspec allows prereleases — it is what these entries point at.
+
+## [0.9.8] - unreleased
+Stable-channel republication of `1.1.0-beta.13`. Depends on
+`dartastic_opentelemetry_api: ^0.9.1`.
+
+Carries the OTLP debug-log header redaction described under `1.1.0-beta.13-wip`
+(#100, #96) — **and** the `1.1.0-beta.12` changes, which never reached this channel:
+the `host.arch` fix (#90), registry-enum attribute keys throughout, and the removal
+of the non-registry `host.processors`, `host.locale`, and `process.num_threads`
+resource attributes. Read both entries before upgrading from 0.9.7.
+
+## [0.9.7] - 2026-07-20
+Stable-channel republication of `1.1.0-beta.11` — docs only over 0.9.6. Depends on
+`dartastic_opentelemetry_api: ^0.9.1`.
+
+Adds the `1.1.0-beta.10` fixes over 0.9.6: baggage extraction preserving context and
+endpoint scheme determining TLS (#89), OTLP/JSON enum fields encoded as integers per
+spec (#86), and public `MetricTransformer.transformMetrics` (#85).
+
+## [0.9.6] - 2026-07-18
+Stable-channel republication of `1.1.0-beta.9`. Depends on
+`dartastic_opentelemetry_api: ^0.9.1`, itself the republication of api `1.0.0-rc.1`
+— note the api constraint moved off the `1.0.0-beta.x` range that 0.9.5 used.
+
+Covers everything from `1.1.0-beta.1` through `1.1.0-beta.9`; see those entries for
+the detail. Highlights for anyone coming from 0.9.5: `OTEL_PROPAGATORS` support (#42,
+#76), BatchSpanProcessor environment variables (#59), comma-separated
+`OTEL_*_EXPORTER` lists (#79), OTLP/HTTP-JSON wire format (#45), OTLP/JSON trace and
+span ids encoded as hex per spec (#60), `LoggerProvider` shutdown fixes (#33, #41),
+web/wasm safety (#36), and the removal of the non-standard `dartasticApiKey` and
+`tenantId` (#78).
+
+## [0.9.5] - 2026-05-09
+Stable-channel republication of `1.1.0-beta` — the first of these. Depends on
+`dartastic_opentelemetry_api: ^1.0.0-beta.2`. Covers `1.0.0-alpha` through
+`1.1.0-beta` for users still on 0.9.3, most notably the Log signal SDK.
+
+`0.9.4` was stamped in git a minute before 0.9.5 with the same code but never published to
+pub.dev; there is no 0.9.4 release.
 
 ## [0.9.3] - 2025-10-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,27 +18,45 @@ best choice for production Flutter applications.
 
 Dartastic and Flutterrific OTel are made with 💙 by Michael Bushe at [Dartastic.io](https://dartastic.io)
 
-## Commercial Support
+## Commercial: Dartastic.io - Pro OpenTelemetry
 
-[Dartastic.io](https://dartastic.io) tools and services for Dart and Flutter teams shipping to production.
-* **Dartastic Pro OTel Runtime**
-  * Native OTel runtime that takes OTel of the UI thread or server threads.
-    * Detects native crashes
-    * Identifies the janky widget
+[Dartastic.io](https://dartastic.io) provides tools and services for Dart and Flutter, focused on OpenTelemetry.
+* **[Dartastic Native OTel](https://dartastic.io/otel/)**
+  * A native Rust OTel runtime.
+    * Dozens of attributes beyond the spec that work with [Dartastic Observatory](https://dartastic.io/observatory/) or your OTel backend.
+    * Moves OTel onto native threads.
+    * Detects native crashes.
+    * Identifies the janky widget.
     * Strips PII out of your data on the fly.
-    * Sends source code lines with error spans with Symbolizer.
-    * Metrics from iOS, Android and Linux, standard and beyond the standard. 
+    * Metrics from iOS, Android and Linux, standard and beyond the standard.
     * Use with any o11y backend.
-  * Professionally supported version of this open source dartastic_opentelemetry package and dartastic_opentelemetry_api - and their future CNCF equivalents.
-  * Over 50 OSS OpenTelemetry integration libraries for Dart and Flutter - dio, shelf, logger...
-  * Over 600 Pro OpenTelemetry integration libraries for Dart and Flutter - anthropic, aws, azure, stripe...
-* **Dartastic Pub** [pub.dartastic.io](pub.dartastic.io) Privately share your packages and plugins with your team,
-  partners and customers.
-* **Dartastic Symbolizer** [symbolizer.dartastic.io](symbolizer.dartastic.io) Turn production errors into
-  source code lines with a Web API call. Squash Dart and Flutter bugs fast and keep your source code artifacts private.
-* **Dartastic Hosted** - spin up a private observability ecosystem customized for Flutter and Dart - private pub server, private unlimited Symbolizer, custom dashboards for Dart and Flutter.
+    * Passes the same tests as dartastic_opentelemetry.
+* **[Dartastic Observatory](https://dartastic.io/observatory/)** - live in minutes 
+  * An observability backend with first class support for Flutter and Dart.
+  * Flutter App Health Dashboard.
+  * Mobile Release Health Dashboard.
+  * Crash tracking - track crashes per release and platform.
+  * Cloud Observatory - low cost, shared infrastructure.
+  * Hosted Observatory - your private observability box that scales.
+* **[Dartastic Pub](https://dartastic.io/pub/)**
+  * Your private Dart/Flutter package registry.
+  * Publish and consume with your team, partners, and customers.
+  * Fine-grained access controls with quick revocations.
+* **[Dartastic Symbolizer](https://dartastic.io/symbolizer/)**
+  * Get source code lines from binary data in error spans.
+  * Integrated with Dartastic Observatory.
+  * Build your own integration with the Dartastic Symbolizer Web API.
+* **[Dartastic Labs](https://dartastic.io/otel/#labs)**
+    * Over 50 OSS OpenTelemetry integration libraries for Dart and Flutter - dio, shelf, logger...
+    * Over 600 Pro OpenTelemetry integration libraries for Dart and Flutter - anthropic, aws, azure, stripe...
+* **[Professional Support](https://dartastic.io/support/)**
+  * Professional support for Dart and Flutter OpenTelemetry.
+  * Support for [Dartastic Native OTel](https://dartastic.io/otel/) and [Dartastic Observatory](https://dartastic.io/observatory/).
+  * Support for `dartastic_opentelemetry` and its future CNCF equivalents.
+  * Priority bug fixes.
+  * Support SLAs.
 
-## Features
+## Features of `dartastic_opentelemetry` 
 
 - 🚀 **Friendly API**: An easy to use, discoverable, immutable, typesafe API that feels familiar to Dart developers.
 - 📐 **Standards Compliant**: Complies with the [OpenTelemetry specification](https://opentelemetry.io/docs/specs/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,15 @@
 
 Below are the versions of the OpenTelemetry SDK for Dart that are currently supported with security updates:
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.8.x   | :white_check_mark: |
-| < 0.8.0 | :x:                |
+| Version           | Supported          |
+| ----------------- | ------------------ |
+| 1.1.0-beta.x      | :white_check_mark: |
+| 0.9.x             | :white_check_mark: |
+| 0.8.x and earlier | :x:                |
+
+The `0.9.x` line is not separate development. Each `0.9.x` release is the current
+`1.1.0-beta.x` code republished under a `0.9.x` version, so that users who have not
+opted into prereleases still receive fixes. A security fix lands on both lines.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,13 +18,20 @@ opted into prereleases still receive fixes. A security fix lands on both lines.
 
 We take the security of OpenTelemetry SDK for Dart seriously. If you believe you have found a security vulnerability, please follow these steps:
 
-1. **Do not disclose the vulnerability publicly**
-2. **Contact the maintainers privately** - Email security@dartastic.io with details of the vulnerability
+1. **Do not disclose the vulnerability publicly** - please do not open a public issue or
+   pull request describing it. That makes the vulnerability public before a fix exists.
+2. **Report it privately**, by either route:
+   - **Preferred:** [open a private report on GitHub][report]. Private vulnerability
+     reporting is enabled on this repository, so the report is visible only to the
+     maintainers and stays attached to the advisory that fixes it.
+   - Or email security@dartastic.io.
 3. **Provide sufficient information** to reproduce the issue, including:
    - Description of the vulnerability
    - Steps to reproduce
    - Potential impact
    - Suggested mitigation if available
+
+[report]: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/security/advisories/new
 
 ## What to Expect
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -12,18 +12,24 @@ void main() {
     late HttpServer server;
     late int port;
     late List<HttpRequest> receivedRequests;
+    late List<List<int>> receivedBodies;
 
     setUp(() async {
       await OTel.reset();
       receivedRequests = [];
+      receivedBodies = [];
       server = await HttpServer.bind('localhost', 0);
       port = server.port;
       server.listen((request) async {
         receivedRequests.add(request);
-        // Drain the request body so the connection completes properly
-        await request.fold<List<int>>(
-          [],
-          (bytes, chunk) => bytes..addAll(chunk),
+        // Drain the request body so the connection completes properly, and
+        // keep it: a test that asserts on the wire format reads it from here
+        // rather than rebinding the server on the same port.
+        receivedBodies.add(
+          await request.fold<List<int>>(
+            [],
+            (bytes, chunk) => bytes..addAll(chunk),
+          ),
         );
         request.response.statusCode = 200;
         await request.response.close();
@@ -85,19 +91,6 @@ void main() {
     test(
         'export with httpJson protocol sends application/json + proto3-JSON body',
         () async {
-      // Rebind the server so we can capture the request body for this test.
-      await server.close(force: true);
-      receivedRequests = [];
-      var capturedBody = <int>[];
-      server = await HttpServer.bind('localhost', port);
-      server.listen((request) async {
-        receivedRequests.add(request);
-        capturedBody = await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
-        request.response.statusCode = 200;
-        await request.response.close();
-      });
-
       final exporter = OtlpHttpMetricExporter(
         OtlpHttpMetricExporterConfig(
           endpoint: 'http://localhost:$port',
@@ -116,7 +109,7 @@ void main() {
 
       // Body must decode to a Map with the proto3-JSON top-level
       // `resourceMetrics` key.
-      final decoded = jsonDecode(utf8.decode(capturedBody));
+      final decoded = jsonDecode(utf8.decode(receivedBodies.first));
       expect(decoded, isA<Map<String, dynamic>>());
       expect((decoded as Map).containsKey('resourceMetrics'), isTrue);
       expect(decoded['resourceMetrics'], isA<List>());

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -12,18 +12,24 @@ void main() {
     late HttpServer server;
     late int port;
     late List<HttpRequest> receivedRequests;
+    late List<List<int>> receivedBodies;
 
     setUp(() async {
       await OTel.reset();
       receivedRequests = [];
+      receivedBodies = [];
       server = await HttpServer.bind('localhost', 0);
       port = server.port;
       server.listen((request) async {
         receivedRequests.add(request);
-        // Drain the request body so the connection completes properly
-        await request.fold<List<int>>(
-          [],
-          (bytes, chunk) => bytes..addAll(chunk),
+        // Drain the request body so the connection completes properly, and
+        // keep it: a test that asserts on the wire format reads it from here
+        // rather than rebinding the server on the same port.
+        receivedBodies.add(
+          await request.fold<List<int>>(
+            [],
+            (bytes, chunk) => bytes..addAll(chunk),
+          ),
         );
         request.response.statusCode = 200;
         await request.response.close();
@@ -89,19 +95,6 @@ void main() {
         ),
       );
 
-      // Capture the request body for shape validation.
-      var capturedBody = <int>[];
-      receivedRequests.clear();
-      await server.close(force: true);
-      server = await HttpServer.bind('localhost', port);
-      server.listen((request) async {
-        receivedRequests.add(request);
-        capturedBody = await request
-            .fold<List<int>>([], (bytes, chunk) => bytes..addAll(chunk));
-        request.response.statusCode = 200;
-        await request.response.close();
-      });
-
       final spans = createTestSpans();
       await exporter.export(spans);
 
@@ -114,7 +107,7 @@ void main() {
       // The body must be valid JSON that decodes to a Map shaped like a
       // proto3-JSON `ExportTraceServiceRequest` — the top-level key
       // `resourceSpans` is the spec-defined field name.
-      final decoded = jsonDecode(utf8.decode(capturedBody));
+      final decoded = jsonDecode(utf8.decode(receivedBodies.first));
       expect(decoded, isA<Map<String, dynamic>>());
       expect((decoded as Map).containsKey('resourceSpans'), isTrue);
       expect(decoded['resourceSpans'], isA<List>());

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -10,6 +10,7 @@ cd "$(dirname "$0")/.." || exit 1
 # Need trace logging for coverage of debug and trace logs
 LOG_LEVEL="trace"
 CONCURRENCY="10"
+FAIL_FAST="false"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -21,11 +22,19 @@ while [[ $# -gt 0 ]]; do
       CONCURRENCY="$2"
       shift 2
       ;;
+    --fail-fast)
+      FAIL_FAST="true"
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--log LEVEL] [--concurrency N]"
+      echo "Usage: $0 [--log LEVEL] [--concurrency N] [--fail-fast]"
       echo "  --log LEVEL        Set log level (trace, debug, info, warn, error, fatal)"
       echo "  --concurrency N    Set test concurrency (default: 10 for coverage)"
+      echo "  --fail-fast        Stop after the first failing test. Suites already"
+      echo "                     in flight still report, so pair with"
+      echo "                     --concurrency 1 to stop at exactly one failure."
+      echo "                     The coverage report is skipped when tests fail."
       exit 1
       ;;
   esac
@@ -63,7 +72,12 @@ mkdir -p coverage
 # `test/web/` are tagged `@TestOn('browser')` and are skipped on the VM
 # target.
 echo "Running tests with coverage..."
-dart test --chain-stack-traces --coverage=coverage --concurrency="$CONCURRENCY" --exclude-tags="fail" ./test
+FAIL_FAST_FLAG=""
+if [ "$FAIL_FAST" = "true" ]; then
+  FAIL_FAST_FLAG="--fail-fast"
+  echo "Stopping after the first failure"
+fi
+dart test --chain-stack-traces --coverage=coverage --concurrency="$CONCURRENCY" --exclude-tags="fail" $FAIL_FAST_FLAG ./test
 
 # Generate LCOV coverage report, excluding certain directories
 dart run coverage:format_coverage  --in=./coverage --package=./lib --report-on=lib/ --lcov --out=coverage/lcov.info --check-ignore

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -3,6 +3,7 @@
 # Parse command line arguments
 LOG_LEVEL="info"
 CONCURRENCY="20"
+FAIL_FAST="false"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -14,11 +15,18 @@ while [[ $# -gt 0 ]]; do
       CONCURRENCY="$2"
       shift 2
       ;;
+    --fail-fast)
+      FAIL_FAST="true"
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--log LEVEL] [--concurrency N]"
+      echo "Usage: $0 [--log LEVEL] [--concurrency N] [--fail-fast]"
       echo "  --log LEVEL        Set log level (trace, debug, info, warn, error, fatal)"
       echo "  --concurrency N    Set test concurrency (default: auto)"
+      echo "  --fail-fast        Stop after the first failing test. Suites already"
+      echo "                     in flight still report, so pair with"
+      echo "                     --concurrency 1 to stop at exactly one failure."
       exit 1
       ;;
   esac
@@ -57,6 +65,11 @@ TEST_CMD="dart test ./test"
 if [ -n "$CONCURRENCY" ]; then
   TEST_CMD="$TEST_CMD --concurrency=$CONCURRENCY"
   echo "Setting concurrency to: $CONCURRENCY"
+fi
+
+if [ "$FAIL_FAST" = "true" ]; then
+  TEST_CMD="$TEST_CMD --fail-fast"
+  echo "Stopping after the first failure"
 fi
 
 # Run all tests


### PR DESCRIPTION
Release-prep changes for `1.1.0-beta.13`, split out of `main` so they go through review rather than landing directly.

## CHANGELOG

Documents the OTLP debug-log header redaction that landed in #101:

- Both leaks, not just the reported one — the raw env var value in `OTelEnv.getOtlpConfig` (#100), **and** every non-`Authorization` header value printed by `OtlpHttpSpanExporter` / `OtlpHttpLogRecordExporter` at construction and on each export, including headers configured in code that never touch an environment variable.
- The new `OTEL_DART_HEADER_LOG_ALLOWLIST` / `OTel.initialize(otlpHeaderLogAllowlist:)` opt-in (#96).
- The default flip: every header value is now `[REDACTED]`, without the length. Anyone relying on seeing a header value at debug level has to allowlist it.

Backfills the **0.9.x stable channel**, which had no entries past 0.9.3. Each republication wrote its entry only on the release tag, so none reached `main`. Adds 0.9.5, 0.9.6, 0.9.7 and an unreleased 0.9.8, with a note explaining that the channel is the current beta republished under a 0.9.x stamp. 0.9.4 was stamped in git but never published to pub.dev, so it gets no entry.

## README

Rewrites the commercial section around the current Dartastic.io offerings, and fixes the Pub and Symbolizer links — they were relative (`[pub.dartastic.io](pub.dartastic.io)`) and 404'd on both GitHub and pub.dev.

## tool

Adds `--fail-fast` to `test.sh` and `coverage.sh`, passing through to `dart test --fail-fast`. In `coverage.sh`, `set -e` means a test failure exits before `format_coverage`/`genhtml`, so a failed run doesn't leave a half-built report.

## Review notes

Two things in the CHANGELOG to confirm before publishing:

- `[0.9.8] - unreleased` assumes 0.9.8 is a straight republication of `1.1.0-beta.13`. Written that way, it also carries `1.1.0-beta.12` — the `host.arch` fix (#90) and the registry-enum keys — which never reached the 0.9.x channel. If the releases are sequenced differently, that entry needs splitting.
- The `dartastic_opentelemetry_api: ^0.9.1` pin for 0.9.8 is carried over from 0.9.6/0.9.7. Still correct today, wrong if beta.13 adopts a newer api first.