### PR TITLE
tool: pre-commit and pre-push git hooks (format, analyze, tests, coverage)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,17 @@ There are many ways to contribute to this project:
    ```bash
    dart pub get
    ```
+5. Install the git hooks:
+   ```bash
+   ./tool/setup-hooks.sh
+   ```
+   - **pre-commit**: Automatically formats Dart files and restages them
+   - **pre-push**: Blocks the push if the analyzer reports issues, tests fail,
+     or coverage drops below the published coverage badge
+
+   First-time contributors' CI runs need maintainer approval before they
+   execute, so the hooks are your first line of feedback — they run the same
+   checks CI enforces.
 
 ### Development Workflow
 
@@ -47,14 +58,14 @@ There are many ways to contribute to this project:
    ```bash
    ./tool/test.sh
    ```
-   Why not just `dart test`? The unit tests uses a real otel collector for robustness.  
-   The test.sh script downloads the otel collector for the currecnt platform if it hasn't been downloaded before
+   Why not just `dart test`? The unit tests use a real otel collector for robustness.  
+   The test.sh script downloads the otel collector for the current platform if it hasn't been downloaded before
 
     Optionally, set debug log level or change concurrency from the default of 10.
    ```bash
    ./tool/test.sh --concurrency 1 --log debug
    ```
-4. Run coverage to ensure code has adequete (+80%) code coverage:
+4. Run coverage to ensure code has adequate (+80%) code coverage:
    ```bash
    ./tool/coverage.sh
    ```
