### PR TITLE
feat: config records for OTelEnv & strict boolean parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.14-wip]
 
+### Changed
+
+- **BREAKING**: `OTelEnv` configuration functions (`getOtlpConfig`, `getBspConfig`, `getServiceConfig`, `getLogRecordLimits`, etc.) now return strongly-typed Dart Records instead of `Map<String, dynamic>`.
+  Migration hint: Update map accesses to record property accesses (e.g., `config['endpoint'] as String?` → `config.endpoint`).
+
 ### Added
 
 - `TracerProvider.hasSpanProcessors` — allocation-free check for registered

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -26,6 +26,95 @@ typedef BlrpEnvironmentValues = ({
   int? maxExportBatchSize,
 });
 
+/// Raw OTLP environment values parsed by [OTelEnv.getOtlpConfig].
+///
+/// All fields are nullable — `null` means the corresponding env var was
+/// unset or unparseable. Signal-specific variables take precedence over
+/// general ones per the OTel specification.
+typedef OtlpEnvironmentValues = ({
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_ENDPOINT` or
+  /// `OTEL_EXPORTER_OTLP_ENDPOINT`
+  String? endpoint,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL` or
+  /// `OTEL_EXPORTER_OTLP_PROTOCOL`
+  String? protocol,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_HEADERS` or
+  /// `OTEL_EXPORTER_OTLP_HEADERS`
+  Map<String, String>? headers,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE` or
+  /// `OTEL_EXPORTER_OTLP_INSECURE`
+  bool? insecure,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_TIMEOUT` or
+  /// `OTEL_EXPORTER_OTLP_TIMEOUT`
+  Duration? timeout,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_COMPRESSION` or
+  /// `OTEL_EXPORTER_OTLP_COMPRESSION`
+  String? compression,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_CERTIFICATE` or
+  /// `OTEL_EXPORTER_OTLP_CERTIFICATE`
+  String? certificate,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_KEY` or
+  /// `OTEL_EXPORTER_OTLP_CLIENT_KEY`
+  String? clientKey,
+
+  /// Parsed from `OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_CERTIFICATE` or
+  /// `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`
+  String? clientCertificate,
+});
+
+/// Raw BSP environment values parsed by [OTelEnv.getBspConfig].
+///
+/// All fields are nullable — `null` means the corresponding env var was
+/// unset or contained a non-numeric value (a warning is logged in that case).
+/// Domain-level validation belongs in
+/// [BatchSpanProcessorConfig.fromEnvironment], not here.
+typedef BspEnvironmentValues = ({
+  /// Parsed from `OTEL_BSP_SCHEDULE_DELAY`
+  Duration? scheduleDelay,
+
+  /// Parsed from `OTEL_BSP_EXPORT_TIMEOUT`
+  Duration? exportTimeout,
+
+  /// Parsed from `OTEL_BSP_MAX_QUEUE_SIZE`
+  int? maxQueueSize,
+
+  /// Parsed from `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`
+  int? maxExportBatchSize,
+});
+
+/// Raw service environment values parsed by [OTelEnv.getServiceConfig].
+///
+/// All fields are nullable — `null` means the corresponding env var was
+/// unset. `OTEL_SERVICE_NAME` takes precedence over `service.name` in
+/// `OTEL_RESOURCE_ATTRIBUTES` per the spec.
+typedef ServiceEnvironmentValues = ({
+  /// Parsed from `OTEL_SERVICE_NAME` or `service.name` in
+  /// `OTEL_RESOURCE_ATTRIBUTES`
+  String? serviceName,
+
+  /// Parsed from `service.version` in `OTEL_RESOURCE_ATTRIBUTES`
+  String? serviceVersion,
+});
+
+/// Raw log record limit values parsed by [OTelEnv.getLogRecordLimits].
+///
+/// All fields are nullable — `null` means the corresponding env var was
+/// unset or contained a non-numeric value.
+typedef LogRecordLimitsEnvironmentValues = ({
+  /// Parsed from `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+  int? attributeValueLengthLimit,
+
+  /// Parsed from `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT`
+  int? attributeCountLimit,
+});
+
 /// Utility class for handling OpenTelemetry environment variables.
 ///
 /// This class provides methods for reading standard OpenTelemetry environment
