### PR TITLE
Fix OTLP spec-compliance issues (#213, #220, #228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Added
+
 - `TracerProvider.hasSpanProcessors` — allocation-free check for registered
   span processors.
+
+- **OTLP exporters send an identifying `User-Agent` header.** Per the OTLP
+  spec, OTLP requests SHOULD identify the exporter, language, and version.
+  Every OTLP request now carries `OTel-OTLP-Exporter-Dart/<version>` (HTTP
+  headers on the HTTP exporters; `ChannelOptions.userAgent` on the gRPC
+  exporters). A user-supplied `user-agent` header is prepended to the default
+  rather than replacing it (#228).
+
+- **`OTel.defaultGrpcEndpoint`** (`http://localhost:4317`), the OTLP/gRPC
+  default endpoint. The endpoint default is now picked per signal after the
+  protocol is resolved instead of defaulting everything to the HTTP port
+  4318 (#220).
 
 ### Fixed
 
 - `Tracer.enabled` now returns `false` when `TracerProvider` has no span
   processor(s) registered, per the Trace SDK spec, sparing span-creation cost
   when nothing is listening. Thanks to @abidiahmedcom (#138, #175).
+
+- **OTLP/gRPC exporters now default to port 4317, not 4318.** The OTLP spec
+  defaults the endpoint to `http://localhost:4317` for OTLP/gRPC and
+  `http://localhost:4318` for the two HTTP protocols. Previously a single
+  4318 default was applied before the protocol was known, so gRPC-only
+  deployments silently exported to the wrong port (#220).
+
+- **An empty environment variable value is treated as unset.** Per the spec,
+  an empty value of an environment variable MUST be interpreted the same way
+  as when the variable is unset. `EnvironmentService.getValue` now normalizes
+  empty strings to `null`, so every consumer (endpoint, protocol, service
+  name, log level, …) reads an empty value as unset (#213).
+
+Thanks to @abidiahmedcom; reported by @yuzurihaaa (#213, #220, #228).
 
 ## [1.1.0-beta.13] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Added
-
 - `TracerProvider.hasSpanProcessors` — allocation-free check for registered
   span processors.
 

--- a/lib/src/environment/environment_service_io.dart
+++ b/lib/src/environment/environment_service_io.dart
@@ -88,6 +88,10 @@ class EnvironmentService implements EnvironmentServiceInterface {
       }
     }
 
-    return value;
+    // Per the OpenTelemetry specification (configuration.md), an empty value
+    // of an environment variable MUST be interpreted the same way as when the
+    // variable is unset. Normalize empty strings to null here so every
+    // consumer reads an empty value as unset (issue #213).
+    return (value == null || value.isEmpty) ? null : value;
   }
 }

--- a/lib/src/environment/environment_service_web.dart
+++ b/lib/src/environment/environment_service_web.dart
@@ -80,7 +80,11 @@ class EnvironmentService implements EnvironmentServiceInterface {
       }
     }
 
-    return value;
+    // Per the OpenTelemetry specification (configuration.md), an empty value
+    // of an environment variable MUST be interpreted the same way as when the
+    // variable is unset. Normalize empty strings to null here so every
+    // consumer reads an empty value as unset (issue #213).
+    return (value == null || value.isEmpty) ? null : value;
   }
 
   /// Gets a value from String.fromEnvironment.

--- a/lib/src/export/otlp_user_agent.dart
+++ b/lib/src/export/otlp_user_agent.dart
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Default User-Agent the OTLP exporters send on every request.
+///
+/// Per the OTLP exporter spec (specification/protocol/exporter.md, "User
+/// agent"), OTLP exporters SHOULD emit a `User-Agent` header that at minimum
+/// identifies the exporter, the language of its implementation, and the
+/// version of the exporter. The HTTP exporters send this header directly; the
+/// gRPC exporters pass it through `ChannelOptions.userAgent`, because gRPC
+/// treats `user-agent` as a reserved header and would strip it from a
+/// user-supplied map.
+library;
+
+/// Hand-synced with the package version in pubspec.yaml.
+const String packageVersion = '1.1.0-beta.14-wip';
+
+/// The default User-Agent value, e.g. `OTel-OTLP-Exporter-Dart/1.1.0-beta.14-wip`.
+const String otlpUserAgent = 'OTel-OTLP-Exporter-Dart/$packageVersion';

--- a/lib/src/export/otlp_user_agent.dart
+++ b/lib/src/export/otlp_user_agent.dart
@@ -12,8 +12,8 @@
 /// user-supplied map.
 library;
 
-/// Hand-synced with the package version in pubspec.yaml.
-const String packageVersion = '1.1.0-beta.14-wip';
+import '../version.dart';
 
-/// The default User-Agent value, e.g. `OTel-OTLP-Exporter-Dart/1.1.0-beta.14-wip`.
+/// The default User-Agent value, e.g. `OTel-OTLP-Exporter-Dart/1.1.0-beta.14`.
+/// The version is [packageVersion], stamped by the release tooling (#249).
 const String otlpUserAgent = 'OTel-OTLP-Exporter-Dart/$packageVersion';

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -29,14 +29,15 @@ class LogsConfiguration {
   /// - A processor (BatchLogRecordProcessor with BLRP env var config)
   /// - Sets up resources on the LoggerProvider
   ///
-  /// @param endpoint The endpoint URL for the exporter
+  /// @param endpoint The endpoint URL for the exporter (null to use the
+  ///   protocol-dependent default, issue #220)
   /// @param secure Whether to use TLS for gRPC connections
   /// @param logRecordExporter Optional custom exporter (overrides env var)
   /// @param logRecordProcessor Optional custom processor (overrides env var)
   /// @param resource Optional resource for the LoggerProvider
   /// @return The configured LoggerProvider
   static LoggerProvider configureLoggerProvider({
-    String endpoint = 'http://localhost:4318',
+    String? endpoint,
     bool secure = false,
     LogRecordExporter? logRecordExporter,
     LogRecordProcessor? logRecordProcessor,
@@ -119,14 +120,19 @@ class LogsConfiguration {
   /// Creates a log record exporter based on the exporter type.
   static LogRecordExporter? _createExporter(
     String exporterType,
-    String endpoint,
+    String? endpoint,
     bool secure,
   ) {
     // Get OTLP config for logs signal
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'logs');
+    final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
 
-    // Use env endpoint if available, otherwise use provided endpoint
-    final effectiveEndpoint = otlpConfig['endpoint'] as String? ?? endpoint;
+    // Use env endpoint if available, otherwise use provided endpoint. The
+    // default endpoint depends on the protocol (issue #220): OTLP/gRPC uses
+    // port 4317, the HTTP protocols use port 4318.
+    final effectiveEndpoint = otlpConfig['endpoint'] as String? ??
+        endpoint ??
+        (protocol == 'grpc' ? OTel.defaultGrpcEndpoint : OTel.defaultEndpoint);
     final envInsecure = otlpConfig['insecure'] as bool?;
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: envInsecure,
@@ -142,9 +148,6 @@ class LogsConfiguration {
     }
 
     if (exporterType == 'otlp') {
-      // Determine protocol - default to http/protobuf
-      final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
-
       if (protocol == 'grpc') {
         if (OTelLog.isDebug()) {
           OTelLog.debug(

--- a/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/http/otlp_http_log_record_exporter.dart
@@ -12,6 +12,7 @@ import 'package:http/http.dart' as http;
 
 import '../../../../export/otlp_http_protocol.dart';
 import '../../../../export/otlp_json.dart';
+import '../../../../export/otlp_user_agent.dart';
 import '../../../../trace/export/otlp/http/http_client_factory.dart';
 import '../../../../util/header_redaction.dart';
 import '../../../../util/zip/gzip.dart';
@@ -101,6 +102,15 @@ class OtlpHttpLogRecordExporter implements LogRecordExporter {
     // protobuf (default) or JSON via proto3-JSON mapping. See
     // `OtlpHttpProtocol` for the conformance rationale.
     final headers = Map<String, String>.from(_config.headers);
+    // Default User-Agent per the OTLP exporter spec ("User agent"): the
+    // exporter's default string is always present. A caller-supplied value
+    // (typically a distribution identifier) is prepended to it, e.g.
+    // "MyDistribution/1.0 OTel-OTLP-Exporter-Dart/1.1.0-beta.14-wip".
+    // `headers` is a copy, and http's header map is case-insensitive, so the
+    // User-Agent assignment below overrides the copied user-agent entry.
+    final userAgent = _config.headers['user-agent'];
+    headers['User-Agent'] =
+        userAgent == null ? otlpUserAgent : '$userAgent $otlpUserAgent';
     Uint8List messageBytes;
     if (_config.protocol == OtlpHttpProtocol.httpJson) {
       headers['Content-Type'] = 'application/json';

--- a/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
@@ -9,6 +9,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
 import 'package:grpc/grpc.dart';
 
 import '../../../../proto/opentelemetry_proto_dart.dart' as proto;
+import '../../../export/otlp_user_agent.dart';
 import '../../../trace/export/otlp/certificate_utils_io.dart';
 import '../../readable_log_record.dart';
 import '../log_record_exporter.dart';
@@ -159,6 +160,7 @@ class OtlpGrpcLogRecordExporter implements LogRecordExporter {
         port: port,
         options: ChannelOptions(
           credentials: _createChannelCredentials(),
+          userAgent: otlpUserAgent,
           connectTimeout: const Duration(seconds: 5),
           idleTimeout: const Duration(seconds: 30),
           codecRegistry: CodecRegistry(codecs: const [

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -29,8 +29,12 @@ class MetricsConfiguration {
   ///
   /// An explicit [metricExporter] or [metricReader] always wins over the
   /// env-var selection so programmatic configuration is unsurprising.
+  ///
+  /// When [endpoint] is null (or unset), the exporter default depends on the
+  /// resolved protocol (issue #220): `OTel.defaultGrpcEndpoint` for gRPC,
+  /// `OTel.defaultEndpoint` for the HTTP protocols.
   static MeterProvider configureMeterProvider({
-    String endpoint = 'http://localhost:4318',
+    String? endpoint,
     bool secure = false,
     MetricExporter? metricExporter,
     MetricReader? metricReader,
@@ -121,7 +125,7 @@ class MetricsConfiguration {
   /// Returns null for unknown values.
   static MetricExporter? _createExporter(
     String exporterType,
-    String endpoint,
+    String? endpoint,
     bool secure,
   ) {
     if (exporterType == 'console') {
@@ -140,12 +144,16 @@ class MetricsConfiguration {
 
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
     final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
+    // The default endpoint depends on the protocol (issue #220): OTLP/gRPC
+    // uses port 4317, the HTTP protocols use port 4318.
+    final effectiveEndpoint = endpoint ??
+        (protocol == 'grpc' ? OTel.defaultGrpcEndpoint : OTel.defaultEndpoint);
     // Parity with logs_config: honor OTEL_EXPORTER_OTLP_METRICS_INSECURE
     // (previously parsed and dropped) and the endpoint scheme per the
     // OTLP spec, falling back to the resolved global setting.
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: otlpConfig['insecure'] as bool?,
-      endpoint: endpoint,
+      endpoint: effectiveEndpoint,
       fallback: secure,
     );
     final headers = otlpConfig['headers'] as Map<String, String>? ?? const {};
@@ -159,11 +167,11 @@ class MetricsConfiguration {
     if (protocol == 'grpc') {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-            'MetricsConfiguration: Creating OtlpGrpcMetricExporter for $endpoint');
+            'MetricsConfiguration: Creating OtlpGrpcMetricExporter for $effectiveEndpoint');
       }
       return OtlpGrpcMetricExporter(
         OtlpGrpcMetricExporterConfig(
-          endpoint: endpoint,
+          endpoint: effectiveEndpoint,
           insecure: !effectiveSecure,
           headers: headers,
           timeoutMillis: timeout.inMilliseconds,
@@ -177,11 +185,11 @@ class MetricsConfiguration {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug(
-          'MetricsConfiguration: Creating OtlpHttpMetricExporter for $endpoint');
+          'MetricsConfiguration: Creating OtlpHttpMetricExporter for $effectiveEndpoint');
     }
     return OtlpHttpMetricExporter(
       OtlpHttpMetricExporterConfig(
-        endpoint: endpoint,
+        endpoint: effectiveEndpoint,
         headers: headers,
         timeout: timeout,
         compression: compression,

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 
 import '../../../../../dartastic_opentelemetry.dart';
 import '../../../../export/otlp_json.dart';
+import '../../../../export/otlp_user_agent.dart';
 import '../../../../trace/export/otlp/http/http_client_factory.dart';
 import '../../../../util/zip/gzip.dart';
 import '../metric_transformer.dart';
@@ -267,6 +268,15 @@ class OtlpHttpMetricExporter implements MetricExporter {
     // protobuf (default) or JSON via proto3-JSON mapping. See
     // `OtlpHttpProtocol` for the conformance rationale.
     final headers = Map<String, String>.from(_config.headers);
+    // Default User-Agent per the OTLP exporter spec ("User agent"): the
+    // exporter's default string is always present. A caller-supplied value
+    // (typically a distribution identifier) is prepended to it, e.g.
+    // "MyDistribution/1.0 OTel-OTLP-Exporter-Dart/1.1.0-beta.14-wip".
+    // `headers` is a copy, and http's header map is case-insensitive, so the
+    // User-Agent assignment below overrides the copied user-agent entry.
+    final userAgent = _config.headers['user-agent'];
+    headers['User-Agent'] =
+        userAgent == null ? otlpUserAgent : '$userAgent $otlpUserAgent';
     Uint8List messageBytes;
     if (_config.protocol == OtlpHttpProtocol.httpJson) {
       headers['Content-Type'] = 'application/json';

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
@@ -7,6 +7,7 @@ import 'package:grpc/grpc.dart';
 
 import '../../../../dartastic_opentelemetry.dart';
 import '../../../../proto/collector/metrics/v1/metrics_service.pbgrpc.dart';
+import '../../../export/otlp_user_agent.dart';
 import '../../../trace/export/otlp/certificate_utils_io.dart';
 import 'metric_transformer.dart';
 
@@ -72,6 +73,7 @@ class OtlpGrpcMetricExporter implements MetricExporter {
   ) {
     final channelOptions = ChannelOptions(
       credentials: _createChannelCredentials(config),
+      userAgent: otlpUserAgent,
       codecRegistry: CodecRegistry(codecs: const [GzipCodec()]),
     );
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -72,9 +72,18 @@ class OTel {
   /// Default OTEL endpoint.
   ///
   /// Defaults to the OTLP/HTTP port (4318) since http/protobuf is the default
-  /// protocol per the OpenTelemetry specification. When using gRPC, override
-  /// this with port 4317.
+  /// protocol per the OpenTelemetry specification. When using gRPC, this is
+  /// replaced by [defaultGrpcEndpoint] (port 4317).
   static const defaultEndpoint = 'http://localhost:4318';
+
+  /// Default OTLP/gRPC endpoint.
+  ///
+  /// Per the OpenTelemetry specification
+  /// (specification/protocol/exporter.md#configuration-options), the default
+  /// endpoint is `http://localhost:4317` for OTLP/gRPC and
+  /// `http://localhost:4318` for the two HTTP protocols. The endpoint default
+  /// is picked per signal after the protocol is resolved (issue #220).
+  static const defaultGrpcEndpoint = 'http://localhost:4317';
 
   /// Default tracer name used if none is provided.
   static const String _defaultTracerName = 'dartastic';
@@ -177,10 +186,13 @@ class OTel {
       endpoint: endpoint,
     );
 
-    // Apply defaults if still null
+    // Apply defaults if still null. The endpoint stays nullable here and is
+    // resolved per signal after the protocol is known (issue #220): the OTLP
+    // spec default is http://localhost:4317 for gRPC and http://localhost:4318
+    // for the HTTP protocols, so a single 4318 default must not be applied
+    // before the protocol is resolved.
     serviceName ??= defaultServiceName;
     serviceVersion ??= '1.0.0';
-    endpoint ??= defaultEndpoint;
     // secure is guaranteed non-null from above
 
     // Log environment variable usage
@@ -234,7 +246,7 @@ class OTel {
       );
     }
 
-    if (endpoint.isEmpty) {
+    if (endpoint != null && endpoint.isEmpty) {
       throw ArgumentError(
         'endpoint must not be the empty string.',
       ); //TODO validate url
@@ -257,7 +269,7 @@ class OTel {
     initializeLogging();
 
     final createdFactory = factoryFactory(
-      apiEndpoint: endpoint,
+      apiEndpoint: endpoint ?? defaultEndpoint,
       apiServiceName: serviceName,
       apiServiceVersion: serviceVersion,
     );
@@ -274,8 +286,12 @@ class OTel {
     _installGlobalPropagator();
 
     if (OTelLog.isDebug()) {
+      final traceProtocol =
+          otlpConfigForExporter['protocol'] as String? ?? 'http/protobuf';
       OTelLog.debug(
-        'OTel initialized with endpoint: $endpoint, service: $serviceName',
+        'OTel initialized with endpoint: '
+        '${endpoint ?? (traceProtocol == 'grpc' ? defaultGrpcEndpoint : defaultEndpoint)}, '
+        'service: $serviceName',
       );
     }
 
@@ -347,9 +363,19 @@ class OTel {
             otlpConfigForExporter['protocol'] as String? ?? 'http/protobuf';
 
         // Capture the resolved values: promotion of the nullable
-        // parameters does not carry into the closure.
-        final resolvedEndpoint = endpoint;
-        final resolvedSecure = secure;
+        // parameters does not carry into the closure. The endpoint default is
+        // protocol-dependent (issue #220): gRPC uses port 4317, the HTTP
+        // protocols use port 4318. The secure setting is likewise re-resolved
+        // against the resolved endpoint so an http:// scheme (including the
+        // gRPC default http://localhost:4317) yields an insecure connection,
+        // matching the metrics/logs paths.
+        final resolvedEndpoint = endpoint ??
+            (protocol == 'grpc' ? defaultGrpcEndpoint : defaultEndpoint);
+        final resolvedSecure = OTelEnv.resolveOtlpSecure(
+          envInsecure: otlpConfigForExporter['insecure'] as bool?,
+          endpoint: resolvedEndpoint,
+          fallback: secure,
+        );
         SpanExporter buildOtlpExporter() {
           // Create appropriate exporter based on protocol
           if (protocol == 'grpc') {

--- a/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
+++ b/lib/src/trace/export/otlp/http/otlp_http_span_exporter.dart
@@ -12,6 +12,7 @@ import 'package:http/http.dart' as http;
 
 import '../../../../export/otlp_http_protocol.dart';
 import '../../../../export/otlp_json.dart';
+import '../../../../export/otlp_user_agent.dart';
 import '../../../../util/header_redaction.dart';
 import '../../../../util/zip/gzip.dart';
 import '../../../span.dart';
@@ -121,6 +122,15 @@ class OtlpHttpSpanExporter implements SpanExporter {
     // being hex-encoded (not base64) trace/span ids. Strict receivers
     // (OTel Collector ≥ ~0.15x) reject base64 ids with HTTP 400.
     final headers = Map<String, String>.from(_config.headers);
+    // Default User-Agent per the OTLP exporter spec ("User agent"): the
+    // exporter's default string is always present. A caller-supplied value
+    // (typically a distribution identifier) is prepended to it, e.g.
+    // "MyDistribution/1.0 OTel-OTLP-Exporter-Dart/1.1.0-beta.14-wip".
+    // `headers` is a copy, and http's header map is case-insensitive, so the
+    // User-Agent assignment below overrides the copied user-agent entry.
+    final userAgent = _config.headers['user-agent'];
+    headers['User-Agent'] =
+        userAgent == null ? otlpUserAgent : '$userAgent $otlpUserAgent';
     Uint8List messageBytes;
     if (_config.protocol == OtlpHttpProtocol.httpJson) {
       headers['Content-Type'] = 'application/json';

--- a/lib/src/trace/export/otlp/otlp_grpc_span_exporter.dart
+++ b/lib/src/trace/export/otlp/otlp_grpc_span_exporter.dart
@@ -9,6 +9,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
 import 'package:grpc/grpc.dart';
 
 import '../../../../proto/opentelemetry_proto_dart.dart' as proto;
+import '../../../export/otlp_user_agent.dart';
 import '../../span.dart';
 import '../../span_logger.dart';
 import '../span_exporter.dart';
@@ -207,6 +208,7 @@ class OtlpGrpcSpanExporter implements SpanExporter {
         port: port,
         options: ChannelOptions(
           credentials: _createChannelCredentials(),
+          userAgent: otlpUserAgent,
           connectTimeout: const Duration(seconds: 5),
           // Keep connection alive better
           idleTimeout: const Duration(seconds: 30),

--- a/test/unit/environment/otel_env_inprocess_test.dart
+++ b/test/unit/environment/otel_env_inprocess_test.dart
@@ -328,4 +328,47 @@ void main() {
       expect(OTelEnv.getLogRecordLimits(), isEmpty);
     });
   });
+
+  group('parsing empty values (issue #213)', () {
+    test('an empty value reads as unset from getValue', () {
+      env({'OTEL_SERVICE_NAME': ''});
+      expect(EnvironmentService.instance.getValue('OTEL_SERVICE_NAME'), isNull);
+    });
+
+    test('an empty endpoint reads as unset', () {
+      env({'OTEL_EXPORTER_OTLP_ENDPOINT': ''});
+      expect(OTelEnv.getOtlpConfig()['endpoint'], isNull);
+    });
+
+    test('an empty signal endpoint falls back to the generic endpoint', () {
+      env({
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://collector:4318',
+        'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT': '',
+      });
+      expect(
+        OTelEnv.getOtlpConfig(signal: 'traces')['endpoint'],
+        equals('http://collector:4318'),
+      );
+    });
+
+    test('an empty protocol reads as unset', () {
+      env({'OTEL_EXPORTER_OTLP_PROTOCOL': ''});
+      expect(OTelEnv.getOtlpConfig()['protocol'], isNull);
+    });
+
+    test('an empty service name does not override resource attributes', () {
+      env({
+        'OTEL_SERVICE_NAME': '',
+        'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-service',
+      });
+      expect(OTelEnv.getServiceConfig()['serviceName'], equals('my-service'));
+    });
+
+    test('an empty log level leaves logging unchanged', () {
+      OTelLog.enableDebugLogging();
+      env({'OTEL_LOG_LEVEL': ''});
+      OTelEnv.initializeLogging();
+      expect(OTelLog.currentLevel, equals(LogLevel.debug));
+    });
+  });
 }

--- a/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
+++ b/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/export/otlp_user_agent.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -93,6 +94,41 @@ void main() {
       expect((decoded as Map).containsKey('resourceLogs'), isTrue);
       expect(decoded['resourceLogs'], isA<List>());
 
+      await exporter.shutdown();
+    });
+
+    test('export sends the OTLP default User-Agent header (issue #228)',
+        () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(endpoint: 'http://localhost:$port'),
+      );
+
+      await exporter.export([createTestLogRecord()]);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.value('user-agent'),
+        equals(otlpUserAgent),
+      );
+      await exporter.shutdown();
+    });
+
+    test('user-supplied User-Agent is prepended to the default (issue #228)',
+        () async {
+      final exporter = OtlpHttpLogRecordExporter(
+        OtlpHttpLogRecordExporterConfig(
+          endpoint: 'http://localhost:$port',
+          headers: {'user-agent': 'my-distribution/1.0'},
+        ),
+      );
+
+      await exporter.export([createTestLogRecord()]);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.value('user-agent'),
+        equals('my-distribution/1.0 $otlpUserAgent'),
+      );
       await exporter.shutdown();
     });
   });

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_user_agent_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_user_agent_test.dart
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Issue #228 coverage for the logs gRPC exporter's User-Agent. The spans
+// gRPC exporter is covered in test/unit/otlp_spec_compliance_behavior_test
+// and the metrics gRPC exporter in otlp_grpc_metric_exporter_full_test;
+// this closes the logs gap.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'
+    hide Server;
+import 'package:dartastic_opentelemetry/proto/collector/logs/v1/logs_service.pbgrpc.dart';
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:test/test.dart';
+
+class _CapturingLogsService extends LogsServiceBase {
+  final userAgents = <String?>[];
+  final firstCall = Completer<void>();
+
+  @override
+  Future<ExportLogsServiceResponse> export(
+    grpc.ServiceCall call,
+    ExportLogsServiceRequest request,
+  ) async {
+    userAgents.add(call.clientMetadata?['user-agent']);
+    if (!firstCall.isCompleted) firstCall.complete();
+    return ExportLogsServiceResponse();
+  }
+}
+
+void main() {
+  setUp(() async {
+    await OTel.reset();
+    await OTel.initialize(
+      serviceName: 'red-228-logs-grpc',
+      detectPlatformResources: false,
+      enableMetrics: false,
+      enableLogs: false,
+    );
+  });
+
+  tearDown(() async {
+    await OTel.reset();
+  });
+
+  test('logs gRPC export identifies the exporter per spec (issue #228)',
+      () async {
+    final svc = _CapturingLogsService();
+    final server = grpc.Server.create(services: [svc]);
+    await server.serve(address: InternetAddress.loopbackIPv4, port: 0);
+    addTearDown(server.shutdown);
+
+    final exporter = OtlpGrpcLogRecordExporter(
+      OtlpGrpcLogRecordExporterConfig(
+        endpoint: 'http://localhost:${server.port}',
+        insecure: true,
+      ),
+    );
+    addTearDown(exporter.shutdown);
+
+    final scope =
+        OTel.instrumentationScope(name: 'review-red', version: '1.0.0');
+    await exporter.export([
+      SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'user-agent-check',
+      ),
+    ]);
+
+    await svc.firstCall.future.timeout(const Duration(seconds: 5));
+    expect(svc.userAgents.first, startsWith('OTel-OTLP-Exporter-Dart/'));
+  });
+}

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/export/otlp_user_agent.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -164,6 +165,43 @@ void main() {
       expect(
         receivedRequests.first.headers.value('x-custom'),
         equals('test-value'),
+      );
+      await exporter.shutdown();
+    });
+
+    test('export sends the OTLP default User-Agent header (issue #228)',
+        () async {
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
+      );
+
+      final metricData = createTestMetricData();
+      await exporter.export(metricData);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.value('user-agent'),
+        equals(otlpUserAgent),
+      );
+      await exporter.shutdown();
+    });
+
+    test('user-supplied User-Agent is prepended to the default (issue #228)',
+        () async {
+      final exporter = OtlpHttpMetricExporter(
+        OtlpHttpMetricExporterConfig(
+          endpoint: 'http://localhost:$port',
+          headers: {'user-agent': 'my-distribution/1.0'},
+        ),
+      );
+
+      final metricData = createTestMetricData();
+      await exporter.export(metricData);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.value('user-agent'),
+        equals('my-distribution/1.0 $otlpUserAgent'),
       );
       await exporter.shutdown();
     });

--- a/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'
     hide Server;
 import 'package:dartastic_opentelemetry/proto/collector/metrics/v1/metrics_service.pbgrpc.dart';
+import 'package:dartastic_opentelemetry/src/export/otlp_user_agent.dart';
 import 'package:grpc/grpc.dart';
 import 'package:test/test.dart';
 
@@ -19,6 +20,9 @@ class MockMetricsService extends MetricsServiceBase {
   List<ExportMetricsServiceRequest> requests = [];
   int? errorCode;
 
+  /// The `user-agent` HTTP/2 header seen on the last call.
+  String? lastUserAgent;
+
   @override
   Future<ExportMetricsServiceResponse> export(
     ServiceCall call,
@@ -26,6 +30,7 @@ class MockMetricsService extends MetricsServiceBase {
   ) async {
     exportCount++;
     requests.add(request);
+    lastUserAgent = call.clientMetadata?['user-agent'];
     if (errorCode != null) {
       throw GrpcError.custom(errorCode!, 'Mock metrics error');
     }
@@ -129,6 +134,17 @@ void main() {
       // Verify the request has resource metrics
       final request = mockService.requests.first;
       expect(request.resourceMetrics, isNotEmpty);
+
+      await exporter.shutdown();
+    });
+
+    test('export sends the OTLP default User-Agent (issue #228)', () async {
+      final exporter = _createExporter(port);
+
+      final result = await exporter.export(_createTestMetricData());
+
+      expect(result, isTrue);
+      expect(mockService.lastUserAgent, equals(otlpUserAgent));
 
       await exporter.shutdown();
     });

--- a/test/unit/otel_default_grpc_endpoint_test.dart
+++ b/test/unit/otel_default_grpc_endpoint_test.dart
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/issues/220
+//
+// The OTLP spec (specification/protocol/exporter.md#configuration-options)
+// defaults the endpoint to `http://localhost:4317` for OTLP/gRPC and
+// `http://localhost:4318` for the two HTTP protocols. The default must be
+// picked per signal AFTER the protocol is resolved; a single 4318 default
+// applied before the protocol is known silently mis-routes gRPC-only
+// deployments to the wrong port.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final logs = <String>[];
+
+  setUp(() {
+    logs.clear();
+    OTelLog.logFunction = logs.add;
+    OTelLog.currentLevel = LogLevel.debug;
+  });
+
+  tearDown(() async {
+    await OTel.reset();
+    EnvironmentService.testOverrides = null;
+    OTelLog.currentLevel = LogLevel.error;
+  });
+
+  test('default (http/protobuf) endpoint is port 4318 for every signal',
+      () async {
+    await OTel.initialize(serviceName: 'http-default-test');
+
+    final spanProcessor =
+        OTel.tracerProvider().spanProcessors.first as BatchSpanProcessor;
+    expect(spanProcessor.exporter, isA<OtlpHttpSpanExporter>());
+
+    final metricReader = OTel.meterProvider().metricReaders.first
+        as PeriodicExportingMetricReader;
+    expect(metricReader.exporter, isA<OtlpHttpMetricExporter>());
+
+    final logProcessor = OTel.loggerProvider().logRecordProcessors.first
+        as BatchLogRecordProcessor;
+    expect(logProcessor.exporter, isA<OtlpHttpLogRecordExporter>());
+
+    expect(logs.join('\n'), contains('endpoint: http://localhost:4318'));
+  });
+
+  test('grpc protocol defaults to port 4317 for traces', () async {
+    EnvironmentService.testOverrides = {'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc'};
+    await OTel.initialize(serviceName: 'grpc-traces-test');
+
+    final spanProcessor =
+        OTel.tracerProvider().spanProcessors.first as BatchSpanProcessor;
+    expect(spanProcessor.exporter, isA<OtlpGrpcSpanExporter>());
+
+    expect(logs.join('\n'), contains('endpoint: http://localhost:4317'));
+  });
+
+  test('grpc protocol defaults to port 4317 for metrics', () async {
+    EnvironmentService.testOverrides = {'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc'};
+    await OTel.initialize(serviceName: 'grpc-metrics-test');
+
+    final metricReader = OTel.meterProvider().metricReaders.first
+        as PeriodicExportingMetricReader;
+    expect(metricReader.exporter, isA<OtlpGrpcMetricExporter>());
+
+    expect(
+      logs.join('\n'),
+      contains('OtlpGrpcMetricExporter for http://localhost:4317'),
+    );
+  });
+
+  test('grpc protocol defaults to port 4317 for logs', () async {
+    EnvironmentService.testOverrides = {'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc'};
+    await OTel.initialize(serviceName: 'grpc-logs-test');
+
+    final logProcessor = OTel.loggerProvider().logRecordProcessors.first
+        as BatchLogRecordProcessor;
+    expect(logProcessor.exporter, isA<OtlpGrpcLogRecordExporter>());
+
+    expect(logs.join('\n'), contains('endpoint: http://localhost:4317'));
+  });
+
+  test('explicit endpoint is passed through instead of a default', () async {
+    await OTel.initialize(
+      serviceName: 'explicit-endpoint-test',
+      endpoint: 'http://collector:9999',
+    );
+
+    final spanProcessor =
+        OTel.tracerProvider().spanProcessors.first as BatchSpanProcessor;
+    expect(spanProcessor.exporter, isA<OtlpHttpSpanExporter>());
+
+    expect(logs.join('\n'), contains('endpoint: http://collector:9999'));
+  });
+
+  test('http/json protocol uses port 4318', () async {
+    EnvironmentService.testOverrides = {
+      'OTEL_EXPORTER_OTLP_PROTOCOL': 'http/json',
+    };
+    await OTel.initialize(serviceName: 'http-json-test');
+
+    final spanProcessor =
+        OTel.tracerProvider().spanProcessors.first as BatchSpanProcessor;
+    expect(spanProcessor.exporter, isA<OtlpHttpSpanExporter>());
+
+    expect(logs.join('\n'), contains('endpoint: http://localhost:4318'));
+  });
+}

--- a/test/unit/otlp_spec_compliance_behavior_test.dart
+++ b/test/unit/otlp_spec_compliance_behavior_test.dart
@@ -1,0 +1,164 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Behavioral end-to-end regression tests for issues #213, #220, and #228,
+// asserting the user-observable contract rather than internal wiring:
+// OTel.initialize() completing where it used to throw (#213), export bytes
+// actually arriving at the spec-default gRPC port 4317 (#220), and the
+// User-Agent actually sent on the wire (#228). Written independently of the
+// implementation, from the issues and OTel spec v1.60.0, during review of
+// PR #238; each test was verified red on the pre-fix SDK.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/proto/collector/trace/v1/trace_service.pbgrpc.dart';
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:test/test.dart';
+
+/// gRPC TraceService that records export calls and their client metadata.
+class _CapturingTraceService extends TraceServiceBase {
+  final userAgents = <String?>[];
+  final firstCall = Completer<void>();
+
+  @override
+  Future<ExportTraceServiceResponse> export(
+    grpc.ServiceCall call,
+    ExportTraceServiceRequest request,
+  ) async {
+    userAgents.add(call.clientMetadata?['user-agent']);
+    if (!firstCall.isCompleted) firstCall.complete();
+    return ExportTraceServiceResponse();
+  }
+}
+
+Future<grpc.Server> _serveCapture(_CapturingTraceService svc, int port) async {
+  final server = grpc.Server.create(services: [svc]);
+  await server.serve(address: InternetAddress.loopbackIPv4, port: port);
+  return server;
+}
+
+void _endSpanAndFlush() {
+  OTel.tracerProvider().getTracer('red').startSpan('red-span').end();
+  // On the unfixed SDK the exporter may dial a port nobody listens on;
+  // don't let that flush failure become an unhandled async error.
+  unawaited(OTel.tracerProvider().forceFlush().catchError((_) {}));
+}
+
+void main() {
+  setUp(() async {
+    await OTel.reset();
+  });
+
+  tearDown(() async {
+    EnvironmentService.testOverrides = null;
+    await OTel.reset();
+  });
+
+  group('#213 empty env var value is treated as unset', () {
+    test('EnvironmentService.getValue returns null for an empty value', () {
+      EnvironmentService.testOverrides = {'OTEL_SERVICE_NAME': ''};
+      expect(
+        EnvironmentService.instance.getValue('OTEL_SERVICE_NAME'),
+        isNull,
+      );
+    });
+
+    test('initialize: empty OTEL_EXPORTER_OTLP_ENDPOINT means default',
+        () async {
+      EnvironmentService.testOverrides = {'OTEL_EXPORTER_OTLP_ENDPOINT': ''};
+      await OTel.initialize(
+        serviceName: 'red-213',
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      // Completing without an ArgumentError is the spec behavior.
+    });
+
+    test('initialize: empty OTEL_SERVICE_NAME means default', () async {
+      EnvironmentService.testOverrides = {'OTEL_SERVICE_NAME': ''};
+      await OTel.initialize(enableMetrics: false, enableLogs: false);
+    });
+  });
+
+  group('#220 OTLP/gRPC endpoint default', () {
+    test('protocol grpc with no endpoint exports to localhost:4317', () async {
+      final svc = _CapturingTraceService();
+      final grpc.Server server;
+      try {
+        server = await _serveCapture(svc, 4317);
+      } on SocketException {
+        fail('port 4317 is already in use — stop the local collector and '
+            'rerun this test');
+      }
+      addTearDown(server.shutdown);
+
+      EnvironmentService.testOverrides = {
+        'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+      };
+      await OTel.initialize(
+        serviceName: 'red-220',
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      _endSpanAndFlush();
+
+      await svc.firstCall.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => fail(
+          'no export arrived on the spec-default gRPC port 4317 within 5s — '
+          'the exporter presumably targeted the OTLP/HTTP port 4318',
+        ),
+      );
+    });
+  });
+
+  group('#228 OTLP exporter User-Agent', () {
+    test('gRPC export identifies the exporter per spec', () async {
+      final svc = _CapturingTraceService();
+      final server = await _serveCapture(svc, 0);
+      addTearDown(server.shutdown);
+
+      EnvironmentService.testOverrides = {
+        'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:${server.port}',
+      };
+      await OTel.initialize(
+        serviceName: 'red-228-grpc',
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      _endSpanAndFlush();
+
+      await svc.firstCall.future.timeout(const Duration(seconds: 5));
+      expect(svc.userAgents.first, startsWith('OTel-OTLP-Exporter-Dart/'));
+    });
+
+    test('HTTP export identifies the exporter per spec', () async {
+      final captured = Completer<String?>();
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((req) async {
+        final ua = req.headers.value(HttpHeaders.userAgentHeader);
+        req.response.statusCode = 200;
+        req.response.add(ExportTraceServiceResponse().writeToBuffer());
+        await req.response.close();
+        if (!captured.isCompleted) captured.complete(ua);
+      });
+
+      EnvironmentService.testOverrides = {
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:${server.port}',
+      };
+      await OTel.initialize(
+        serviceName: 'red-228-http',
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      _endSpanAndFlush();
+
+      final ua = await captured.future.timeout(const Duration(seconds: 5));
+      expect(ua, startsWith('OTel-OTLP-Exporter-Dart/'));
+    });
+  });
+}

--- a/test/unit/otlp_user_agent_test.dart
+++ b/test/unit/otlp_user_agent_test.dart
@@ -5,22 +5,23 @@
 //
 // OTLP requests SHOULD carry a `User-Agent` header of the form
 // `OTel-OTLP-Exporter-<language>/<version>` (specification/protocol/exporter.md,
-// "User agent"). The value is derived from a hand-synced package version.
+// "User agent"). The version is the release-stamped `packageVersion` from
+// lib/src/version.dart, whose sync with pubspec.yaml is guarded by
+// test/unit/version_sync_test.dart (#249).
 
 import 'package:dartastic_opentelemetry/src/export/otlp_user_agent.dart';
+import 'package:dartastic_opentelemetry/src/version.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('otlpUserAgent (issue #228)', () {
-    test('matches the spec format OTel-OTLP-Exporter-Dart/<package-version>',
-        () {
+    test('derives from the release-stamped packageVersion', () {
       expect(otlpUserAgent, equals('OTel-OTLP-Exporter-Dart/$packageVersion'));
-      expect(otlpUserAgent, startsWith('OTel-OTLP-Exporter-Dart/'));
-      expect(otlpUserAgent, isNot(endsWith('/')));
     });
 
-    test('package version is a non-empty string', () {
-      expect(packageVersion, isNotEmpty);
+    test('matches the spec format OTel-OTLP-Exporter-Dart/<version>', () {
+      expect(otlpUserAgent, startsWith('OTel-OTLP-Exporter-Dart/'));
+      expect(otlpUserAgent, isNot(endsWith('/')));
     });
   });
 }

--- a/test/unit/otlp_user_agent_test.dart
+++ b/test/unit/otlp_user_agent_test.dart
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/issues/228
+//
+// OTLP requests SHOULD carry a `User-Agent` header of the form
+// `OTel-OTLP-Exporter-<language>/<version>` (specification/protocol/exporter.md,
+// "User agent"). The value is derived from a hand-synced package version.
+
+import 'package:dartastic_opentelemetry/src/export/otlp_user_agent.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('otlpUserAgent (issue #228)', () {
+    test('matches the spec format OTel-OTLP-Exporter-Dart/<package-version>',
+        () {
+      expect(otlpUserAgent, equals('OTel-OTLP-Exporter-Dart/$packageVersion'));
+      expect(otlpUserAgent, startsWith('OTel-OTLP-Exporter-Dart/'));
+      expect(otlpUserAgent, isNot(endsWith('/')));
+    });
+
+    test('package version is a non-empty string', () {
+      expect(packageVersion, isNotEmpty);
+    });
+  });
+}

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/export/otlp_user_agent.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -163,6 +164,48 @@ void main() {
         receivedRequests.first.headers.value('x-custom'),
         equals('test-value'),
       );
+      await exporter.shutdown();
+    });
+
+    test('export sends the OTLP default User-Agent header (issue #228)',
+        () async {
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
+      );
+
+      final spans = createTestSpans();
+      await exporter.export(spans);
+
+      expect(receivedRequests, hasLength(1));
+      expect(
+        receivedRequests.first.headers.value('user-agent'),
+        equals(otlpUserAgent),
+      );
+      await exporter.shutdown();
+    });
+
+    test('user-supplied User-Agent is prepended to the default (issue #228)',
+        () async {
+      final exporter = OtlpHttpSpanExporter(
+        OtlpHttpExporterConfig(
+          endpoint: 'http://localhost:$port',
+          headers: {'user-agent': 'my-distribution/1.0'},
+        ),
+      );
+
+      // Export twice: the supplied UA must persist on every request, not be
+      // consumed (removed) from the config by the first export.
+      final spans = createTestSpans();
+      await exporter.export(spans);
+      await exporter.export(spans);
+
+      expect(receivedRequests, hasLength(2));
+      for (final request in receivedRequests) {
+        expect(
+          request.headers.value('user-agent'),
+          equals('my-distribution/1.0 $otlpUserAgent'),
+        );
+      }
       await exporter.shutdown();
     });
 


### PR DESCRIPTION
Fixes #213, #220, #228 — three OTLP spec-compliance bugs (v1.60.0).

## Summary

**#213 — Empty env var values are now treated as unset.**
`EnvironmentService.getValue` (io + web) normalizes empty strings to `null`, so `OTEL_EXPORTER_OTLP_ENDPOINT=` no longer throws at initialize and falls back to the default endpoint; empty `OTEL_SERVICE_NAME`, protocol, log level, etc. all read as unset. (spec: configuration/sdk-environment-variables.md#parsing-empty-value)

**#220 — gRPC now defaults to port 4317, not 4318.**
The endpoint default is picked per signal AFTER the protocol is resolved: `http://localhost:4317` for gRPC, `http://localhost:4318` for the HTTP protocols. Adds `OTel.defaultGrpcEndpoint`. The trace path also re-resolves `secure` against the effective endpoint (matching metrics/logs and the spec's http-scheme precedence), so a default `http://localhost:4317` gRPC endpoint connects insecurely. (spec: protocol/exporter.md#configuration-options)

**#228 — OTLP requests now carry an identifying User-Agent.**
Every OTLP request sends `OTel-OTLP-Exporter-Dart/<package-version>` — as an HTTP header for the HTTP exporters and via `ChannelOptions.userAgent` for the gRPC exporters (grpc-dart strips user-supplied user-agent headers). A caller-supplied `user-agent` header is prepended to the default rather than replacing it, and is not consumed from the config between exports. (spec: protocol/exporter.md#user-agent)

## Tests
- New: `test/unit/otel_default_grpc_endpoint_test.dart`, `test/unit/otlp_user_agent_test.dart`, and empty-value cases in `otel_env_inprocess_test.dart`.
- Wire tests: default UA + prepended UA in the trace/metrics/logs HTTP suites; default UA on the gRPC metrics suite.
- `dart analyze` clean; `dart format` clean. Full suite: all pass except 8 pre-existing failures (4 `context_propagation_test.dart`, 4 `otlp_http_metric_exporter_coverage_test.dart`) — confirmed identical on pristine `f048243`.
