### PR TITLE
fix: release-tooling-stamped packageVersion const with a pubspec drift guard

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/// The package's own version, for code that must identify the SDK at
+/// runtime (e.g. the OTLP `User-Agent` header).
+///
+/// Dart has no runtime API for a library's own version, and reading
+/// pubspec.yaml works only when running JIT from source — not in Flutter
+/// AOT builds or on the web. So the release tooling stamps this constant:
+/// `tool/release.dart` and `tool/backport_release.dart` rewrite it in the
+/// same step that rewrites the pubspec `version:` line, and
+/// `test/unit/version_sync_test.dart` fails whenever the two drift.
+library;
+
+/// Synced with the `version:` line in pubspec.yaml by the release tooling.
+/// Do not edit by hand — see tool/release.dart.
+const String packageVersion = '1.1.0-beta.14-wip';

--- a/test/unit/version_sync_test.dart
+++ b/test/unit/version_sync_test.dart
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Guard for issue #249: lib/src/version.dart is stamped by the release
+// tooling; this test fails the suite — and release.dart itself, which runs
+// the tests after rewriting pubspec.yaml — whenever the two drift.
+
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/src/version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('packageVersion matches the version in pubspec.yaml', () {
+    final line = File('pubspec.yaml')
+        .readAsLinesSync()
+        .firstWhere((l) => l.startsWith('version:'));
+    final pubspecVersion = line.substring('version:'.length).trim();
+    expect(packageVersion, equals(pubspecVersion));
+  });
+}

--- a/tool/backport_release.dart
+++ b/tool/backport_release.dart
@@ -70,6 +70,7 @@ import 'package:pub_semver/pub_semver.dart';
 const _pubspecPath = 'pubspec.yaml';
 const _changelogPath = 'CHANGELOG.md';
 const _readmePath = 'README.md';
+const _versionFilePath = 'lib/src/version.dart';
 
 /// The dependency whose constraint has to move from the prerelease api line
 /// to the stable one. The beta depends on e.g. `^1.0.0-rc.1`; a `0.9.x`