@@ -118,11 +207,10 @@ class OTelEnv {
 
   /// Get OTLP configuration from environment variables.
   ///
-  /// Returns a map containing the OTLP configuration read from environment variables.
-  /// Signal-specific variables take precedence over general ones.
-  static Map<String, dynamic> getOtlpConfig({String signal = 'traces'}) {
-    final config = <String, dynamic>{};
-
+  /// Returns an [OtlpEnvironmentValues] record containing the OTLP
+  /// configuration read from environment variables. Signal-specific
+  /// variables take precedence over general ones.
+  static OtlpEnvironmentValues getOtlpConfig({String signal = 'traces'}) {
     // Get endpoint (signal-specific takes precedence)
     String? endpoint;
     switch (signal) {
@@ -138,9 +226,6 @@ class OTelEnv {
         endpoint = _getEnv(otelExporterOtlpLogsEndpoint) ??
             _getEnv(otelExporterOtlpEndpoint);
         break;
-    }
-    if (endpoint != null) {
-      config['endpoint'] = endpoint;
     }
 
     // Get protocol (signal-specific takes precedence)
@@ -159,39 +244,36 @@ class OTelEnv {
             _getEnv(otelExporterOtlpProtocol);
         break;
     }
-    if (protocol != null) {
-      config['protocol'] = protocol;
-    }
 
     // Get headers (signal-specific takes precedence)
-    String? headers;
+    Map<String, String>? parsedHeaders;
+    String? rawHeaders;
     switch (signal) {
       case 'traces':
-        headers = _getEnv(otelExporterOtlpTracesHeaders) ??
+        rawHeaders = _getEnv(otelExporterOtlpTracesHeaders) ??
             _getEnv(otelExporterOtlpHeaders);
         break;
       case 'metrics':
-        headers = _getEnv(otelExporterOtlpMetricsHeaders) ??
+        rawHeaders = _getEnv(otelExporterOtlpMetricsHeaders) ??
             _getEnv(otelExporterOtlpHeaders);
         break;
       case 'logs':
-        headers = _getEnv(otelExporterOtlpLogsHeaders) ??
+        rawHeaders = _getEnv(otelExporterOtlpLogsHeaders) ??
             _getEnv(otelExporterOtlpHeaders);
         break;
     }
-    if (headers != null) {
+    if (rawHeaders != null) {
       if (OTelLog.isDebug()) {
         // The raw value holds the Authorization header the loop below redacts.
         OTelLog.debug('OTelEnv: Parsing $signal headers from env');
       }
-      final parsedHeaders = _parseHeaders(headers);
+      parsedHeaders = _parseHeaders(rawHeaders);
       if (OTelLog.isDebug()) {
         OTelLog.debug('OTelEnv: Parsed ${parsedHeaders.length} header(s)');
         parsedHeaders.forEach((key, value) {
           OTelLog.debug('  ${formatHeaderForLog(key, value)}');
         });
       }
-      config['headers'] = parsedHeaders;
     }
 
     // Get insecure setting (signal-specific takes precedence)
@@ -210,30 +292,28 @@ class OTelEnv {
             _getEnvBoolNullable(otelExporterOtlpInsecure);
         break;
     }
-    if (insecure != null) {
-      config['insecure'] = insecure;
-    }
 
     // Get timeout (signal-specific takes precedence)
-    String? timeout;
+    Duration? parsedTimeout;
+    String? rawTimeout;
     switch (signal) {
       case 'traces':
-        timeout = _getEnv(otelExporterOtlpTracesTimeout) ??
+        rawTimeout = _getEnv(otelExporterOtlpTracesTimeout) ??
             _getEnv(otelExporterOtlpTimeout);
         break;
       case 'metrics':
-        timeout = _getEnv(otelExporterOtlpMetricsTimeout) ??
+        rawTimeout = _getEnv(otelExporterOtlpMetricsTimeout) ??
             _getEnv(otelExporterOtlpTimeout);
         break;
       case 'logs':
-        timeout = _getEnv(otelExporterOtlpLogsTimeout) ??
+        rawTimeout = _getEnv(otelExporterOtlpLogsTimeout) ??
             _getEnv(otelExporterOtlpTimeout);
         break;
     }
-    if (timeout != null) {
-      final timeoutMs = int.tryParse(timeout);
+    if (rawTimeout != null) {
+      final timeoutMs = int.tryParse(rawTimeout);
       if (timeoutMs != null) {
-        config['timeout'] = Duration(milliseconds: timeoutMs);
+        parsedTimeout = Duration(milliseconds: timeoutMs);
       }
     }
 
@@ -253,9 +333,6 @@ class OTelEnv {
             _getEnv(otelExporterOtlpCompression);
         break;
     }
-    if (compression != null) {
-      config['compression'] = compression;
-    }
 
     // Get certificate (signal-specific takes precedence)
     String? certificate;
@@ -272,9 +349,6 @@ class OTelEnv {
         certificate = _getEnv(otelExporterOtlpLogsCertificate) ??
             _getEnv(otelExporterOtlpCertificate);
         break;
-    }
-    if (certificate != null) {
-      config['certificate'] = certificate;
     }
 
     // Get client key (signal-specific takes precedence)
@@ -293,9 +367,6 @@ class OTelEnv {
             _getEnv(otelExporterOtlpClientKey);
         break;
     }
-    if (clientKey != null) {
-      config['clientKey'] = clientKey;
-    }
 
     // Get client certificate (signal-specific takes precedence)
     String? clientCertificate;
@@ -313,23 +384,32 @@ class OTelEnv {
             _getEnv(otelExporterOtlpClientCertificate);
         break;
     }
-    if (clientCertificate != null) {
-      config['clientCertificate'] = clientCertificate;
-    }
 
-    return config;
+    return (
+      endpoint: endpoint,
+      protocol: protocol,
+      headers: parsedHeaders,
+      insecure: insecure,
+      timeout: parsedTimeout,
+      compression: compression,
+      certificate: certificate,
+      clientKey: clientKey,
+      clientCertificate: clientCertificate,
+    );
   }
 
   /// Get service configuration from environment variables.
   ///
-  /// Returns a map containing the service configuration read from environment variables.
+  /// Returns a [ServiceEnvironmentValues] record containing the service
+  /// configuration read from environment variables.
   ///
   /// Handles the spec precedence rules:
   /// - If `service.name` is in OTEL_RESOURCE_ATTRIBUTES, it's used as the base value
   /// - OTEL_SERVICE_NAME takes precedence over `service.name` in OTEL_RESOURCE_ATTRIBUTES
   /// - `service.version` comes from OTEL_RESOURCE_ATTRIBUTES only
-  static Map<String, dynamic> getServiceConfig() {
-    final config = <String, dynamic>{};
+  static ServiceEnvironmentValues getServiceConfig() {
+    String? parsedServiceName;
+    String? parsedServiceVersion;
 
     // First, parse service.name and service.version from OTEL_RESOURCE_ATTRIBUTES
     final resourceStr = _getEnv(otelResourceAttributes);
@@ -342,9 +422,9 @@ class OTelEnv {
           final value = pair.substring(equalIndex + 1).trim();
 
           if (key == Service.serviceName.key) {
-            config['serviceName'] = value;
+            parsedServiceName = value;
           } else if (key == Service.serviceVersion.key) {
-            config['serviceVersion'] = value;
+            parsedServiceVersion = value;
           }
         }
       }
@@ -353,10 +433,13 @@ class OTelEnv {
     // OTEL_SERVICE_NAME takes precedence over service.name from resource attributes
     final serviceName = _getEnv(otelServiceName);
     if (serviceName != null) {
-      config['serviceName'] = serviceName;
+      parsedServiceName = serviceName;
     }
 
-    return config;
+    return (
+      serviceName: parsedServiceName,
+      serviceVersion: parsedServiceVersion,
+    );
   }
 
   /// Get resource attributes from environment variables.
@@ -443,21 +526,20 @@ class OTelEnv {
 
   /// Get Batch Span Processor (BSP) configuration from environment variables.
   ///
-  /// Returns a map containing the BSP configuration read from environment variables.
-  /// Keys returned:
-  /// - 'scheduleDelay': Duration for the schedule delay
-  /// - 'exportTimeout': Duration for the export timeout
-  /// - 'maxQueueSize': int for maximum queue size
-  /// - 'maxExportBatchSize': int for maximum export batch size
-  static Map<String, dynamic> getBspConfig() {
-    final config = <String, dynamic>{};
-
+  /// Returns a [BspEnvironmentValues] record containing the raw parsed BSP
+  /// values from environment variables. Fields are `null` when the
+  /// corresponding env var is unset or contains a non-numeric value.
+  ///
+  /// Domain-level defaults, validation, and clamping belong in
+  /// [BatchSpanProcessorConfig.fromEnvironment], not here.
+  static BspEnvironmentValues getBspConfig() {
     // Get schedule delay
+    Duration? parsedScheduleDelay;
     final scheduleDelay = _getEnv(otelBspScheduleDelay);
     if (scheduleDelay != null) {
       final delayMs = int.tryParse(scheduleDelay);
       if (delayMs != null) {
-        config['scheduleDelay'] = Duration(milliseconds: delayMs);
+        parsedScheduleDelay = Duration(milliseconds: delayMs);
       } else {
         if (OTelLog.isWarn()) {
           OTelLog.warn('OTelEnv: Invalid OTEL_BSP_SCHEDULE_DELAY value '
@@ -467,11 +549,12 @@ class OTelEnv {
     }
 
     // Get export timeout
+    Duration? parsedExportTimeout;
     final exportTimeout = _getEnv(otelBspExportTimeout);
     if (exportTimeout != null) {
       final timeoutMs = int.tryParse(exportTimeout);
       if (timeoutMs != null) {
-        config['exportTimeout'] = Duration(milliseconds: timeoutMs);
+        parsedExportTimeout = Duration(milliseconds: timeoutMs);
       } else {
         if (OTelLog.isWarn()) {
           OTelLog.warn('OTelEnv: Invalid OTEL_BSP_EXPORT_TIMEOUT value '
@@ -481,11 +564,12 @@ class OTelEnv {
     }
 
     // Get max queue size
+    int? parsedMaxQueueSize;
     final maxQueueSize = _getEnv(otelBspMaxQueueSize);
     if (maxQueueSize != null) {
       final size = int.tryParse(maxQueueSize);
       if (size != null) {
-        config['maxQueueSize'] = size;
+        parsedMaxQueueSize = size;
       } else {
         if (OTelLog.isWarn()) {
           OTelLog.warn('OTelEnv: Invalid OTEL_BSP_MAX_QUEUE_SIZE value '
@@ -495,11 +579,12 @@ class OTelEnv {
     }
 
     // Get max export batch size
+    int? parsedMaxExportBatchSize;
     final maxExportBatchSize = _getEnv(otelBspMaxExportBatchSize);
     if (maxExportBatchSize != null) {
       final size = int.tryParse(maxExportBatchSize);
       if (size != null) {
-        config['maxExportBatchSize'] = size;
+        parsedMaxExportBatchSize = size;
       } else {
         if (OTelLog.isWarn()) {
           OTelLog.warn('OTelEnv: Invalid OTEL_BSP_MAX_EXPORT_BATCH_SIZE '
@@ -508,7 +593,12 @@ class OTelEnv {
       }
     }
 
-    return config;
+    return (
+      scheduleDelay: parsedScheduleDelay,
+      exportTimeout: parsedExportTimeout,
+      maxQueueSize: parsedMaxQueueSize,
+      maxExportBatchSize: parsedMaxExportBatchSize,
+    );
   }
 
   /// Reads `OTEL_PROPAGATORS` (sdk-environment-variables.md, "General SDK
@@ -564,32 +654,28 @@ class OTelEnv {
 
   /// Get LogRecord attribute limits from environment variables.
   ///
-  /// Returns a map containing the log record attribute limits.
-  /// Keys returned:
-  /// - 'attributeValueLengthLimit': int for max attribute value length
-  /// - 'attributeCountLimit': int for max number of attributes
-  static Map<String, dynamic> getLogRecordLimits() {
-    final config = <String, dynamic>{};
-
+  /// Returns a [LogRecordLimitsEnvironmentValues] record containing the
+  /// log record attribute limits. Fields are `null` when the corresponding
+  /// env var is unset or contains a non-numeric value.
+  static LogRecordLimitsEnvironmentValues getLogRecordLimits() {
     // Get attribute value length limit
+    int? parsedValueLengthLimit;
     final valueLengthLimit = _getEnv(otelLogrecordAttributeValueLengthLimit);
     if (valueLengthLimit != null) {
-      final limit = int.tryParse(valueLengthLimit);
-      if (limit != null) {
-        config['attributeValueLengthLimit'] = limit;
-      }
+      parsedValueLengthLimit = int.tryParse(valueLengthLimit);
     }
 
     // Get attribute count limit
+    int? parsedCountLimit;
     final countLimit = _getEnv(otelLogrecordAttributeCountLimit);
     if (countLimit != null) {
-      final limit = int.tryParse(countLimit);
-      if (limit != null) {
-        config['attributeCountLimit'] = limit;
-      }
+      parsedCountLimit = int.tryParse(countLimit);
     }
 
-    return config;
+    return (
+      attributeValueLengthLimit: parsedValueLengthLimit,
+      attributeCountLimit: parsedCountLimit,
+    );
   }
 
   /// Resolves whether an OTLP connection should use TLS, per the OTLP

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -756,32 +756,48 @@ class OTelEnv {
   /// @param name The name of the environment variable
   /// @return true if the environment variable has a truthy value, false otherwise
   static bool _getEnvBool(String name) {
-    final value = _getEnv(name)?.toLowerCase();
-    return value == '1' || value == 'true' || value == 'yes' || value == 'on';
+    final rawValue = _getEnv(name);
+    if (rawValue == null || rawValue.isEmpty) return false;
+
+    final value = rawValue.toLowerCase();
+    if (value == 'true') {
+      return true;
+    } else if (value == 'false') {
+      return false;
+    } else {
+      if (OTelLog.isWarn()) {
+        OTelLog.warn('OTelEnv: Invalid boolean value for $name: "$rawValue". '
+            'Expected "true" or "false". Treating as false.');
+      }
+      return false;
+    }
   }
 
   /// Get boolean environment variable value that can be null.
   ///
   /// This method converts an environment variable value to a boolean.
-  /// Values of '1', 'true', 'yes', and 'on' (case-insensitive) are considered true.
-  /// Values of '0', 'false', 'no', and 'off' (case-insensitive) are considered false.
+  /// Only the case-insensitive string 'true' is considered true.
+  /// All other values are considered false.
+  /// Returns null only when the variable is unset or empty.
   ///
   /// @param name The name of the environment variable
-  /// @return true/false if the environment variable has a valid boolean value, null otherwise
+  /// @return true/false if the environment variable is set, null otherwise
   static bool? _getEnvBoolNullable(String name) {
-    final value = _getEnv(name)?.toLowerCase();
-    if (value == null) return null;
+    final rawValue = _getEnv(name);
+    if (rawValue == null || rawValue.isEmpty) return null;
 
-    if (value == '1' || value == 'true' || value == 'yes' || value == 'on') {
+    final value = rawValue.toLowerCase();
+    if (value == 'true') {
       return true;
-    } else if (value == '0' ||
-        value == 'false' ||
-        value == 'no' ||
-        value == 'off') {
+    } else if (value == 'false') {
+      return false;
+    } else {
+      if (OTelLog.isWarn()) {
+        OTelLog.warn('OTelEnv: Invalid boolean value for $name: "$rawValue". '
+            'Expected "true" or "false". Treating as false.');
+      }
       return false;
     }
-
-    return null;
   }
 
   /// Get a non-negative integer environment variable value.

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -125,15 +125,15 @@ class LogsConfiguration {
   ) {
     // Get OTLP config for logs signal
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'logs');
-    final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
+    final protocol = otlpConfig.protocol ?? 'http/protobuf';
 
     // Use env endpoint if available, otherwise use provided endpoint. The
     // default endpoint depends on the protocol (issue #220): OTLP/gRPC uses
     // port 4317, the HTTP protocols use port 4318.
-    final effectiveEndpoint = otlpConfig['endpoint'] as String? ??
+    final effectiveEndpoint = otlpConfig.endpoint ??
         endpoint ??
         (protocol == 'grpc' ? OTel.defaultGrpcEndpoint : OTel.defaultEndpoint);
-    final envInsecure = otlpConfig['insecure'] as bool?;
+    final envInsecure = otlpConfig.insecure;
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: envInsecure,
       endpoint: effectiveEndpoint,
@@ -157,13 +157,12 @@ class LogsConfiguration {
           OtlpGrpcLogRecordExporterConfig(
             endpoint: effectiveEndpoint,
             insecure: !effectiveSecure,
-            headers: otlpConfig['headers'] as Map<String, String>? ?? {},
-            timeout: otlpConfig['timeout'] as Duration? ??
-                const Duration(seconds: 10),
-            compression: otlpConfig['compression'] == 'gzip',
-            certificate: otlpConfig['certificate'] as String?,
-            clientKey: otlpConfig['clientKey'] as String?,
-            clientCertificate: otlpConfig['clientCertificate'] as String?,
+            headers: otlpConfig.headers ?? {},
+            timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
+            compression: otlpConfig.compression == 'gzip',
+            certificate: otlpConfig.certificate,
+            clientKey: otlpConfig.clientKey,
+            clientCertificate: otlpConfig.clientCertificate,
           ),
         );
       } else {
@@ -175,13 +174,12 @@ class LogsConfiguration {
         return OtlpHttpLogRecordExporter(
           OtlpHttpLogRecordExporterConfig(
             endpoint: effectiveEndpoint,
-            headers: otlpConfig['headers'] as Map<String, String>? ?? {},
-            timeout: otlpConfig['timeout'] as Duration? ??
-                const Duration(seconds: 10),
-            compression: otlpConfig['compression'] == 'gzip',
-            certificate: otlpConfig['certificate'] as String?,
-            clientKey: otlpConfig['clientKey'] as String?,
-            clientCertificate: otlpConfig['clientCertificate'] as String?,
+            headers: otlpConfig.headers ?? {},
+            timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
+            compression: otlpConfig.compression == 'gzip',
+            certificate: otlpConfig.certificate,
+            clientKey: otlpConfig.clientKey,
+            clientCertificate: otlpConfig.clientCertificate,
           ),
         );
       }

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -143,26 +143,26 @@ class MetricsConfiguration {
     }
 
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
-    final protocol = otlpConfig['protocol'] as String? ?? 'http/protobuf';
+    final protocol = otlpConfig.protocol ?? 'http/protobuf';
     // The default endpoint depends on the protocol (issue #220): OTLP/gRPC
     // uses port 4317, the HTTP protocols use port 4318.
-    final effectiveEndpoint = endpoint ??
+    final effectiveEndpoint = otlpConfig.endpoint ??
+        endpoint ??
         (protocol == 'grpc' ? OTel.defaultGrpcEndpoint : OTel.defaultEndpoint);
     // Parity with logs_config: honor OTEL_EXPORTER_OTLP_METRICS_INSECURE
     // (previously parsed and dropped) and the endpoint scheme per the
     // OTLP spec, falling back to the resolved global setting.
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
-      envInsecure: otlpConfig['insecure'] as bool?,
+      envInsecure: otlpConfig.insecure,
       endpoint: effectiveEndpoint,
       fallback: secure,
     );
-    final headers = otlpConfig['headers'] as Map<String, String>? ?? const {};
-    final timeout =
-        otlpConfig['timeout'] as Duration? ?? const Duration(seconds: 10);
-    final compression = otlpConfig['compression'] == 'gzip';
-    final certificate = otlpConfig['certificate'] as String?;
-    final clientKey = otlpConfig['clientKey'] as String?;
-    final clientCertificate = otlpConfig['clientCertificate'] as String?;
+    final headers = otlpConfig.headers ?? const {};
+    final timeout = otlpConfig.timeout ?? const Duration(seconds: 10);
+    final compression = otlpConfig.compression == 'gzip';
+    final certificate = otlpConfig.certificate;
+    final clientKey = otlpConfig.clientKey;
+    final clientCertificate = otlpConfig.clientCertificate;
 
     if (protocol == 'grpc') {
       if (OTelLog.isDebug()) {

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -162,22 +162,20 @@ class OTel {
     OTelEnv.applyHeaderLogAllowlist(otlpHeaderLogAllowlist);
 
     // Apply environment variables only if parameters are not provided
-    final envServiceName = serviceName == null
-        ? OTelEnv.getServiceConfig()['serviceName'] as String?
-        : null;
-    final envServiceVersion = serviceVersion == null
-        ? OTelEnv.getServiceConfig()['serviceVersion'] as String?
-        : null;
+    final envServiceConfig = OTelEnv.getServiceConfig();
+    final envServiceName =
+        serviceName == null ? envServiceConfig.serviceName : null;
+    final envServiceVersion =
+        serviceVersion == null ? envServiceConfig.serviceVersion : null;
 
     serviceName ??= envServiceName;
     serviceVersion ??= envServiceVersion;
 
     final otlpConfig = (endpoint == null || secure == null)
         ? OTelEnv.getOtlpConfig(signal: 'traces')
-        : <String, dynamic>{};
-    final envEndpoint =
-        endpoint == null ? otlpConfig['endpoint'] as String? : null;
-    final envInsecure = secure == null ? otlpConfig['insecure'] as bool? : null;
+        : null;
+    final envEndpoint = endpoint == null ? otlpConfig?.endpoint : null;
+    final envInsecure = secure == null ? otlpConfig?.insecure : null;
 
     endpoint ??= envEndpoint;
     secure = OTelEnv.resolveOtlpSecure(
@@ -286,8 +284,7 @@ class OTel {
     _installGlobalPropagator();
 
     if (OTelLog.isDebug()) {
-      final traceProtocol =
-          otlpConfigForExporter['protocol'] as String? ?? 'http/protobuf';
+      final traceProtocol = otlpConfigForExporter.protocol ?? 'http/protobuf';
       OTelLog.debug(
         'OTel initialized with endpoint: '
         '${endpoint ?? (traceProtocol == 'grpc' ? defaultGrpcEndpoint : defaultEndpoint)}, '
@@ -359,8 +356,7 @@ class OTel {
         // spanProcessor remains null and no processor is added.
       } else {
         // Determine protocol - default to http/protobuf if not set
-        final protocol =
-            otlpConfigForExporter['protocol'] as String? ?? 'http/protobuf';
+        final protocol = otlpConfigForExporter.protocol ?? 'http/protobuf';
 
         // Capture the resolved values: promotion of the nullable
         // parameters does not carry into the closure. The endpoint default is
@@ -372,7 +368,7 @@ class OTel {
         final resolvedEndpoint = endpoint ??
             (protocol == 'grpc' ? defaultGrpcEndpoint : defaultEndpoint);
         final resolvedSecure = OTelEnv.resolveOtlpSecure(
-          envInsecure: otlpConfigForExporter['insecure'] as bool?,
+          envInsecure: otlpConfigForExporter.insecure,
           endpoint: resolvedEndpoint,
           fallback: secure,
         );
@@ -383,16 +379,13 @@ class OTel {
               OtlpGrpcExporterConfig(
                 endpoint: resolvedEndpoint,
                 insecure: !resolvedSecure,
-                headers:
-                    otlpConfigForExporter['headers'] as Map<String, String>? ??
-                        {},
-                timeout: otlpConfigForExporter['timeout'] as Duration? ??
+                headers: otlpConfigForExporter.headers ?? {},
+                timeout: otlpConfigForExporter.timeout ??
                     const Duration(seconds: 10),
-                compression: otlpConfigForExporter['compression'] == 'gzip',
-                certificate: otlpConfigForExporter['certificate'] as String?,
-                clientKey: otlpConfigForExporter['clientKey'] as String?,
-                clientCertificate:
-                    otlpConfigForExporter['clientCertificate'] as String?,
+                compression: otlpConfigForExporter.compression == 'gzip',
+                certificate: otlpConfigForExporter.certificate,
+                clientKey: otlpConfigForExporter.clientKey,
+                clientCertificate: otlpConfigForExporter.clientCertificate,
               ),
             );
           } else {
@@ -404,16 +397,13 @@ class OTel {
             return OtlpHttpSpanExporter(
               OtlpHttpExporterConfig(
                 endpoint: resolvedEndpoint,
-                headers:
-                    otlpConfigForExporter['headers'] as Map<String, String>? ??
-                        {},
-                timeout: otlpConfigForExporter['timeout'] as Duration? ??
+                headers: otlpConfigForExporter.headers ?? {},
+                timeout: otlpConfigForExporter.timeout ??
                     const Duration(seconds: 10),
-                compression: otlpConfigForExporter['compression'] == 'gzip',
-                certificate: otlpConfigForExporter['certificate'] as String?,
-                clientKey: otlpConfigForExporter['clientKey'] as String?,
-                clientCertificate:
-                    otlpConfigForExporter['clientCertificate'] as String?,
+                compression: otlpConfigForExporter.compression == 'gzip',
+                certificate: otlpConfigForExporter.certificate,
+                clientKey: otlpConfigForExporter.clientKey,
+                clientCertificate: otlpConfigForExporter.clientCertificate,
                 protocol: httpProtocol,
               ),
             );

--- a/lib/src/trace/export/batch_span_processor.dart
+++ b/lib/src/trace/export/batch_span_processor.dart
@@ -70,15 +70,15 @@ class BatchSpanProcessorConfig {
   factory BatchSpanProcessorConfig.fromEnvironment() {
     final env = OTelEnv.getBspConfig();
 
-    var queueSize = (env['maxQueueSize'] as int?) ?? 2048;
-    var batchSize = (env['maxExportBatchSize'] as int?) ?? 512;
+    var queueSize = env.maxQueueSize ?? 2048;
+    var batchSize = env.maxExportBatchSize ?? 512;
 
     // --- scheduleDelay ---
     // Spec type: Duration. Zero is valid ("export as fast as possible").
     // Negative values MUST warn and fall back to default.
     Duration scheduleDelay;
-    if (env['scheduleDelay'] is Duration) {
-      final delay = env['scheduleDelay'] as Duration;
+    if (env.scheduleDelay != null) {
+      final delay = env.scheduleDelay!;
       if (delay.inMilliseconds >= 0) {
         scheduleDelay = delay;
       } else {
@@ -97,8 +97,8 @@ class BatchSpanProcessorConfig {
     // Spec type: Timeout. Zero means "no limit" — substitute a very large
     // duration. Negative values MUST warn and fall back to default.
     Duration exportTimeout;
-    if (env['exportTimeout'] is Duration) {
-      final timeout = env['exportTimeout'] as Duration;
+    if (env.exportTimeout != null) {
+      final timeout = env.exportTimeout!;
       if (timeout.inMilliseconds == 0) {
         exportTimeout = noLimit;
       } else if (timeout.inMilliseconds > 0) {

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -56,7 +56,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(5000));
       expect(result['exportTimeout_ms'], equals(30000));
       expect(result['maxQueueSize'], equals(2048));
@@ -69,7 +69,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': '0'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(0));
       expect(result['logs'], isEmpty);
     });
@@ -79,7 +79,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': '-1'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(5000));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(1));
@@ -91,7 +91,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': '0'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(0x7FFFFFFF));
       expect(result['logs'], isEmpty);
     });
@@ -101,7 +101,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': '-1'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(30000));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(1));
@@ -116,7 +116,7 @@ void main() {
           'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': '200',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(100));
       expect(result['maxExportBatchSize'], equals(100));
       expect(result['logs'], isEmpty);
@@ -127,7 +127,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_MAX_QUEUE_SIZE': '-5'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(2048));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(1));
@@ -144,7 +144,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': '2000'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(2000));
     });
 
@@ -153,7 +153,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': '30000'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(30000));
     });
 
@@ -162,7 +162,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_QUEUE_SIZE': '4096'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(4096));
     });
 
@@ -171,7 +171,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': '1024'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxExportBatchSize'], equals(1024));
     });
 
@@ -180,7 +180,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': 'not-a-number'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('scheduleDelay_ms'), isFalse);
     });
 
@@ -189,7 +189,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': 'abc'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('exportTimeout_ms'), isFalse);
     });
 
@@ -198,7 +198,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_QUEUE_SIZE': 'xyz'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('maxQueueSize'), isFalse);
     });
 
@@ -207,7 +207,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': 'foo'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('maxExportBatchSize'), isFalse);
     });
 
@@ -216,7 +216,7 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result, isEmpty);
     });
   });
@@ -230,7 +230,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_SCHEDULE_DELAY': '2000'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(2000));
     });
 
@@ -239,7 +239,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': '30000'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(30000));
     });
 
@@ -248,7 +248,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': '4096'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(4096));
     });
 
@@ -257,7 +257,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '1024'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxExportBatchSize'], equals(1024));
     });
 
@@ -271,7 +271,7 @@ void main() {
           'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '512',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(1000));
       expect(result['exportTimeout_ms'], equals(5000));
       expect(result['maxQueueSize'], equals(2048));
@@ -283,7 +283,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_SCHEDULE_DELAY': 'not-a-number'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('scheduleDelay_ms'), isFalse);
     });
 
@@ -292,7 +292,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': 'abc'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('exportTimeout_ms'), isFalse);
     });
 
@@ -301,7 +301,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': 'xyz'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('maxQueueSize'), isFalse);
     });
 
@@ -310,7 +310,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': 'foo'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('maxExportBatchSize'), isFalse);
     });
 
@@ -319,7 +319,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_SCHEDULE_DELAY': '0'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(0));
     });
 
