### PR TITLE
ci: cap test concurrency on hosted runners; 60s timeout on socket-bound suites

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Run tests
         run: |
           chmod +x tool/test.sh
-          ./tool/test.sh
+          # Match the runner's core count. The local default of 20 oversubscribes
+          # the 4-vCPU hosted runners: suites that bind sockets and wait on
+          # exports get time-sliced past the 30s per-test timeout and flake.
+          ./tool/test.sh --concurrency 4
 
   test-env-vars:
     runs-on: ubuntu-latest

--- a/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
+++ b/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_protocol_test.dart
@@ -6,6 +6,9 @@
 // `OtlpHttpProtocol.httpJson` switches the Content-Type to
 // `application/json` and the body to proto3-JSON.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_retry_test.dart
+++ b/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_retry_test.dart
@@ -4,6 +4,9 @@
 // Retry and error handling for OtlpHttpLogRecordExporter, mirroring the
 // span exporter's retry suite.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_coverage_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_edge_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_edge_test.dart
@@ -6,6 +6,9 @@
 // flush/shutdown, generic errors, retryable gRPC errors, give-up,
 // shutdown-during-retry, and channel cleanup.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'

--- a/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_user_agent_test.dart
+++ b/test/unit/logs/export/otlp/otlp_grpc_log_record_exporter_user_agent_test.dart
@@ -6,6 +6,9 @@
 // and the metrics gRPC exporter in otlp_grpc_metric_exporter_full_test;
 // this closes the logs gap.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_full_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_retry_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_retry_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
+++ b/test/unit/metrics/export/otlp/otlp_grpc_metric_exporter_full_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'

--- a/test/unit/otlp_spec_compliance_behavior_test.dart
+++ b/test/unit/otlp_spec_compliance_behavior_test.dart
@@ -9,6 +9,9 @@
 // implementation, from the issues and OTel spec v1.60.0, during review of
 // PR #238; each test was verified red on the pre-fix SDK.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/trace/export/otlp/http/otlp_http_exporter_lifecycle_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_exporter_lifecycle_test.dart
@@ -5,6 +5,9 @@
 // shutdown-during-retry, forceFlush with pending exports, and
 // flush/export after shutdown.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';

--- a/test/unit/trace/export/otlp/http/otlp_http_exporter_pending_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_exporter_pending_test.dart
@@ -5,6 +5,9 @@
 // exports, exports failing while flush/shutdown wait on them, and the
 // unexpected-error retry tail (connection refused with retries left).
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_full_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_edge_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_full_test.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'

--- a/test/unit/trace/export/otlp/otlp_grpc_span_exporter_more_edge_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_span_exporter_more_edge_test.dart
@@ -5,6 +5,9 @@
 // channel recreation, secure-credential fallback, and post-shutdown
 // behavior.
 
+@Timeout(Duration(seconds: 60))
+library;
+
 import 'dart:async';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart'


### PR DESCRIPTION
Fixes the timeout-class CI flakes seen twice on 2026-08-21:

- Run 32468785631 (PR #252, **docs-only**): `otlp_grpc_metric_exporter_full_test.dart` "export sends metrics to gRPC endpoint" — `TimeoutException after 0:00:30`; the identical commit passed on main minutes later.
- Run 32468732765 (#250 merge): `otlp_http_metric_exporter_retry_test.dart` timeout, green sibling run of the same code.

**Cause:** `tool/test.sh` defaults to `--concurrency 20`; hosted runners have 4 vCPUs. Twenty suites — many binding gRPC/HTTP servers and waiting on real exports — get time-sliced ~5:1, and the first export test in a suite (isolate spawn + JIT warm-up + channel setup, trace logging on) blows the 30s default per-test timeout.

**Changes:**
1. CI passes `--concurrency 4` to `tool/test.sh` (local default stays 20).
2. The 17 `test/unit` suites that bind sockets (`Server.create`/`HttpServer.bind`) get `@Timeout(Duration(seconds: 60))` as a shock absorber.

Verified: `dart format`/`dart analyze` clean on all 17, annotated suites pass locally (+25). Related: the load-sensitive suites are exactly the live-socket ones #55 proposes segregating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)