@@ -171,6 +172,7 @@ Future<void> main(List<String> args) async {
     _runOrThrow('git', ['checkout', '--detach', from]);
 
     _replaceVersionLine(to: version);
+    _replaceVersionConst(to: version);
     _replaceDependencyConstraint(name: _backportedDep, to: apiConstraint);
     _replaceReadmeVersion(packageName: _readPackageName(), to: version);
     // The beta tag's CHANGELOG predates the entry we just validated on the
@@ -199,6 +201,7 @@ Future<void> main(List<String> args) async {
       'add',
       _pubspecPath,
       _changelogPath,
+      _versionFilePath,
       if (File(_readmePath).existsSync()) _readmePath,
     ]);
     _runOrThrow('git', [
@@ -464,6 +467,30 @@ void _replaceVersionLine({required String to}) {
   if (!replaced) throw StateError('no `version:` line in $_pubspecPath');
   f.writeAsStringSync('${lines.join('\n')}\n');
   stdout.writeln('✓ pubspec version -> $to');
+}
+
+/// Rewrites the stamped `packageVersion` const in lib/src/version.dart
+/// (see issue #249), so the backported release identifies itself as its own
+/// version rather than the beta's. Throws if the line is missing so a moved
+/// or hand-edited file fails the release loudly.
+void _replaceVersionConst({required String to}) {
+  final f = File(_versionFilePath);
+  final lines = f.readAsLinesSync();
+  final re = RegExp(r"^const String packageVersion = '.*';$");
+  var replaced = false;
+  for (var i = 0; i < lines.length; i++) {
+    if (!re.hasMatch(lines[i])) continue;
+    lines[i] = "const String packageVersion = '$to';";
+    replaced = true;
+    break;
+  }
+  if (!replaced) {
+    throw StateError(
+      'did not find the packageVersion const in $_versionFilePath',
+    );
+  }
+  f.writeAsStringSync('${lines.join('\n')}\n');
+  stdout.writeln('✓ $_versionFilePath -> $to');
 }
 
 /// Rewrites `  <name>: <constraint>` in place, preserving indentation and any

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -60,6 +60,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 const _wipSuffix = '-wip';
 const _pubspecPath = 'pubspec.yaml';
 const _changelogPath = 'CHANGELOG.md';
+const _versionFilePath = 'lib/src/version.dart';
 
 Future<void> main(List<String> args) async {
   final flags = _Flags.parse(args);
@@ -104,6 +105,7 @@ Future<void> main(List<String> args) async {
   try {
     // ---- release commit ----
     _replaceVersionLine(from: current, to: release);
+    _replaceVersionConst(to: release);
     _replaceChangelogSection(
       from: current,
       newHeader: '## [$release] - ${_today()}',
@@ -139,6 +141,7 @@ Future<void> main(List<String> args) async {
       'add',
       _pubspecPath,
       _changelogPath,
+      _versionFilePath,
       if (readmeRefs > 0) _readmePath,
     ]);
     _runOrThrow('git', ['commit', '-m', 'Release $release']);
@@ -147,8 +150,9 @@ Future<void> main(List<String> args) async {
 
     // ---- next-wip commit ----
     _replaceVersionLine(from: release, to: nextWip);
+    _replaceVersionConst(to: nextWip);
     _injectChangelogSectionAbove(existingHeader: release, newSection: nextWip);
-    _runOrThrow('git', ['add', _pubspecPath, _changelogPath]);
+    _runOrThrow('git', ['add', _pubspecPath, _changelogPath, _versionFilePath]);
     _runOrThrow('git', ['commit', '-m', 'Bump to $nextWip']);
   } catch (e) {
     stderr
@@ -499,6 +503,29 @@ void _replaceVersionLine({required String from, required String to}) {
   }
   // readAsLinesSync drops line terminators; rejoin with \n and add a
   // trailing newline so we don't end the file abruptly.
+  f.writeAsStringSync('${lines.join('\n')}\n');
+}
+
+/// Rewrites the stamped `packageVersion` const in lib/src/version.dart
+/// (see issue #249 — Dart has no runtime API for a package's own version).
+/// Line-precise like [_replaceVersionLine]; throws if the line is missing
+/// so a moved or hand-edited file fails the release loudly.
+void _replaceVersionConst({required String to}) {
+  final f = File(_versionFilePath);
+  final lines = f.readAsLinesSync();
+  final re = RegExp(r"^const String packageVersion = '.*';$");
+  var replaced = false;
+  for (var i = 0; i < lines.length; i++) {
+    if (!re.hasMatch(lines[i])) continue;
+    lines[i] = "const String packageVersion = '$to';";
+    replaced = true;
+    break;
+  }
+  if (!replaced) {
+    throw StateError(
+      'did not find the packageVersion const in $_versionFilePath',
+    );
+  }
   f.writeAsStringSync('${lines.join('\n')}\n');
 }
 


### PR DESCRIPTION
Implements the decision in #249.

- **`lib/src/version.dart`** — a `packageVersion` const, documented as stamped by the release tooling.
- **`tool/release.dart`** — rewrites the const alongside the pubspec `version:` line in both the release commit and the next-`-wip` bump, with the same line-precise style; throws loudly if the const line is missing.
- **`tool/backport_release.dart`** — stamps it when restamping the beta tree, so a `0.9.x` republication advertises its own version, not the beta's `-wip`.
- **`test/unit/version_sync_test.dart`** — reads `pubspec.yaml` from disk and compares. Any drift fails CI, and fails `release.dart` itself before publish (it runs the tests *after* rewriting the pubspec), so the release process is the enforcement gate.

Verified: `dart analyze` clean on all four files, guard test passes.

PR #238 should rebase onto this and derive `otlpUserAgent` from the shared const, dropping its hand-synced copy and the literal-vs-literal test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)