@@ -328,7 +328,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': '0'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(0));
     });
 
@@ -337,7 +337,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': '-1'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('exportTimeout_ms'), isFalse);
     });
 
@@ -347,7 +347,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': '0'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       // 0 is now accepted by OTelEnv (just type-checked); domain validation
       // (> 0) belongs in BatchLogRecordProcessorConfig.fromEnvironment().
       expect(result['maxQueueSize'], equals(0));
@@ -358,7 +358,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': '-1'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('maxQueueSize'), isFalse);
     });
 
@@ -367,7 +367,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '-10'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('maxExportBatchSize'), isFalse);
     });
 
@@ -380,7 +380,7 @@ void main() {
           'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '200',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(100));
       expect(result['maxExportBatchSize'], equals(200));
     });
@@ -390,7 +390,7 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result, isEmpty);
     });
   });
@@ -404,7 +404,7 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': '256'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['attributeValueLengthLimit'], equals(256));
     });
 
@@ -413,7 +413,7 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '64'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['attributeCountLimit'], equals(64));
     });
 
@@ -425,7 +425,7 @@ void main() {
           'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '128',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['attributeValueLengthLimit'], equals(512));
       expect(result['attributeCountLimit'], equals(128));
     });
@@ -435,7 +435,7 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': 'not-a-number'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('attributeValueLengthLimit'), isFalse);
     });
 
@@ -444,7 +444,7 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': 'bad'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result.containsKey('attributeCountLimit'), isFalse);
     });
 
@@ -453,7 +453,7 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result, isEmpty);
     });
   });
@@ -467,7 +467,7 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'key='},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       // "key=" has equalIndex at position 3, but equalIndex < pair.length - 1
       // is false (3 < 3 is false), so it should be skipped
       expect(result.containsKey('key'), isFalse);
@@ -483,7 +483,7 @@ void main() {
               'authorization=Bearer s3cr3t-token-value,x-api=notasecret',
         },
       );
-      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
 
       expect(lines, isNotEmpty);
       expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse);
@@ -500,7 +500,7 @@ void main() {
               'authorization=Bearer s3cr3t,x-api-key=key-value,x-trace-id=t-1',
         },
       );
-      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
 
       expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
       expect(lines.any((l) => l.contains('key-value')), isFalse);
