### PR TITLE
docs: adopt the OpenTelemetry Generative AI policy; add AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+Instructions for AI agents (and their humans) working in
+`dartastic_opentelemetry`. Read [CONTRIBUTING.md](CONTRIBUTING.md) first —
+everything there applies, including the git hooks
+(`./tool/setup-hooks.sh`), the CHANGELOG conventions, and the
+OpenTelemetry
+[Generative AI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+
+## Commit formatting
+
+We appreciate it if users disclose the use of AI tools when the significant part of a commit is
+taken from a tool without changes. When making a commit this should be disclosed through an
+Assisted-by: commit message trailer.
+
+Examples:
+
+Assisted-by: ChatGPT 5.2
+Assisted-by: Claude Opus 4.5
+
+## Architecture: one entrypoint, everything through factories
+
+This SDK is **not structured like most OpenTelemetry SDKs**. In most
+language SDKs you construct providers, tracers, and exporters directly.
+Here there is a single entrypoint — the `OTel` class — backed by a factory
+layer, and all calls flow through them:
+
+- **`OTel` is the front door.** `OTel.initialize()` configures the SDK, and
+  every object — tracer providers, tracers, spans, attributes, resources,
+  meters, baggage, context — is obtained from static methods on `OTel`,
+  never by calling constructors. Most constructors are private; creation
+  code lives in `*_create.dart` part files next to each class.
+- **A global factory does the construction.** `OTel.initialize()` installs
+  an `OTelSDKFactory` in `OTelFactory.otelFactory`. If API-only code runs
+  before initialization, the API package auto-installs a no-op
+  `OTelAPIFactory`; `initialize()` upgrades it to the SDK factory, per the
+  OpenTelemetry spec. This factory swap is how no-op vs SDK behavior and
+  platform (native vs web) variants are selected without user code
+  changing.
+- **Consequence for changes:** adding a creatable type means threading it
+  through the factory, not just adding a public constructor. When tracing a
+  call path, start at `OTel`, follow into the factory, then into the
+  `*_create.dart` part file — not at the class's constructor.
+
+The API package
+([`dartastic_opentelemetry_api`](https://pub.dev/packages/dartastic_opentelemetry_api))
+mirrors this with `OTelAPI` and `OTelAPIFactory`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Read and follow [AGENTS.md](AGENTS.md) — the instructions there (commit
+formatting, architecture orientation, and contributor policies) apply to
+Claude sessions in this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,24 @@ Thank you for your interest in contributing to the OpenTelemetry SDK for Dart! T
 
 This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
 
+## Generative AI Policy
+
+This project follows the OpenTelemetry
+[Generative AI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+In short: AI assistance is welcome for code, documentation, and tests, but
+**you remain in control and bear full responsibility** — review and validate
+everything before submitting, never post raw AI output as an issue, PR, or
+reply, and when AI generates the bulk of a commit, disclose it with an
+`Assisted-by:` commit trailer (e.g. `Assisted-by: Claude Opus 4.5`).
+Maintainers may close low-effort AI-generated contributions.
+
+**First-time contributors:** your first three contributions should be
+primarily human-written, and PR descriptions must be your own words — see
+the short guide at
+[Using AI](https://opentelemetry.io/docs/contributing/pull-requests/#using-ai).
+
+AI agents: see [AGENTS.md](AGENTS.md).
+
 ## Ways to Contribute
 
 There are many ways to contribute to this project:


### PR DESCRIPTION
- **CONTRIBUTING.md** gains a Generative AI Policy section summarizing and linking the [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md) — AI assistance welcome, human responsible, `Assisted-by:` trailer for AI-generated bulk, low-effort AI PRs may be closed — plus a shorter first-time-contributor note pointing at [Using AI](https://opentelemetry.io/docs/contributing/pull-requests/#using-ai) (first three contributions primarily human-written; PR descriptions in your own words).
- **AGENTS.md** carries the commit-formatting convention (`Assisted-by:` trailer with examples) and orients agents to what makes this SDK unusual: a single `OTel` entrypoint and a factory layer (`OTelSDKFactory` installed by `initialize()`, upgrading the API's auto-installed no-op factory), with creation in `*_create.dart` part files — so call paths are traced from `OTel` through the factory, not from constructors.
- **CLAUDE.md** points Claude at AGENTS.md.

Companion PR on the api repo mirrors this with the `OTelAPI`/`OTelAPIFactory` orientation.

Assisted-by: Claude Fable 5