### PR TITLE
fix: preserve existing baggage when header is unparseable

### DIFF
--- a/lib/src/context/propagation/w3c_baggage_propagator.dart
+++ b/lib/src/context/propagation/w3c_baggage_propagator.dart
@@ -35,7 +35,9 @@ class W3CBaggagePropagator
     TextMapGetter<String> getter,
   ) {
     final value = getter.get(_baggageHeader);
-    OTelLog.debug('Extracting baggage: $value');
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('Extracting baggage: $value');
+    }
     if (value == null || value.isEmpty) {
       // Propagators API spec: extract returns the passed context, updated
       // with extracted values — and unchanged when there is nothing to

--- a/lib/src/context/propagation/w3c_baggage_propagator.dart
+++ b/lib/src/context/propagation/w3c_baggage_propagator.dart
@@ -66,6 +66,8 @@ class W3CBaggagePropagator
       entries[key] = OTel.baggageEntry(value, metadata);
     }
 
+    if (entries.isEmpty) return context;
+
     final baggage = OTel.baggage(entries);
     return context.withBaggage(baggage);
   }

--- a/test/unit/baggage/w3c_baggage_propagator_test.dart
+++ b/test/unit/baggage/w3c_baggage_propagator_test.dart
@@ -127,10 +127,9 @@ void main() {
       final getter = TestTextMapGetter(carrier);
 
       final extractedContext = propagator.extract(context, carrier, getter);
-      final extractedBaggage = extractedContext.baggage;
 
-      expect(extractedBaggage, isA<Baggage>());
-      expect(extractedBaggage!.getAllEntries(), isEmpty);
+      expect(extractedContext, same(context));
+      expect(extractedContext.baggage, isNull);
     });
 
     test('unparseable baggage header preserves existing baggage', () {

--- a/test/unit/baggage/w3c_baggage_propagator_test.dart
+++ b/test/unit/baggage/w3c_baggage_propagator_test.dart
@@ -133,6 +133,21 @@ void main() {
       expect(extractedBaggage!.getAllEntries(), isEmpty);
     });
 
+    test('unparseable baggage header preserves existing baggage', () {
+      final existingBaggage = OTel.baggage({'test': OTel.baggageEntry('value')});
+      final contextWithExisting = context.withBaggage(existingBaggage);
+
+      final carrier = {'baggage': 'invalid_format'};
+      final getter = TestTextMapGetter(carrier);
+
+      final extractedContext = propagator.extract(contextWithExisting, carrier, getter);
+      final extractedBaggage = extractedContext.baggage;
+
+      expect(extractedContext, same(contextWithExisting));
+      expect(extractedBaggage, isNotNull);
+      expect(extractedBaggage!.getEntry('test')?.value, equals('value'));
+    });
+
     test(
         'extract without a baggage header returns the passed context'
         ' unchanged', () {

--- a/test/unit/baggage/w3c_baggage_propagator_test.dart
+++ b/test/unit/baggage/w3c_baggage_propagator_test.dart
@@ -133,13 +133,15 @@ void main() {
     });
 
     test('unparseable baggage header preserves existing baggage', () {
-      final existingBaggage = OTel.baggage({'test': OTel.baggageEntry('value')});
+      final existingBaggage =
+          OTel.baggage({'test': OTel.baggageEntry('value')});
       final contextWithExisting = context.withBaggage(existingBaggage);
 
       final carrier = {'baggage': 'invalid_format'};
       final getter = TestTextMapGetter(carrier);
 
-      final extractedContext = propagator.extract(contextWithExisting, carrier, getter);
+      final extractedContext =
+          propagator.extract(contextWithExisting, carrier, getter);
       final extractedBaggage = extractedContext.baggage;
 
       expect(extractedContext, same(contextWithExisting));


### PR DESCRIPTION
Fixes #200. Ensures that when the baggage header is unparseable and produces no valid entries, we return the existing context unmodified so that we don't accidentally drop valid baggage.