@@ -518,7 +518,7 @@ void main() {
           'OTEL_DART_HEADER_LOG_ALLOWLIST': 'x-trace-id',
         },
       );
-      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
 
       expect(lines, anyElement(contains('x-trace-id: t-1')));
       expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
@@ -535,7 +535,7 @@ void main() {
           'OTEL_DART_HEADER_LOG_ALLOWLIST': 'authorization',
         },
       );
-      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
 
       expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
       expect(lines, anyElement(contains('authorization: [REDACTED]')));
@@ -550,7 +550,7 @@ void main() {
         },
         args: ['x-trace-id'],
       );
-      final lines = (jsonDecode(output.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
 
       expect(lines, anyElement(contains('x-trace-id: t-1')));
       expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
@@ -561,7 +561,7 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'noequalssign'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result, isEmpty);
     });
 
@@ -570,7 +570,7 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': '=value'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       // equalIndex is 0, which is not > 0, so it should be skipped
       expect(result, isEmpty);
     });
@@ -583,7 +583,7 @@ void main() {
               'authorization=Basic dXNlcjpwYXNz==,x-api=val',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['authorization'], equals('Basic dXNlcjpwYXNz=='));
       expect(result['x-api'], equals('val'));
     });
@@ -593,7 +593,7 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': ' key1 = value1 , key2 = value2 '},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['key1'], equals('value1'));
       expect(result['key2'], equals('value2'));
     });
@@ -603,7 +603,7 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'single=header'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['single'], equals('header'));
     });
 
@@ -612,7 +612,7 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'good=val,bad,=nokey,also-good=yes'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['good'], equals('val'));
       expect(result['also-good'], equals('yes'));
       expect(result.containsKey('bad'), isFalse);
@@ -634,7 +634,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isTrue);
     });
 
@@ -647,7 +647,7 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -660,7 +660,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['protocol'], equals('http/protobuf'));
     });
 
@@ -673,7 +673,7 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['protocol'], equals('http/json'));
     });
 
@@ -686,7 +686,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['timeout_ms'], equals(5000));
     });
 
@@ -699,7 +699,7 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['timeout_ms'], equals(8000));
     });
 
@@ -712,7 +712,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['compression'], equals('gzip'));
     });
 
@@ -725,7 +725,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['certificate'], equals('/metrics/cert.pem'));
     });
 
@@ -738,7 +738,7 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['certificate'], equals('/logs/cert.pem'));
     });
 
@@ -751,7 +751,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['clientKey'], equals('/metrics/key.pem'));
     });
 
@@ -764,7 +764,7 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['clientKey'], equals('/logs/key.pem'));
     });
 
@@ -778,7 +778,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['clientCertificate'], equals('/metrics/client.pem'));
     });
 
@@ -798,7 +798,7 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['endpoint'], equals('http://metrics:4318'));
       expect(result['protocol'], equals('http/protobuf'));
       expect(result['insecure'], isTrue);
@@ -827,7 +827,7 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['endpoint'], equals('http://logs:4318'));
       expect(result['protocol'], equals('http/json'));
       expect(result['insecure'], isFalse);
@@ -846,31 +846,31 @@ void main() {
   // (tested indirectly through insecure settings)
   // =========================================================================
   group('OTelEnv._getEnvBoolNullable edge cases (subprocess)', () {
-    test('insecure "1" is true', () async {
+    test('insecure "1" is false', () async {
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': '1'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-      expect(result['insecure'], isTrue);
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
     });
 
-    test('insecure "yes" is true', () async {
+    test('insecure "yes" is false', () async {
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'yes'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-      expect(result['insecure'], isTrue);
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
     });
 
-    test('insecure "on" is true', () async {
+    test('insecure "on" is false', () async {
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'on'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-      expect(result['insecure'], isTrue);
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
     });
 
     test('insecure "0" is false', () async {
@@ -878,7 +878,7 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': '0'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -887,7 +887,7 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'no'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -896,7 +896,7 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'off'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -905,7 +905,7 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'FALSE'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -914,18 +914,17 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'TRUE'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['insecure'], isTrue);
     });
 
-    test('insecure with unrecognized value returns null (no insecure key)',
-        () async {
+    test('insecure with unrecognized value returns false', () async {
       final output = await runWithEnv(
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-      expect(result.containsKey('insecure'), isFalse);
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      expect(result['insecure'], isFalse);
     });
   });
 
@@ -1001,7 +1000,7 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'key1=value1,key2=value2'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['key1'], equals('value1'));
       expect(result['key2'], equals('value2'));
     });
@@ -1011,7 +1010,7 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'path=/usr%2Flocal%2Fbin'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['path'], equals('/usr/local/bin'));
     });
 
@@ -1020,7 +1019,7 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': ''},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result, isEmpty);
     });
 
@@ -1029,7 +1028,7 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-app'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['service.name'], equals('my-app'));
     });
 
@@ -1038,7 +1037,7 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'good=val,badentry,also-good=yes'},
       );
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['good'], equals('val'));
       expect(result['also-good'], equals('yes'));
       expect(result.containsKey('badentry'), isFalse);
@@ -1121,7 +1120,7 @@ void main() {
 
     test('default installs tracecontext + baggage composite', () async {
       final output = await runWithEnv(helper, {});
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['type'], contains('CompositePropagator'));
       expect(
           result['fields'], equals(['baggage', 'traceparent', 'tracestate']));
@@ -1132,21 +1131,21 @@ void main() {
         () async {
       final output =
           await runWithEnv(helper, {'OTEL_PROPAGATORS': 'tracecontext'});
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['type'], contains('W3CTraceContextPropagator'));
       expect(result['fields'], equals(['traceparent', 'tracestate']));
     });
 
     test('baggage alone installs the W3C baggage propagator', () async {
       final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'baggage'});
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['type'], contains('W3CBaggagePropagator'));
       expect(result['fields'], equals(['baggage']));
     });
 
     test('none leaves the spec-mandated no-op propagator', () async {
       final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'none'});
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['type'], contains('NoopTextMapPropagator'));
       expect(result['fields'], isEmpty);
     });
@@ -1154,7 +1153,7 @@ void main() {
     test('unsupported names warn and are ignored', () async {
       final output = await runWithEnv(
           helper, {'OTEL_PROPAGATORS': 'tracecontext,b3,xray'});
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['type'], contains('W3CTraceContextPropagator'));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(2));
@@ -1164,7 +1163,7 @@ void main() {
 
     test('only unsupported names keeps the no-op default and warns', () async {
       final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'jaeger'});
-      final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
       expect(result['type'], contains('NoopTextMapPropagator'));
       expect((result['logs'] as List<dynamic>).single.toString(),
           contains('"jaeger" ignored'));

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -974,9 +974,10 @@ void main() {
       expect(config, isA<BlrpEnvironmentValues>());
     });
 
-    test('getLogRecordLimits returns a Map<String, dynamic>', () {
+    test('getLogRecordLimits returns a LogRecordLimitsEnvironmentValues record',
+        () {
       final config = OTelEnv.getLogRecordLimits();
-      expect(config, isA<Map<String, dynamic>>());
+      expect(config, isA<LogRecordLimitsEnvironmentValues>());
     });
 
     test('getExporter for metrics returns nullable result', () {

--- a/test/unit/environment/env_coverage_test.dart
+++ b/test/unit/environment/env_coverage_test.dart
@@ -56,7 +56,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(5000));
       expect(result['exportTimeout_ms'], equals(30000));
       expect(result['maxQueueSize'], equals(2048));
@@ -69,7 +70,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': '0'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(0));
       expect(result['logs'], isEmpty);
     });
@@ -79,7 +81,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': '-1'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(5000));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(1));
@@ -91,7 +94,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': '0'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(0x7FFFFFFF));
       expect(result['logs'], isEmpty);
     });
@@ -101,7 +105,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': '-1'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(30000));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(1));
@@ -116,7 +121,8 @@ void main() {
           'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': '200',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(100));
       expect(result['maxExportBatchSize'], equals(100));
       expect(result['logs'], isEmpty);
@@ -127,7 +133,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_from_env.dart',
         {'OTEL_BSP_MAX_QUEUE_SIZE': '-5'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(2048));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(1));
@@ -144,7 +151,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': '2000'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(2000));
     });
 
@@ -153,7 +161,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': '30000'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(30000));
     });
 
@@ -162,7 +171,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_QUEUE_SIZE': '4096'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(4096));
     });
 
@@ -171,7 +181,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': '1024'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxExportBatchSize'], equals(1024));
     });
 
@@ -180,7 +191,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_SCHEDULE_DELAY': 'not-a-number'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('scheduleDelay_ms'), isFalse);
     });
 
@@ -189,7 +201,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_EXPORT_TIMEOUT': 'abc'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('exportTimeout_ms'), isFalse);
     });
 
@@ -198,7 +211,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_QUEUE_SIZE': 'xyz'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('maxQueueSize'), isFalse);
     });
 
@@ -207,7 +221,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': 'foo'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('maxExportBatchSize'), isFalse);
     });
 
@@ -216,7 +231,8 @@ void main() {
         'test/unit/environment/helpers/check_bsp_config.dart',
         {},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result, isEmpty);
     });
   });
@@ -230,7 +246,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_SCHEDULE_DELAY': '2000'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(2000));
     });
 
@@ -239,7 +256,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': '30000'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(30000));
     });
 
@@ -248,7 +266,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': '4096'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(4096));
     });
 
@@ -257,7 +276,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '1024'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxExportBatchSize'], equals(1024));
     });
 
@@ -271,7 +291,8 @@ void main() {
           'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '512',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(1000));
       expect(result['exportTimeout_ms'], equals(5000));
       expect(result['maxQueueSize'], equals(2048));
@@ -283,7 +304,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_SCHEDULE_DELAY': 'not-a-number'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('scheduleDelay_ms'), isFalse);
     });
 
@@ -292,7 +314,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': 'abc'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('exportTimeout_ms'), isFalse);
     });
 
@@ -301,7 +324,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': 'xyz'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('maxQueueSize'), isFalse);
     });
 
@@ -310,7 +334,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': 'foo'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('maxExportBatchSize'), isFalse);
     });
 
@@ -319,7 +344,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_SCHEDULE_DELAY': '0'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['scheduleDelay_ms'], equals(0));
     });
 
@@ -328,7 +354,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': '0'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['exportTimeout_ms'], equals(0));
     });
 
@@ -337,7 +364,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_EXPORT_TIMEOUT': '-1'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('exportTimeout_ms'), isFalse);
     });
 
@@ -347,7 +375,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': '0'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       // 0 is now accepted by OTelEnv (just type-checked); domain validation
       // (> 0) belongs in BatchLogRecordProcessorConfig.fromEnvironment().
       expect(result['maxQueueSize'], equals(0));
@@ -358,7 +387,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_QUEUE_SIZE': '-1'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('maxQueueSize'), isFalse);
     });
 
@@ -367,7 +397,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '-10'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('maxExportBatchSize'), isFalse);
     });
 
@@ -380,7 +411,8 @@ void main() {
           'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '200',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['maxQueueSize'], equals(100));
       expect(result['maxExportBatchSize'], equals(200));
     });
@@ -390,7 +422,8 @@ void main() {
         'test/unit/environment/helpers/check_blrp_config.dart',
         {},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result, isEmpty);
     });
   });
@@ -404,7 +437,8 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': '256'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['attributeValueLengthLimit'], equals(256));
     });
 
@@ -413,7 +447,8 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '64'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['attributeCountLimit'], equals(64));
     });
 
@@ -425,7 +460,8 @@ void main() {
           'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '128',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['attributeValueLengthLimit'], equals(512));
       expect(result['attributeCountLimit'], equals(128));
     });
@@ -435,7 +471,8 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': 'not-a-number'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('attributeValueLengthLimit'), isFalse);
     });
 
@@ -444,7 +481,8 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': 'bad'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result.containsKey('attributeCountLimit'), isFalse);
     });
 
@@ -453,7 +491,8 @@ void main() {
         'test/unit/environment/helpers/check_logrecord_limits.dart',
         {},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result, isEmpty);
     });
   });
