### PR TITLE
docs: correct the span-event deprecation notes and OTEP links

### DIFF
--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -914,8 +914,11 @@ class OTel {
 
   /// Creates a SpanEvent with the current timestamp.
   ///
-  /// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-  /// span events are being deprecated and will be replaced by the Logging API in future versions.
+  /// Note: Per [OTEP 0265: Event Vision](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0265-event-vision.md)
+  /// and [OTEP 4430: Span Event API deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md),
+  /// span events are planned for deprecation in favor of log-based events
+  /// emitted via the Logs API; SDKs will provide options to render log-based
+  /// events as span events for compatibility.
   ///
   /// @param name The name of the event
   /// @param attributes Attributes to associate with the event
@@ -927,8 +930,11 @@ class OTel {
 
   /// Creates a SpanEvent with the specified parameters.
   ///
-  /// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-  /// span events are being deprecated and will be replaced by the Logging API in future versions.
+  /// Note: Per [OTEP 0265: Event Vision](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0265-event-vision.md)
+  /// and [OTEP 4430: Span Event API deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md),
+  /// span events are planned for deprecation in favor of log-based events
+  /// emitted via the Logs API; SDKs will provide options to render log-based
+  /// events as span events for compatibility.
   ///
   /// @param name The name of the event
   /// @param attributes Optional attributes to associate with the event

--- a/lib/src/resource/resource.dart
+++ b/lib/src/resource/resource.dart
@@ -19,9 +19,6 @@ part 'resource_create.dart';
 ///
 /// More information:
 /// https://opentelemetry.io/docs/specs/otel/resource/sdk/
-///
-/// Note: Per [OTEP 0265](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0265-event-vision.md),
-/// span events are being deprecated and will be replaced by the Logging API.
 @immutable
 class Resource {
   final Attributes _attributes;

--- a/lib/src/trace/span.dart
+++ b/lib/src/trace/span.dart
@@ -21,8 +21,11 @@ part 'span_create.dart';
 /// This implementation delegates most functionality to the API Span implementation
 /// while adding SDK-specific behaviors like span processor notification.
 ///
-/// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-/// span events are being deprecated and will be replaced by the Logging API in future versions.
+/// Note: Per [OTEP 0265: Event Vision](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0265-event-vision.md)
+/// and [OTEP 4430: Span Event API deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md),
+/// span events are planned for deprecation in favor of log-based events
+/// emitted via the Logs API; SDKs will provide options to render log-based
+/// events as span events for compatibility.
 ///
 /// More information:
 /// https://opentelemetry.io/docs/specs/otel/trace/sdk/

--- a/lib/src/trace/span_logger.dart
+++ b/lib/src/trace/span_logger.dart
@@ -8,9 +8,6 @@ import '../../dartastic_opentelemetry.dart' show OTelLog, Span;
 /// This utility function logs span information for debugging purposes.
 /// It includes a timestamp and formats the span information in a consistent way.
 ///
-/// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-/// span events are being deprecated and will be replaced by the Logging API in future versions.
-///
 /// @param span The span to log
 /// @param message Optional message to include with the span log
 void logSpan(Span span, [String? message]) {
@@ -25,9 +22,6 @@ void logSpan(Span span, [String? message]) {
 ///
 /// This utility function logs information about multiple spans for debugging purposes.
 /// It includes a timestamp and formats the spans information in a consistent way.
-///
-/// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-/// span events are being deprecated and will be replaced by the Logging API in future versions.
 ///
 /// @param spans The list of spans to log
 /// @param message Optional message to include with the spans log

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -25,8 +25,11 @@ part 'tracer_create.dart';
 /// implementation while adding SDK-specific behaviors like sampling and
 /// span processor notification.
 ///
-/// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-/// span events are being deprecated and will be replaced by the Logging API in future versions.
+/// Note: Per [OTEP 0265: Event Vision](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0265-event-vision.md)
+/// and [OTEP 4430: Span Event API deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md),
+/// span events are planned for deprecation in favor of log-based events
+/// emitted via the Logs API; SDKs will provide options to render log-based
+/// events as span events for compatibility.
 ///
 /// More information:
 /// https://opentelemetry.io/docs/specs/otel/trace/sdk/

--- a/lib/src/trace/tracer_provider.dart
+++ b/lib/src/trace/tracer_provider.dart
@@ -19,8 +19,11 @@ part 'tracer_provider_create.dart';
 /// implementation while adding SDK-specific behaviors like span processor management
 /// and resource association.
 ///
-/// Note: Per [OTEP 0265](https://opentelemetry.io/docs/specs/semconv/general/events/),
-/// span events are being deprecated and will be replaced by the Logging API in future versions.
+/// Note: Per [OTEP 0265: Event Vision](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0265-event-vision.md)
+/// and [OTEP 4430: Span Event API deprecation plan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4430-span-event-api-deprecation-plan.md),
+/// span events are planned for deprecation in favor of log-based events
+/// emitted via the Logs API; SDKs will provide options to render log-based
+/// events as span events for compatibility.
 ///
 /// More information:
 /// https://opentelemetry.io/docs/specs/otel/trace/sdk/


### PR DESCRIPTION
The note cited OTEP 0265 but linked to the semconv Events page, which says nothing about deprecation. Link the actual OTEP 0265 (Event Vision) and OTEP 4430 (Span Event API deprecation plan), and update the wording: the Span Event API is planned for deprecation in favor of log-based events via the Logs API, with SDK options to render log-based events as span events for compatibility.

Drop the note entirely from Resource and the logSpan/logSpans debug utilities, where span events are not involved.