@@ -68,23 +79,23 @@ There are many ways to contribute to this project:
    open coverage/html/index.html
    ```
    
-4. Run the analyzer:
+5. Run the analyzer:
    ```bash
    dart analyze
    ```
-5. Format your code:
+6. Format your code:
    ```bash
    dart format .
    ```
-6. Commit your changes with a descriptive commit message:
+7. Commit your changes with a descriptive commit message:
    ```bash
    git commit -m "Add feature: description of your changes"
    ```
-7. Push your branch to your fork:
+8. Push your branch to your fork:
    ```bash
    git push origin feature/your-feature-name
    ```
-8. Create a pull request to the main repository
+9. Create a pull request to the main repository
 
 ## Pull Request Process
 

--- a/tool/hooks/pre-commit
+++ b/tool/hooks/pre-commit
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Pre-commit hook: format ALL Dart files and restage any that were staged
+
+# Check if dart is available on PATH
+if ! command -v dart &> /dev/null; then
+    echo "Error: dart not found on PATH"
+    echo "Please ensure Dart/Flutter is installed and on your PATH"
+    exit 1
+fi
+
+# Change to the repository root
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Checking dart format on entire codebase..."
+
+dart format . >/dev/null
+
+# Check if any files were changed by formatting
+CHANGED_FILES=$(git diff --name-only | grep '\.dart$')
+
+if [ -n "$CHANGED_FILES" ]; then
+    echo ""
+    echo "The following files were reformatted:"
+    echo "$CHANGED_FILES"
+    echo ""
+
+    for FILE in $CHANGED_FILES; do
+        echo "Staging reformatted file: $FILE"
+        git add "$FILE"
+    done
+
+    echo ""
+    echo "Reformatted files have been staged."
+fi
+
+echo "Dart formatting check complete."
+exit 0

--- a/tool/hooks/pre-push
+++ b/tool/hooks/pre-push
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Pre-push hook: fail the push if the analyzer reports issues, tests fail,
+# or line coverage drops below the published coverage badge.
+#
+# First-time contributors' CI runs need maintainer approval before they
+# execute, so this hook may be the only check that runs before review —
+# it mirrors what CI enforces. Bypass in an emergency with
+# `git push --no-verify` (CI will still hold the line).
+
+# Floor used when the published badge can't be fetched (e.g. offline).
+FALLBACK_MIN_COVERAGE=80
+
+# Check if dart is available on PATH
+if ! command -v dart &> /dev/null; then
+    echo "Error: dart not found on PATH"
+    echo "Please ensure Dart/Flutter is installed and on your PATH"
+    exit 1
+fi
+
+# Change to the repository root
+cd "$(git rev-parse --show-toplevel)"
+
+echo "========================================"
+echo "Running analyzer before push..."
+echo "========================================"
+
+dart analyze
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "========================================"
+    echo "ERROR: Analyzer found issues! Push aborted."
+    echo "Please fix all analyzer warnings/errors before pushing."
+    echo "========================================"
+    exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "Analyzer passed. Running tests with coverage"
+echo "(tool/coverage.sh — this takes a few minutes"
+echo "and uses a local otel collector)..."
+echo "========================================"
+
+./tool/coverage.sh
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "========================================"
+    echo "ERROR: Tests failed! Push aborted."
+    echo "Please fix the failing tests before pushing."
+    echo "========================================"
+    exit 1
+fi
+
+if [ ! -f coverage/lcov.info ]; then
+    echo "ERROR: coverage/lcov.info not found after tool/coverage.sh."
+    exit 1
+fi
+
+# Line coverage straight from lcov.info — no lcov CLI needed.
+COVERAGE_PCT=$(awk -F: '/^LF:/{lf+=$2} /^LH:/{lh+=$2} END{if (lf>0) printf "%.1f", 100*lh/lf}' coverage/lcov.info)
+
+if [ -z "$COVERAGE_PCT" ]; then
+    echo "ERROR: could not compute coverage from coverage/lcov.info."
+    exit 1
+fi
+
+# Baseline: the published badge — coverage must go up, or at least not down.
+BASELINE=$FALLBACK_MIN_COVERAGE
+BASELINE_SOURCE="fallback floor"
+if git fetch -q origin badges 2>/dev/null; then
+    BADGE_PCT=$(git show origin/badges:coverage.svg 2>/dev/null \
+        | grep -o '[0-9][0-9.]*%' | head -1 | tr -d '%')
+    if [ -n "$BADGE_PCT" ]; then
+        BASELINE=$BADGE_PCT
+        BASELINE_SOURCE="published badge"
+    fi
+fi
+
+echo ""
+echo "========================================"
+echo "Line coverage: ${COVERAGE_PCT}%"
+echo "Required:      >= ${BASELINE}% (${BASELINE_SOURCE})"
+echo "========================================"
+
+if command -v bc &> /dev/null; then
+    COVERAGE_OK=$(echo "$COVERAGE_PCT >= $BASELINE" | bc -l)
+else
+    COVERAGE_INT=${COVERAGE_PCT%.*}
+    BASELINE_INT=${BASELINE%.*}
+    if [ "$COVERAGE_INT" -ge "$BASELINE_INT" ]; then
+        COVERAGE_OK=1
+    else
+        COVERAGE_OK=0
+    fi
+fi
+
+if [ "$COVERAGE_OK" != "1" ]; then
+    echo ""
+    echo "========================================"
+    echo "ERROR: Coverage ${COVERAGE_PCT}% is below ${BASELINE}%! Push aborted."
+    echo "Coverage should go up, not down — please add tests."
+    echo "Report: open coverage/html/index.html"
+    echo "========================================"
+    exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "All checks passed. Proceeding with push."
+echo "========================================"
+exit 0

--- a/tool/setup-hooks.sh
+++ b/tool/setup-hooks.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Setup git hooks for local development
+# Run this once after cloning the repository
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Setting up git hooks..."
+
+# Configure git to use our hooks directory
+git config core.hooksPath "$SCRIPT_DIR/hooks"
+
+# Make hooks executable
+chmod +x "$SCRIPT_DIR/hooks/"*
+
+echo "Git hooks installed successfully!"
+echo "Hooks location: $SCRIPT_DIR/hooks"
+echo ""
+echo "Installed hooks:"
+echo "  - pre-commit: Formats Dart files and restages them"
+echo "  - pre-push: Blocks the push if the analyzer reports issues, tests"
+echo "              fail, or coverage drops below the published badge"


### PR DESCRIPTION
Ports the api repo's git-hook setup to the SDK — this is the hook setup the SDK was assumed to have but never did.

- **`tool/hooks/pre-commit`** — formats the tree and restages reformatted files.
- **`tool/hooks/pre-push`** — runs `dart analyze` (matching CI), then `tool/coverage.sh` (full suite against the local otel collector), then blocks the push if line coverage falls below the **published coverage badge** (currently 93.4%), so coverage goes up or stays the same. Falls back to an 80% floor when the badge can't be fetched offline. Parses `coverage/lcov.info` directly — no `lcov` CLI required. Bypass for emergencies: `git push --no-verify` (CI still holds the line).
- **`tool/setup-hooks.sh`** — one-time opt-in (`git config core.hooksPath`); hooks can't be distributed with a clone by design.
- **CONTRIBUTING.md** — hook setup added to Getting Started with the rationale (first-time contributors' CI runs need maintainer approval, so the hooks are the first line of feedback), typo fixes ("currecnt", "adequete", "tests uses"), and the duplicated step-4 numbering fixed.

Companion PR on the api repo updates its existing pre-push to the same badge-baseline + awk parsing.

Assisted-By: Claude Fable 5