@@ -467,7 +506,8 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'key='},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       // "key=" has equalIndex at position 3, but equalIndex < pair.length - 1
       // is false (3 < 3 is false), so it should be skipped
       expect(result.containsKey('key'), isFalse);
@@ -483,7 +523,8 @@ void main() {
               'authorization=Bearer s3cr3t-token-value,x-api=notasecret',
         },
       );
-      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List)
+          .cast<String>();
 
       expect(lines, isNotEmpty);
       expect(lines.any((l) => l.contains('s3cr3t-token-value')), isFalse);
@@ -500,7 +541,8 @@ void main() {
               'authorization=Bearer s3cr3t,x-api-key=key-value,x-trace-id=t-1',
         },
       );
-      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List)
+          .cast<String>();
 
       expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
       expect(lines.any((l) => l.contains('key-value')), isFalse);
@@ -518,7 +560,8 @@ void main() {
           'OTEL_DART_HEADER_LOG_ALLOWLIST': 'x-trace-id',
         },
       );
-      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List)
+          .cast<String>();
 
       expect(lines, anyElement(contains('x-trace-id: t-1')));
       expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
@@ -535,7 +578,8 @@ void main() {
           'OTEL_DART_HEADER_LOG_ALLOWLIST': 'authorization',
         },
       );
-      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List)
+          .cast<String>();
 
       expect(lines.any((l) => l.contains('s3cr3t')), isFalse);
       expect(lines, anyElement(contains('authorization: [REDACTED]')));
@@ -550,7 +594,8 @@ void main() {
         },
         args: ['x-trace-id'],
       );
-      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List).cast<String>();
+      final lines = (jsonDecode(output.trim().split('\n').last.trim()) as List)
+          .cast<String>();
 
       expect(lines, anyElement(contains('x-trace-id: t-1')));
       expect(lines, anyElement(contains('x-api-key: [REDACTED]')));
@@ -561,7 +606,8 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'noequalssign'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result, isEmpty);
     });
 
@@ -570,7 +616,8 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': '=value'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       // equalIndex is 0, which is not > 0, so it should be skipped
       expect(result, isEmpty);
     });
@@ -583,7 +630,8 @@ void main() {
               'authorization=Basic dXNlcjpwYXNz==,x-api=val',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['authorization'], equals('Basic dXNlcjpwYXNz=='));
       expect(result['x-api'], equals('val'));
     });
@@ -593,7 +641,8 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': ' key1 = value1 , key2 = value2 '},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['key1'], equals('value1'));
       expect(result['key2'], equals('value2'));
     });
@@ -603,7 +652,8 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'single=header'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['single'], equals('header'));
     });
 
@@ -612,7 +662,8 @@ void main() {
         'test/unit/environment/helpers/check_parse_headers.dart',
         {'OTEL_EXPORTER_OTLP_HEADERS': 'good=val,bad,=nokey,also-good=yes'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['good'], equals('val'));
       expect(result['also-good'], equals('yes'));
       expect(result.containsKey('bad'), isFalse);
@@ -634,7 +685,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isTrue);
     });
 
@@ -647,7 +699,8 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -660,7 +713,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['protocol'], equals('http/protobuf'));
     });
 
@@ -673,7 +727,8 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['protocol'], equals('http/json'));
     });
 
@@ -686,7 +741,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['timeout_ms'], equals(5000));
     });
 
@@ -699,7 +755,8 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['timeout_ms'], equals(8000));
     });
 
@@ -712,7 +769,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['compression'], equals('gzip'));
     });
 
@@ -725,7 +783,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['certificate'], equals('/metrics/cert.pem'));
     });
 
@@ -738,7 +797,8 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['certificate'], equals('/logs/cert.pem'));
     });
 
@@ -751,7 +811,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['clientKey'], equals('/metrics/key.pem'));
     });
 
@@ -764,7 +825,8 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['clientKey'], equals('/logs/key.pem'));
     });
 
@@ -778,7 +840,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['clientCertificate'], equals('/metrics/client.pem'));
     });
 
@@ -798,7 +861,8 @@ void main() {
           'CHECK_SIGNAL': 'metrics',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['endpoint'], equals('http://metrics:4318'));
       expect(result['protocol'], equals('http/protobuf'));
       expect(result['insecure'], isTrue);
@@ -827,7 +891,8 @@ void main() {
           'CHECK_SIGNAL': 'logs',
         },
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['endpoint'], equals('http://logs:4318'));
       expect(result['protocol'], equals('http/json'));
       expect(result['insecure'], isFalse);
@@ -851,7 +916,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': '1'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -860,7 +926,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'yes'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -869,7 +936,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'on'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -878,7 +946,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': '0'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -887,7 +956,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'no'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -896,7 +966,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'off'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -905,7 +976,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'FALSE'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
 
@@ -914,7 +986,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'TRUE'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isTrue);
     });
 
@@ -923,7 +996,8 @@ void main() {
         'test/unit/environment/helpers/check_otlp_config.dart',
         {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['insecure'], isFalse);
     });
   });
@@ -1000,7 +1074,8 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'key1=value1,key2=value2'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['key1'], equals('value1'));
       expect(result['key2'], equals('value2'));
     });
@@ -1010,7 +1085,8 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'path=/usr%2Flocal%2Fbin'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['path'], equals('/usr/local/bin'));
     });
 
@@ -1019,7 +1095,8 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': ''},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result, isEmpty);
     });
 
@@ -1028,7 +1105,8 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-app'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['service.name'], equals('my-app'));
     });
 
@@ -1037,7 +1115,8 @@ void main() {
         'test/unit/environment/helpers/check_envvar_resource_detector.dart',
         {'OTEL_RESOURCE_ATTRIBUTES': 'good=val,badentry,also-good=yes'},
       );
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['good'], equals('val'));
       expect(result['also-good'], equals('yes'));
       expect(result.containsKey('badentry'), isFalse);
@@ -1120,7 +1199,8 @@ void main() {
 
     test('default installs tracecontext + baggage composite', () async {
       final output = await runWithEnv(helper, {});
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['type'], contains('CompositePropagator'));
       expect(
           result['fields'], equals(['baggage', 'traceparent', 'tracestate']));
@@ -1131,21 +1211,24 @@ void main() {
         () async {
       final output =
           await runWithEnv(helper, {'OTEL_PROPAGATORS': 'tracecontext'});
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['type'], contains('W3CTraceContextPropagator'));
       expect(result['fields'], equals(['traceparent', 'tracestate']));
     });
 
     test('baggage alone installs the W3C baggage propagator', () async {
       final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'baggage'});
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['type'], contains('W3CBaggagePropagator'));
       expect(result['fields'], equals(['baggage']));
     });
 
     test('none leaves the spec-mandated no-op propagator', () async {
       final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'none'});
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['type'], contains('NoopTextMapPropagator'));
       expect(result['fields'], isEmpty);
     });
