### PR TITLE
test: move RealCollector-dependent tests to test/integration

### DIFF
--- a/test/integration/context_propagation_test.dart
+++ b/test/integration/context_propagation_test.dart
@@ -8,7 +8,7 @@ import 'dart:math';
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 import 'package:test/test.dart';
 
-import '../../testing_utils/real_collector.dart';
+import '../testing_utils/real_collector.dart';
 
 // Check if we're running in isolated mode
 final bool isIsolatedRun =

--- a/test/integration/otlp_grpc_retry_test.dart
+++ b/test/integration/otlp_grpc_retry_test.dart
@@ -11,8 +11,8 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:grpc/grpc.dart' as grpc;
 import 'package:test/test.dart';
 
-import '../../../../testing_utils/network_proxy.dart';
-import '../../../../testing_utils/real_collector.dart';
+import '../testing_utils/network_proxy.dart';
+import '../testing_utils/real_collector.dart';
 
 // Helper function to create a test span using OTel factory methods
 Span createTestSpan({


### PR DESCRIPTION
Moves the two remaining `test/unit/` suites that invoke the external `otelcol` binary via `RealCollector` into `test/integration/`:

- `test/unit/context/context_propagation_test.dart` → `test/integration/context_propagation_test.dart`
- `test/unit/trace/export/otlp/otlp_grpc_retry_test.dart` → `test/integration/otlp_grpc_retry_test.dart`

With this, `dart test test/unit` no longer crashes on machines without the collector binary (`Bad state: OpenTelemetry Collector not found`), which is the **external-daemon half of #55**. The second half of #55 (moving loopback-socket suites out of unit / standardizing on in-memory + injected clients) is deliberately not addressed here and remains open for discussion.

Only relative imports changed (`../testing_utils/…`); the otelcol config paths are CWD-relative and unaffected. Verified: `dart analyze` clean, and `test/integration/context_propagation_test.dart` passes from its new location against the real collector (+4). CI runs `tool/test.sh`, which tests the whole `./test` tree, so both suites remain in CI.

Refs #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)