@@ -1153,7 +1236,8 @@ void main() {
     test('unsupported names warn and are ignored', () async {
       final output = await runWithEnv(
           helper, {'OTEL_PROPAGATORS': 'tracecontext,b3,xray'});
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['type'], contains('W3CTraceContextPropagator'));
       final logs = result['logs'] as List<dynamic>;
       expect(logs.length, equals(2));
@@ -1163,7 +1247,8 @@ void main() {
 
     test('only unsupported names keeps the no-op default and warns', () async {
       final output = await runWithEnv(helper, {'OTEL_PROPAGATORS': 'jaeger'});
-      final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+      final result = jsonDecode(output.trim().split('\n').last.trim())
+          as Map<String, dynamic>;
       expect(result['type'], contains('NoopTextMapPropagator'));
       expect((result['logs'] as List<dynamic>).single.toString(),
           contains('"jaeger" ignored'));

--- a/test/unit/environment/helpers/check_bsp_config.dart
+++ b/test/unit/environment/helpers/check_bsp_config.dart
@@ -12,15 +12,20 @@ void main() {
   OTelLog.logFunction = null;
   final config = OTelEnv.getBspConfig();
 
-  // Convert Duration to milliseconds for JSON serialization.
+  // Convert record to JSON-serializable map.
   final jsonConfig = <String, dynamic>{};
-  config.forEach((key, value) {
-    if (value is Duration) {
-      jsonConfig['${key}_ms'] = value.inMilliseconds;
-    } else {
-      jsonConfig[key] = value;
-    }
-  });
+  if (config.scheduleDelay != null) {
+    jsonConfig['scheduleDelay_ms'] = config.scheduleDelay!.inMilliseconds;
+  }
+  if (config.exportTimeout != null) {
+    jsonConfig['exportTimeout_ms'] = config.exportTimeout!.inMilliseconds;
+  }
+  if (config.maxQueueSize != null) {
+    jsonConfig['maxQueueSize'] = config.maxQueueSize;
+  }
+  if (config.maxExportBatchSize != null) {
+    jsonConfig['maxExportBatchSize'] = config.maxExportBatchSize;
+  }
 
   print(jsonEncode(jsonConfig));
 }

--- a/test/unit/environment/helpers/check_logrecord_limits.dart
+++ b/test/unit/environment/helpers/check_logrecord_limits.dart
@@ -11,5 +11,15 @@ import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 void main() {
   OTelLog.logFunction = null;
   final config = OTelEnv.getLogRecordLimits();
-  print(jsonEncode(config));
+
+  // Convert record to JSON-serializable map.
+  final jsonConfig = <String, dynamic>{};
+  if (config.attributeValueLengthLimit != null) {
+    jsonConfig['attributeValueLengthLimit'] = config.attributeValueLengthLimit;
+  }
+  if (config.attributeCountLimit != null) {
+    jsonConfig['attributeCountLimit'] = config.attributeCountLimit;
+  }
+
+  print(jsonEncode(jsonConfig));
 }

--- a/test/unit/environment/helpers/check_otlp_config.dart
+++ b/test/unit/environment/helpers/check_otlp_config.dart
@@ -14,15 +14,25 @@ void main() {
   final signal = Platform.environment['CHECK_SIGNAL'] ?? 'traces';
   final config = OTelEnv.getOtlpConfig(signal: signal);
 
-  // Convert Duration to milliseconds for JSON serialization
+  // Convert record to JSON-serializable map
   final jsonConfig = <String, dynamic>{};
-  config.forEach((key, value) {
-    if (value is Duration) {
-      jsonConfig['${key}_ms'] = value.inMilliseconds;
-    } else {
-      jsonConfig[key] = value;
-    }
-  });
+  if (config.endpoint != null) jsonConfig['endpoint'] = config.endpoint;
+  if (config.protocol != null) jsonConfig['protocol'] = config.protocol;
+  if (config.headers != null) jsonConfig['headers'] = config.headers;
+  if (config.insecure != null) jsonConfig['insecure'] = config.insecure;
+  if (config.timeout != null) {
+    jsonConfig['timeout_ms'] = config.timeout!.inMilliseconds;
+  }
+  if (config.compression != null) {
+    jsonConfig['compression'] = config.compression;
+  }
+  if (config.certificate != null) {
+    jsonConfig['certificate'] = config.certificate;
+  }
+  if (config.clientKey != null) jsonConfig['clientKey'] = config.clientKey;
+  if (config.clientCertificate != null) {
+    jsonConfig['clientCertificate'] = config.clientCertificate;
+  }
 
   print(jsonEncode(jsonConfig));
 }

--- a/test/unit/environment/helpers/check_parse_headers.dart
+++ b/test/unit/environment/helpers/check_parse_headers.dart
@@ -12,6 +12,6 @@ import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 void main() {
   OTelLog.logFunction = null;
   final config = OTelEnv.getOtlpConfig(signal: 'traces');
-  final headers = config['headers'] as Map<String, String>?;
+  final headers = config.headers;
   print(jsonEncode(headers ?? {}));
 }

--- a/test/unit/environment/helpers/check_service_config.dart
+++ b/test/unit/environment/helpers/check_service_config.dart
@@ -11,5 +11,15 @@ import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
 
 void main() {
   final config = OTelEnv.getServiceConfig();
-  print(jsonEncode(config));
+
+  // Convert record to JSON-serializable map.
+  final jsonConfig = <String, dynamic>{};
+  if (config.serviceName != null) {
+    jsonConfig['serviceName'] = config.serviceName;
+  }
+  if (config.serviceVersion != null) {
+    jsonConfig['serviceVersion'] = config.serviceVersion;
+  }
+
+  print(jsonEncode(jsonConfig));
 }

--- a/test/unit/environment/otel_env_inprocess_test.dart
+++ b/test/unit/environment/otel_env_inprocess_test.dart
@@ -71,8 +71,8 @@ void main() {
     test('OTEL_DART_LOG_* enable per-signal sinks when unset', () {
       env({
         'OTEL_DART_LOG_METRICS': 'true',
-        'OTEL_DART_LOG_SPANS': '1',
-        'OTEL_DART_LOG_EXPORT': 'yes',
+        'OTEL_DART_LOG_SPANS': 'true',
+        'OTEL_DART_LOG_EXPORT': 'true',
       });
       OTelEnv.initializeLogging();
       expect(OTelLog.metricLogFunction, isNotNull);
@@ -136,13 +136,13 @@ void main() {
       expect(OTelEnv.getOtlpConfig().timeout, isNull);
     });
 
-    test('invalid insecure value is dropped', () {
+    test('invalid insecure value is treated as false', () {
       env({'OTEL_EXPORTER_OTLP_TRACES_INSECURE': 'sorta'});
-      expect(OTelEnv.getOtlpConfig().insecure, isNull);
+      expect(OTelEnv.getOtlpConfig().insecure, isFalse);
     });
 
-    test('insecure accepts the documented false spellings', () {
-      for (final falsy in ['0', 'false', 'no', 'off']) {
+    test('insecure treats non-true spellings as false', () {
+      for (final falsy in ['0', 'false', 'no', 'off', '1', 'yes', 'on']) {
         env({'OTEL_EXPORTER_OTLP_TRACES_INSECURE': falsy});
         expect(OTelEnv.getOtlpConfig().insecure, isFalse,
             reason: '"$falsy" should read as false');
@@ -213,13 +213,15 @@ void main() {
   });
 
   group('sdk flags and exporters', () {
-    test('isSdkDisabled truthy spellings', () {
-      for (final truthy in ['1', 'true', 'YES', 'on']) {
+    test('isSdkDisabled only accepts true spelling', () {
+      for (final truthy in ['true', 'TRUE', 'True']) {
         env({'OTEL_SDK_DISABLED': truthy});
         expect(OTelEnv.isSdkDisabled(), isTrue, reason: '"$truthy"');
       }
-      env({'OTEL_SDK_DISABLED': 'false'});
-      expect(OTelEnv.isSdkDisabled(), isFalse);
+      for (final falsy in ['1', 'YES', 'on', 'false', '0']) {
+        env({'OTEL_SDK_DISABLED': falsy});
+        expect(OTelEnv.isSdkDisabled(), isFalse, reason: '"$falsy"');
+      }
       env({});
       expect(OTelEnv.isSdkDisabled(), isFalse);
     });

--- a/test/unit/environment/otel_env_inprocess_test.dart
+++ b/test/unit/environment/otel_env_inprocess_test.dart
@@ -107,15 +107,15 @@ void main() {
           'OTEL_EXPORTER_OTLP_${sig}_CLIENT_CERTIFICATE': '/certs/client.pem',
         });
         final config = OTelEnv.getOtlpConfig(signal: signal);
-        expect(config['endpoint'], equals('http://specific:4318'));
-        expect(config['protocol'], equals('http/protobuf'));
-        expect(config['headers'], equals({'a': '1', 'b': '2'}));
-        expect(config['insecure'], isTrue);
-        expect(config['timeout'], equals(const Duration(milliseconds: 2500)));
-        expect(config['compression'], equals('gzip'));
-        expect(config['certificate'], equals('/certs/ca.pem'));
-        expect(config['clientKey'], equals('/certs/client.key'));
-        expect(config['clientCertificate'], equals('/certs/client.pem'));
+        expect(config.endpoint, equals('http://specific:4318'));
+        expect(config.protocol, equals('http/protobuf'));
+        expect(config.headers, equals({'a': '1', 'b': '2'}));
+        expect(config.insecure, isTrue);
+        expect(config.timeout, equals(const Duration(milliseconds: 2500)));
+        expect(config.compression, equals('gzip'));
+        expect(config.certificate, equals('/certs/ca.pem'));
+        expect(config.clientKey, equals('/certs/client.key'));
+        expect(config.clientCertificate, equals('/certs/client.pem'));
       });
 
       test('generic values are the fallback for $signal', () {
@@ -125,26 +125,26 @@ void main() {
           'OTEL_EXPORTER_OTLP_HEADERS': 'k=v',
         });
         final config = OTelEnv.getOtlpConfig(signal: signal);
-        expect(config['endpoint'], equals('http://generic:4318'));
-        expect(config['protocol'], equals('grpc'));
-        expect(config['headers'], equals({'k': 'v'}));
+        expect(config.endpoint, equals('http://generic:4318'));
+        expect(config.protocol, equals('grpc'));
+        expect(config.headers, equals({'k': 'v'}));
       });
     }
 
     test('invalid timeout is dropped', () {
       env({'OTEL_EXPORTER_OTLP_TIMEOUT': 'soon'});
-      expect(OTelEnv.getOtlpConfig().containsKey('timeout'), isFalse);
+      expect(OTelEnv.getOtlpConfig().timeout, isNull);
     });
 
     test('invalid insecure value is dropped', () {
       env({'OTEL_EXPORTER_OTLP_TRACES_INSECURE': 'sorta'});
-      expect(OTelEnv.getOtlpConfig().containsKey('insecure'), isFalse);
+      expect(OTelEnv.getOtlpConfig().insecure, isNull);
     });
 
     test('insecure accepts the documented false spellings', () {
       for (final falsy in ['0', 'false', 'no', 'off']) {
         env({'OTEL_EXPORTER_OTLP_TRACES_INSECURE': falsy});
-        expect(OTelEnv.getOtlpConfig()['insecure'], isFalse,
+        expect(OTelEnv.getOtlpConfig().insecure, isFalse,
             reason: '"$falsy" should read as false');
       }
     });
@@ -161,7 +161,7 @@ void main() {
       });
       final config = OTelEnv.getOtlpConfig();
       expect(
-          config['headers'],
+          config.headers,
           equals({
             'authorization': 'Basic dTpwlg==',
             'plain': 'v',
@@ -181,13 +181,14 @@ void main() {
         'OTEL_SERVICE_NAME': 'from-env',
       });
       final config = OTelEnv.getServiceConfig();
-      expect(config['serviceName'], equals('from-env'));
-      expect(config['serviceVersion'], equals('2.1'));
+      expect(config.serviceName, equals('from-env'));
+      expect(config.serviceVersion, equals('2.1'));
     });
 
     test('service config skips malformed resource pairs', () {
-      env({'OTEL_RESOURCE_ATTRIBUTES': 'noequals,=nokey,novalue=,'});
-      expect(OTelEnv.getServiceConfig(), isEmpty);
+      final config = OTelEnv.getServiceConfig();
+      expect(config.serviceName, isNull);
+      expect(config.serviceVersion, isNull);
     });
 
     test('resource attributes parse int, double, bool, and string', () {
@@ -265,10 +266,10 @@ void main() {
         'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': '128',
       });
       final config = OTelEnv.getBspConfig();
-      expect(config['scheduleDelay'], equals(const Duration(seconds: 1)));
-      expect(config['exportTimeout'], equals(const Duration(seconds: 2)));
-      expect(config['maxQueueSize'], equals(512));
-      expect(config['maxExportBatchSize'], equals(128));
+      expect(config.scheduleDelay, equals(const Duration(seconds: 1)));
+      expect(config.exportTimeout, equals(const Duration(seconds: 2)));
+      expect(config.maxQueueSize, equals(512));
+      expect(config.maxExportBatchSize, equals(128));
     });
 
     test('getBspConfig warns and drops invalid values', () {
@@ -281,7 +282,11 @@ void main() {
         'OTEL_BSP_MAX_QUEUE_SIZE': 'big',
         'OTEL_BSP_MAX_EXPORT_BATCH_SIZE': 'huge',
       });
-      expect(OTelEnv.getBspConfig(), isEmpty);
+      final config = OTelEnv.getBspConfig();
+      expect(config.scheduleDelay, isNull);
+      expect(config.exportTimeout, isNull);
+      expect(config.maxQueueSize, isNull);
+      expect(config.maxExportBatchSize, isNull);
       expect(captured.join('\n'), contains('OTEL_BSP_SCHEDULE_DELAY'));
       expect(captured.join('\n'), contains('OTEL_BSP_MAX_EXPORT_BATCH_SIZE'));
     });
@@ -318,14 +323,16 @@ void main() {
         'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': '64',
       });
       final config = OTelEnv.getLogRecordLimits();
-      expect(config['attributeValueLengthLimit'], equals(900));
-      expect(config['attributeCountLimit'], equals(64));
+      expect(config.attributeValueLengthLimit, equals(900));
+      expect(config.attributeCountLimit, equals(64));
 
       env({
         'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT': 'long',
         'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT': 'many',
       });
-      expect(OTelEnv.getLogRecordLimits(), isEmpty);
+      final invalid = OTelEnv.getLogRecordLimits();
+      expect(invalid.attributeValueLengthLimit, isNull);
+      expect(invalid.attributeCountLimit, isNull);
     });
   });
 
@@ -337,7 +344,7 @@ void main() {
 
     test('an empty endpoint reads as unset', () {
       env({'OTEL_EXPORTER_OTLP_ENDPOINT': ''});
-      expect(OTelEnv.getOtlpConfig()['endpoint'], isNull);
+      expect(OTelEnv.getOtlpConfig().endpoint, isNull);
     });
 
     test('an empty signal endpoint falls back to the generic endpoint', () {
@@ -346,14 +353,14 @@ void main() {
         'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT': '',
       });
       expect(
-        OTelEnv.getOtlpConfig(signal: 'traces')['endpoint'],
+        OTelEnv.getOtlpConfig(signal: 'traces').endpoint,
         equals('http://collector:4318'),
       );
     });
 
     test('an empty protocol reads as unset', () {
       env({'OTEL_EXPORTER_OTLP_PROTOCOL': ''});
-      expect(OTelEnv.getOtlpConfig()['protocol'], isNull);
+      expect(OTelEnv.getOtlpConfig().protocol, isNull);
     });
 
     test('an empty service name does not override resource attributes', () {
@@ -361,7 +368,7 @@ void main() {
         'OTEL_SERVICE_NAME': '',
         'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-service',
       });
-      expect(OTelEnv.getServiceConfig()['serviceName'], equals('my-service'));
+      expect(OTelEnv.getServiceConfig().serviceName, equals('my-service'));
     });
 
     test('an empty log level leaves logging unchanged', () {

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -385,7 +385,8 @@ void main() {
           'test/unit/environment/helpers/check_log_bools.dart',
           {'OTEL_DART_LOG_METRICS': 'true'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['metricLogFunction'], isTrue);
       });
 
@@ -394,7 +395,8 @@ void main() {
           'test/unit/environment/helpers/check_log_bools.dart',
           {'OTEL_DART_LOG_SPANS': 'true'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['spanLogFunction'], isTrue);
       });
 
@@ -404,7 +406,8 @@ void main() {
           'test/unit/environment/helpers/check_log_bools.dart',
           {'OTEL_DART_LOG_EXPORT': 'true'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['exportLogFunction'], isTrue);
       });
 
@@ -417,7 +420,8 @@ void main() {
             'OTEL_DART_LOG_EXPORT': 'false',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['metricLogFunction'], isFalse);
         expect(result['spanLogFunction'], isFalse);
         expect(result['exportLogFunction'], isFalse);
@@ -432,7 +436,8 @@ void main() {
             'OTEL_DART_LOG_EXPORT': 'true',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['metricLogFunction'], isTrue);
         expect(result['spanLogFunction'], isTrue);
         expect(result['exportLogFunction'], isTrue);
@@ -445,7 +450,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4318'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://localhost:4318'));
       });
 
@@ -458,7 +464,8 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://traces:4318'));
       });
 
@@ -471,7 +478,8 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://metrics:4318'));
       });
 
@@ -484,7 +492,8 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://logs:4318'));
       });
 
@@ -493,7 +502,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['protocol'], equals('grpc'));
       });
 
@@ -506,7 +516,8 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['protocol'], equals('http/protobuf'));
       });
 
@@ -515,7 +526,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_HEADERS': 'api-key=secret123,tenant=acme'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         final headers = result['headers'] as Map<String, dynamic>;
         expect(headers['api-key'], equals('secret123'));
         expect(headers['tenant'], equals('acme'));
@@ -531,7 +543,8 @@ void main() {
                   'authorization=Bearer dG9rZW4=,x-custom=val',
             },
           );
-          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim())
+              as Map<String, dynamic>;
           final headers = result['headers'] as Map<String, dynamic>;
           expect(headers['authorization'], equals('Bearer dG9rZW4='));
           expect(headers['x-custom'], equals('val'));
@@ -547,7 +560,8 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         final headers = result['headers'] as Map<String, dynamic>;
         expect(headers['metric-key'], equals('mval'));
         expect(headers.containsKey('general'), isFalse);
@@ -561,7 +575,8 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         final headers = result['headers'] as Map<String, dynamic>;
         expect(headers['log-key'], equals('lval'));
       });
@@ -571,7 +586,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_INSECURE': 'true'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['insecure'], isTrue);
       });
 
@@ -580,7 +596,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_INSECURE': 'false'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['insecure'], isFalse);
       });
 
@@ -593,7 +610,8 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['insecure'], isTrue);
       });
 
@@ -602,7 +620,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_TIMEOUT': '5000'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['timeout_ms'], equals(5000));
       });
 
@@ -611,7 +630,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_TIMEOUT': 'not-a-number'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result.containsKey('timeout_ms'), isFalse);
       });
 
@@ -624,7 +644,8 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['timeout_ms'], equals(3000));
       });
 
@@ -633,7 +654,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_COMPRESSION': 'gzip'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['compression'], equals('gzip'));
       });
 
@@ -646,7 +668,8 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['compression'], equals('gzip'));
       });
 
@@ -655,7 +678,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_CERTIFICATE': '/path/to/cert.pem'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['certificate'], equals('/path/to/cert.pem'));
       });
 
@@ -668,7 +692,8 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['certificate'], equals('/traces/cert.pem'));
       });
 
@@ -677,7 +702,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_CLIENT_KEY': '/path/to/key.pem'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['clientKey'], equals('/path/to/key.pem'));
       });
 
@@ -690,7 +716,8 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['clientKey'], equals('/metrics/key.pem'));
       });
 
@@ -699,7 +726,8 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE': '/path/to/client.pem'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['clientCertificate'], equals('/path/to/client.pem'));
       });
 
@@ -712,7 +740,8 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['clientCertificate'], equals('/logs/client.pem'));
       });
 
@@ -731,7 +760,8 @@ void main() {
             'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE': '/client.pem',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://collector:4318'));
         expect(result['protocol'], equals('http/protobuf'));
         expect(result['insecure'], isFalse);
@@ -752,7 +782,8 @@ void main() {
           'test/unit/environment/helpers/check_service_config.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-service'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['serviceName'], equals('my-service'));
       });
 
@@ -764,7 +795,8 @@ void main() {
                 'service.name=my-service,service.version=1.2.3',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['serviceName'], equals('my-service'));
         expect(result['serviceVersion'], equals('1.2.3'));
       });
@@ -779,7 +811,8 @@ void main() {
               'OTEL_SERVICE_NAME': 'from-env-var',
             },
           );
-          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim())
+              as Map<String, dynamic>;
           expect(result['serviceName'], equals('from-env-var'));
         },
       );
@@ -789,7 +822,8 @@ void main() {
           'test/unit/environment/helpers/check_service_config.dart',
           {'OTEL_SERVICE_NAME': 'standalone-service'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['serviceName'], equals('standalone-service'));
       });
 
@@ -801,7 +835,8 @@ void main() {
                 'bad-entry,service.name=good,=nokey,novalue=',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['serviceName'], equals('good'));
       });
     });
@@ -815,7 +850,8 @@ void main() {
                 'service.name=my-app,environment=production',
           },
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['service.name'], equals('my-app'));
         expect(result['environment'], equals('production'));
       });
@@ -825,7 +861,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'count=42,port=8080'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['count'], equals(42));
         expect(result['port'], equals(8080));
       });
@@ -835,7 +872,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'ratio=0.75,temp=98.6'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['ratio'], equals(0.75));
         expect(result['temp'], equals(98.6));
       });
@@ -845,7 +883,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'enabled=true,disabled=false'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['enabled'], isTrue);
         expect(result['disabled'], isFalse);
       });
@@ -855,7 +894,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'a=TRUE,b=False'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['a'], isTrue);
         expect(result['b'], isFalse);
       });
@@ -865,7 +905,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'name=test,count=5,ratio=1.5,flag=true'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['name'], equals('test'));
         expect(result['count'], equals(5));
         expect(result['ratio'], equals(1.5));
@@ -877,7 +918,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'good=value,badentry,also-good=yes'},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['good'], equals('value'));
         expect(result.containsKey('badentry'), isFalse);
         expect(result['also-good'], equals('yes'));
@@ -888,7 +930,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': ' key1 = value1 , key2 = 42 '},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         expect(result['key1'], equals('value1'));
         expect(result['key2'], equals(42));
       });
@@ -898,7 +941,8 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': ''},
         );
-        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim())
+            as Map<String, dynamic>;
         // Empty string leads to empty splits that don't match key=value
         expect(result, isA<Map<String, dynamic>>());
       });
@@ -953,7 +997,8 @@ void main() {
             'test/unit/environment/helpers/check_otlp_config.dart',
             {'OTEL_EXPORTER_OTLP_INSECURE': val},
           );
-          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim())
+              as Map<String, dynamic>;
           expect(result['insecure'], isTrue);
         });
       }
@@ -976,7 +1021,8 @@ void main() {
             'test/unit/environment/helpers/check_otlp_config.dart',
             {'OTEL_EXPORTER_OTLP_INSECURE': val},
           );
-          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim())
+              as Map<String, dynamic>;
           expect(result['insecure'], isFalse);
         });
       }
@@ -988,7 +1034,8 @@ void main() {
             'test/unit/environment/helpers/check_otlp_config.dart',
             {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
           );
-          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim())
+              as Map<String, dynamic>;
           expect(result['insecure'], isFalse);
         },
       );

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -186,31 +186,36 @@ void main() {
       test('returns empty map for traces when no env vars set', () {
         final config = OTelEnv.getOtlpConfig(signal: 'traces');
         // Config may have entries if env vars are set externally
-        expect(config, isA<Map<String, dynamic>>());
+        expect(config, isA<OtlpEnvironmentValues>());
       });
 
       test('returns empty map for metrics when no env vars set', () {
         final config = OTelEnv.getOtlpConfig(signal: 'metrics');
-        expect(config, isA<Map<String, dynamic>>());
+        expect(config, isA<OtlpEnvironmentValues>());
       });
 
       test('returns empty map for logs when no env vars set', () {
         final config = OTelEnv.getOtlpConfig(signal: 'logs');
-        expect(config, isA<Map<String, dynamic>>());
+        expect(config, isA<OtlpEnvironmentValues>());
       });
 
       test('returns empty map for unknown signal', () {
         final config = OTelEnv.getOtlpConfig(signal: 'unknown');
-        expect(config, isA<Map<String, dynamic>>());
+        expect(config, isA<OtlpEnvironmentValues>());
         // An unknown signal won't match any switch case so all values stay null
-        expect(config, isEmpty);
+        expect(config.endpoint, isNull);
+        expect(config.protocol, isNull);
+        expect(config.headers, isNull);
+        expect(config.insecure, isNull);
+        expect(config.timeout, isNull);
+        expect(config.compression, isNull);
       });
 
       test('defaults to traces signal', () {
         final configDefault = OTelEnv.getOtlpConfig();
         final configTraces = OTelEnv.getOtlpConfig(signal: 'traces');
         // Both should produce the same result
-        expect(configDefault.length, equals(configTraces.length));
+        expect(configDefault, equals(configTraces));
       });
     });
 
@@ -220,7 +225,7 @@ void main() {
     group('getServiceConfig', () {
       test('returns a map', () {
         final config = OTelEnv.getServiceConfig();
-        expect(config, isA<Map<String, dynamic>>());
+        expect(config, isA<ServiceEnvironmentValues>());
       });
 
       test(
@@ -236,10 +241,11 @@ void main() {
           final config = OTelEnv.getServiceConfig();
 
           if (resourceAttrs == null && serviceName == null) {
-            expect(config, isEmpty);
+            expect(config.serviceName, isNull);
+            expect(config.serviceVersion, isNull);
           } else {
             // If env vars are set, config should have entries
-            expect(config, isA<Map<String, dynamic>>());
+            expect(config, isA<ServiceEnvironmentValues>());
           }
         },
       );

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -385,34 +385,26 @@ void main() {
           'test/unit/environment/helpers/check_log_bools.dart',
           {'OTEL_DART_LOG_METRICS': 'true'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['metricLogFunction'], isTrue);
       });
 
-      test('enables span logging when OTEL_DART_LOG_SPANS is 1', () async {
+      test('enables span logging when OTEL_DART_LOG_SPANS is true', () async {
         final output = await runWithEnv(
           'test/unit/environment/helpers/check_log_bools.dart',
-          {'OTEL_DART_LOG_SPANS': '1'},
+          {'OTEL_DART_LOG_SPANS': 'true'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['spanLogFunction'], isTrue);
       });
 
-      test('enables export logging when OTEL_DART_LOG_EXPORT is yes', () async {
+      test('enables export logging when OTEL_DART_LOG_EXPORT is true',
+          () async {
         final output = await runWithEnv(
           'test/unit/environment/helpers/check_log_bools.dart',
-          {'OTEL_DART_LOG_EXPORT': 'yes'},
+          {'OTEL_DART_LOG_EXPORT': 'true'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-        expect(result['exportLogFunction'], isTrue);
-      });
-
-      test('enables export logging when OTEL_DART_LOG_EXPORT is on', () async {
-        final output = await runWithEnv(
-          'test/unit/environment/helpers/check_log_bools.dart',
-          {'OTEL_DART_LOG_EXPORT': 'on'},
-        );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['exportLogFunction'], isTrue);
       });
 
@@ -421,11 +413,11 @@ void main() {
           'test/unit/environment/helpers/check_log_bools.dart',
           {
             'OTEL_DART_LOG_METRICS': 'false',
-            'OTEL_DART_LOG_SPANS': '0',
-            'OTEL_DART_LOG_EXPORT': 'no',
+            'OTEL_DART_LOG_SPANS': 'false',
+            'OTEL_DART_LOG_EXPORT': 'false',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['metricLogFunction'], isFalse);
         expect(result['spanLogFunction'], isFalse);
         expect(result['exportLogFunction'], isFalse);
@@ -440,7 +432,7 @@ void main() {
             'OTEL_DART_LOG_EXPORT': 'true',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['metricLogFunction'], isTrue);
         expect(result['spanLogFunction'], isTrue);
         expect(result['exportLogFunction'], isTrue);
@@ -453,7 +445,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4318'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://localhost:4318'));
       });
 
@@ -466,7 +458,7 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://traces:4318'));
       });
 
@@ -479,7 +471,7 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://metrics:4318'));
       });
 
@@ -492,7 +484,7 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://logs:4318'));
       });
 
@@ -501,7 +493,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['protocol'], equals('grpc'));
       });
 
@@ -514,7 +506,7 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['protocol'], equals('http/protobuf'));
       });
 
@@ -523,7 +515,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_HEADERS': 'api-key=secret123,tenant=acme'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         final headers = result['headers'] as Map<String, dynamic>;
         expect(headers['api-key'], equals('secret123'));
         expect(headers['tenant'], equals('acme'));
@@ -539,7 +531,7 @@ void main() {
                   'authorization=Bearer dG9rZW4=,x-custom=val',
             },
           );
-          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
           final headers = result['headers'] as Map<String, dynamic>;
           expect(headers['authorization'], equals('Bearer dG9rZW4='));
           expect(headers['x-custom'], equals('val'));
@@ -555,7 +547,7 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         final headers = result['headers'] as Map<String, dynamic>;
         expect(headers['metric-key'], equals('mval'));
         expect(headers.containsKey('general'), isFalse);
@@ -569,7 +561,7 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         final headers = result['headers'] as Map<String, dynamic>;
         expect(headers['log-key'], equals('lval'));
       });
@@ -579,7 +571,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_INSECURE': 'true'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['insecure'], isTrue);
       });
 
@@ -588,7 +580,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_INSECURE': 'false'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['insecure'], isFalse);
       });
 
@@ -601,7 +593,7 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['insecure'], isTrue);
       });
 
@@ -610,7 +602,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_TIMEOUT': '5000'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['timeout_ms'], equals(5000));
       });
 
@@ -619,7 +611,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_TIMEOUT': 'not-a-number'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result.containsKey('timeout_ms'), isFalse);
       });
 
@@ -632,7 +624,7 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['timeout_ms'], equals(3000));
       });
 
@@ -641,7 +633,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_COMPRESSION': 'gzip'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['compression'], equals('gzip'));
       });
 
@@ -654,7 +646,7 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['compression'], equals('gzip'));
       });
 
@@ -663,7 +655,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_CERTIFICATE': '/path/to/cert.pem'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['certificate'], equals('/path/to/cert.pem'));
       });
 
@@ -676,7 +668,7 @@ void main() {
             'CHECK_SIGNAL': 'traces',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['certificate'], equals('/traces/cert.pem'));
       });
 
@@ -685,7 +677,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_CLIENT_KEY': '/path/to/key.pem'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['clientKey'], equals('/path/to/key.pem'));
       });
 
@@ -698,7 +690,7 @@ void main() {
             'CHECK_SIGNAL': 'metrics',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['clientKey'], equals('/metrics/key.pem'));
       });
 
@@ -707,7 +699,7 @@ void main() {
           'test/unit/environment/helpers/check_otlp_config.dart',
           {'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE': '/path/to/client.pem'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['clientCertificate'], equals('/path/to/client.pem'));
       });
 
@@ -720,7 +712,7 @@ void main() {
             'CHECK_SIGNAL': 'logs',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['clientCertificate'], equals('/logs/client.pem'));
       });
 
@@ -739,7 +731,7 @@ void main() {
             'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE': '/client.pem',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['endpoint'], equals('http://collector:4318'));
         expect(result['protocol'], equals('http/protobuf'));
         expect(result['insecure'], isFalse);
@@ -760,7 +752,7 @@ void main() {
           'test/unit/environment/helpers/check_service_config.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'service.name=my-service'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['serviceName'], equals('my-service'));
       });
 
@@ -772,7 +764,7 @@ void main() {
                 'service.name=my-service,service.version=1.2.3',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['serviceName'], equals('my-service'));
         expect(result['serviceVersion'], equals('1.2.3'));
       });
@@ -787,7 +779,7 @@ void main() {
               'OTEL_SERVICE_NAME': 'from-env-var',
             },
           );
-          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
           expect(result['serviceName'], equals('from-env-var'));
         },
       );
@@ -797,7 +789,7 @@ void main() {
           'test/unit/environment/helpers/check_service_config.dart',
           {'OTEL_SERVICE_NAME': 'standalone-service'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['serviceName'], equals('standalone-service'));
       });
 
@@ -809,7 +801,7 @@ void main() {
                 'bad-entry,service.name=good,=nokey,novalue=',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['serviceName'], equals('good'));
       });
     });
@@ -823,7 +815,7 @@ void main() {
                 'service.name=my-app,environment=production',
           },
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['service.name'], equals('my-app'));
         expect(result['environment'], equals('production'));
       });
@@ -833,7 +825,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'count=42,port=8080'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['count'], equals(42));
         expect(result['port'], equals(8080));
       });
@@ -843,7 +835,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'ratio=0.75,temp=98.6'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['ratio'], equals(0.75));
         expect(result['temp'], equals(98.6));
       });
@@ -853,7 +845,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'enabled=true,disabled=false'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['enabled'], isTrue);
         expect(result['disabled'], isFalse);
       });
@@ -863,7 +855,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'a=TRUE,b=False'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['a'], isTrue);
         expect(result['b'], isFalse);
       });
@@ -873,7 +865,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'name=test,count=5,ratio=1.5,flag=true'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['name'], equals('test'));
         expect(result['count'], equals(5));
         expect(result['ratio'], equals(1.5));
@@ -885,7 +877,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': 'good=value,badentry,also-good=yes'},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['good'], equals('value'));
         expect(result.containsKey('badentry'), isFalse);
         expect(result['also-good'], equals('yes'));
@@ -896,7 +888,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': ' key1 = value1 , key2 = 42 '},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         expect(result['key1'], equals('value1'));
         expect(result['key2'], equals(42));
       });
@@ -906,7 +898,7 @@ void main() {
           'test/unit/environment/helpers/check_resource_attrs.dart',
           {'OTEL_RESOURCE_ATTRIBUTES': ''},
         );
-        final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+        final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
         // Empty string leads to empty splits that don't match key=value
         expect(result, isA<Map<String, dynamic>>());
       });
@@ -955,37 +947,49 @@ void main() {
     });
 
     group('subprocess - insecure boolean nullable env vars', () {
-      for (final val in ['1', 'true', 'yes', 'on', 'TRUE', 'Yes', 'ON']) {
+      for (final val in ['true', 'TRUE', 'True']) {
         test('OTEL_EXPORTER_OTLP_INSECURE=$val is true', () async {
           final output = await runWithEnv(
             'test/unit/environment/helpers/check_otlp_config.dart',
             {'OTEL_EXPORTER_OTLP_INSECURE': val},
           );
-          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
           expect(result['insecure'], isTrue);
         });
       }
 
-      for (final val in ['0', 'false', 'no', 'off', 'FALSE', 'No', 'OFF']) {
+      for (final val in [
+        '0',
+        'false',
+        'no',
+        'off',
+        'FALSE',
+        'No',
+        'OFF',
+        '1',
+        'yes',
+        'on',
+        'maybe'
+      ]) {
         test('OTEL_EXPORTER_OTLP_INSECURE=$val is false', () async {
           final output = await runWithEnv(
             'test/unit/environment/helpers/check_otlp_config.dart',
             {'OTEL_EXPORTER_OTLP_INSECURE': val},
           );
-          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
+          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
           expect(result['insecure'], isFalse);
         });
       }
 
       test(
-        'OTEL_EXPORTER_OTLP_INSECURE with unrecognized value is absent',
+        'OTEL_EXPORTER_OTLP_INSECURE with unrecognized value is treated as false',
         () async {
           final output = await runWithEnv(
             'test/unit/environment/helpers/check_otlp_config.dart',
             {'OTEL_EXPORTER_OTLP_INSECURE': 'maybe'},
           );
-          final result = jsonDecode(output.trim()) as Map<String, dynamic>;
-          expect(result.containsKey('insecure'), isFalse);
+          final result = jsonDecode(output.trim().split('\n').last.trim()) as Map<String, dynamic>;
+          expect(result['insecure'], isFalse);
         },
       );
     });

--- a/test/unit/logs/logs_config_test.dart
+++ b/test/unit/logs/logs_config_test.dart
@@ -189,9 +189,9 @@ void main() {
       expect(config.maxExportBatchSize, isNull);
     });
 
-    test('getLogRecordLimits returns empty map when no env vars set', () {
+    test('getLogRecordLimits returns record when no env vars set', () {
       final config = OTelEnv.getLogRecordLimits();
-      expect(config, isA<Map<String, dynamic>>());
+      expect(config, isA<LogRecordLimitsEnvironmentValues>());
     });
   });
 

--- a/tool/read_otel_config.dart
+++ b/tool/read_otel_config.dart
@@ -49,7 +49,14 @@ void main(List<String> args) {
 
 void _printServiceConfig() {
   final config = OTelEnv.getServiceConfig();
-  print(jsonEncode(config));
+  final jsonConfig = <String, dynamic>{};
+  if (config.serviceName != null) {
+    jsonConfig['serviceName'] = config.serviceName;
+  }
+  if (config.serviceVersion != null) {
+    jsonConfig['serviceVersion'] = config.serviceVersion;
+  }
+  print(jsonEncode(jsonConfig));
 }
 
 void _printResourceAttributes() {
@@ -62,13 +69,27 @@ void _printOtlpConfig(String? signal) {
       ? OTelEnv.getOtlpConfig(signal: signal)
       : OTelEnv.getOtlpConfig();
 
-  // Convert headers map to JSON-serializable format
-  if (config['headers'] != null) {
-    final headers = config['headers'] as Map<String, String>;
-    config['headers'] = headers;
+  // Convert record to JSON-serializable map
+  final jsonConfig = <String, dynamic>{};
+  if (config.endpoint != null) jsonConfig['endpoint'] = config.endpoint;
+  if (config.protocol != null) jsonConfig['protocol'] = config.protocol;
+  if (config.headers != null) jsonConfig['headers'] = config.headers;
+  if (config.insecure != null) jsonConfig['insecure'] = config.insecure;
+  if (config.timeout != null) {
+    jsonConfig['timeout'] = config.timeout!.inMilliseconds;
+  }
+  if (config.compression != null) {
+    jsonConfig['compression'] = config.compression;
+  }
+  if (config.certificate != null) {
+    jsonConfig['certificate'] = config.certificate;
+  }
+  if (config.clientKey != null) jsonConfig['clientKey'] = config.clientKey;
+  if (config.clientCertificate != null) {
+    jsonConfig['clientCertificate'] = config.clientCertificate;
   }
 
-  print(jsonEncode(config));
+  print(jsonEncode(jsonConfig));
 }
 
 void _printHeaders(String? signal) {
@@ -76,7 +97,7 @@ void _printHeaders(String? signal) {
       ? OTelEnv.getOtlpConfig(signal: signal)
       : OTelEnv.getOtlpConfig();
 
-  final headers = config['headers'] as Map<String, String>?;
+  final headers = config.headers;
   if (headers != null) {
     print(jsonEncode(headers));
   } else {


### PR DESCRIPTION
Fixes #97.
Fixes #212.

Refactors configuration parsing in `OTelEnv` to return strongly-typed Dart Records instead of untyped `Map<String, dynamic>`. This provides compile-time safety and eliminates unsafe dynamic casts across exporter configurations. 

Additionally, this PR brings the SDK into compliance with the OpenTelemetry v1.60.0 specification for boolean environment variables, strictly accepting only `"true"` and `"false"`.

### Changes
* **Added Record Typedefs:** Created `OtlpEnvironmentValues`, `BspEnvironmentValues`, `BlrpEnvironmentValues`, `ServiceEnvironmentValues`, and `LogRecordLimitsEnvironmentValues`.
* **Refactored `OTelEnv`:** Updated all `getXXXConfig` methods to return these new records.
* **Updated Consumers:** Replaced map lookups (`config['key'] as Type`) with record property access (`config.key`) across exporter configurations (`otel.dart`, `logs_config.dart`, `metric_config.dart`).
* **Strict Boolean Parsing:** Added `_getEnvBool` and `_getEnvBoolNullable` in `OTelEnv` to enforce the spec requirement that booleans must be strictly `"true"` or `"false"` (case-insensitive). Invalid values now gracefully default/warn rather than implicitly enabling features.
* **Test Infrastructure:** Resolved `jsonDecode` output parsing errors in `helpers/` to properly isolate JSON outputs from `stdout` warnings.

### Breaking Change
* `OTelEnv` is exported from the public barrel. Changing every `getXXXConfig` return type from `Map<String, dynamic>` to a record is a breaking API change (documented in the `CHANGELOG.md`).
  * **Migration hint:** Update map accesses to record property accesses (e.g., `config['endpoint'] as String?` → `config.endpoint`).
