### PR TITLE
fix(trace): honor sampler decisions end to end (spec-compliance sampling set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING (spec compliance): sampler decisions are now honored end to end**
+  (#120, #121, #122, #123, #129). A `Drop` decision produces a non-recording
+  span that reaches no processor; `RecordOnly` records without setting the
+  W3C `Sampled` flag; built-in processors deliver only recording spans to
+  `onStart`/`onEnd` and only sampled spans to exporters, per the spec's
+  IsRecording/Sampled reaction table; the forbidden Sampled+non-recording
+  combination is unrepresentable; `createSpan` routes through the sampler and
+  processors instead of bypassing them. Code that relied on unsampled or
+  dropped spans being exported must adjust its sampler configuration.
+
+- **BREAKING (spec compliance): the default sampler is now
+  `ParentBased(root: AlwaysOn)`** instead of bare `AlwaysOn` (#126). Root
+  spans still sample by default, but child spans of unsampled remote or local
+  parents now respect the parent's decision. Pass
+  `sampler: const AlwaysOnSampler()` to restore the old behavior.
+
+- **Child spans inherit the parent `TraceState`** (#124), and
+  **`SamplingResult` gains a `traceState` field** (#125) so samplers can
+  modify or replace it: `null` keeps the inherited parent TraceState, an
+  explicitly empty `TraceState` clears it. Existing custom samplers keep
+  working unchanged.
+
 - **BREAKING**: `OTelEnv` configuration functions (`getOtlpConfig`, `getBspConfig`, `getServiceConfig`, `getLogRecordLimits`, etc.) now return strongly-typed Dart Records instead of `Map<String, dynamic>`.
   Migration hint: Update map accesses to record property accesses (e.g., `config['endpoint'] as String?` → `config.endpoint`).
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -107,7 +107,7 @@ class OTel {
   /// @param tracerVersion Version of the default tracer (default: null)
   /// @param resourceAttributes Additional attributes for the resource
   /// @param spanProcessor Custom span processor (default: BatchSpanProcessor with OtlpGrpcSpanExporter)
-  /// @param sampler Sampling strategy to use (default: AlwaysOnSampler)
+  /// @param sampler Sampling strategy to use (default: ParentBased(root=AlwaysOn) per the spec)
   /// @param spanKind Default span kind (default: SpanKind.server)
   /// @param metricExporter Custom metric exporter for metrics
   /// @param metricReader Custom metric reader for metrics
@@ -141,7 +141,7 @@ class OTel {
     String? tracerVersion,
     Attributes? resourceAttributes,
     SpanProcessor? spanProcessor,
-    Sampler sampler = const AlwaysOnSampler(),
+    Sampler? sampler,
     SpanExceptionOptions spanExceptionOptions = const SpanExceptionOptions(),
     SpanKind spanKind = SpanKind.server,
     MetricExporter? metricExporter,
@@ -273,8 +273,12 @@ class OTel {
     }
     final factoryFactory =
         oTelFactoryCreationFunction ?? otelSDKFactoryFactoryFunction;
-    // Initialize with default sampler
-    _defaultSampler = sampler;
+    // Initialize with default sampler. Per the Trace SDK spec
+    // (Built-in samplers), "The default sampler is
+    // ParentBased(root=AlwaysOn)": children follow their parent's
+    // sampling decision (a remote unsampled parent's child is dropped),
+    // and root spans are always sampled.
+    _defaultSampler = sampler ?? ParentBasedSampler(const AlwaysOnSampler());
     _defaultSpanExceptionOptions = spanExceptionOptions;
     _defaultTimeProvider = timeProvider;
     OTel.defaultTracerName = tracerName ?? _defaultTracerName;

--- a/lib/src/trace/export/batch_span_processor.dart
+++ b/lib/src/trace/export/batch_span_processor.dart
@@ -213,6 +213,18 @@ class BatchSpanProcessor implements SpanProcessor {
       return;
     }
 
+    // Per the Trace SDK spec (Sampling), span exporters MUST receive
+    // spans with the Sampled flag set and SHOULD NOT receive the ones
+    // that do not (e.g. RECORD_ONLY spans record but are not exported).
+    if (!span.spanContext.traceFlags.isSampled) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+          'BatchSpanProcessor: Skipping enqueue - span ${span.spanContext.spanId} is not sampled',
+        );
+      }
+      return;
+    }
+
     return _lock.synchronized(() {
       if (_spanQueue.length >= _config.maxQueueSize) {
         if (OTelLog.isDebug()) {

--- a/lib/src/trace/export/simple_span_processor.dart
+++ b/lib/src/trace/export/simple_span_processor.dart
@@ -45,6 +45,18 @@ class SimpleSpanProcessor implements SpanProcessor {
       return;
     }
 
+    // Per the Trace SDK spec (Sampling), span exporters MUST receive
+    // spans with the Sampled flag set and SHOULD NOT receive the ones
+    // that do not (e.g. RECORD_ONLY spans record but are not exported).
+    if (!span.spanContext.traceFlags.isSampled) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+          'SimpleSpanProcessor: Skipping export - span ${span.spanContext.spanId} is not sampled',
+        );
+      }
+      return;
+    }
+
     // Verify the span has a valid end time
     if (span.endTime == null) {
       if (OTelLog.isWarn()) {

--- a/lib/src/trace/sampling/always_off_sampler.dart
+++ b/lib/src/trace/sampling/always_off_sampler.dart
@@ -44,9 +44,12 @@ class AlwaysOffSampler implements Sampler {
     required Attributes? attributes,
     required List<SpanLink>? links,
   }) {
-    return const SamplingResult(
+    return SamplingResult(
       decision: SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
+      // Spec: samplers SHOULD return the passed-in Tracestate unchanged
+      // when they do not intend to modify it.
+      traceState: parentContext.spanContext?.traceState,
     );
   }
 }

--- a/lib/src/trace/sampling/always_on_sampler.dart
+++ b/lib/src/trace/sampling/always_on_sampler.dart
@@ -44,9 +44,12 @@ class AlwaysOnSampler implements Sampler {
     required Attributes? attributes,
     required List<SpanLink>? links,
   }) {
-    return const SamplingResult(
+    return SamplingResult(
       decision: SamplingDecision.recordAndSample,
       source: SamplingDecisionSource.tracerConfig,
+      // Spec: samplers SHOULD return the passed-in Tracestate unchanged
+      // when they do not intend to modify it.
+      traceState: parentContext.spanContext?.traceState,
     );
   }
 }

--- a/lib/src/trace/sampling/composite_sampler.dart
+++ b/lib/src/trace/sampling/composite_sampler.dart
@@ -34,9 +34,10 @@ class CompositeSampler implements Sampler {
     required List<SpanLink>? links,
   }) {
     if (_samplers.isEmpty) {
-      return const SamplingResult(
+      return SamplingResult(
         decision: SamplingDecision.recordAndSample,
         source: SamplingDecisionSource.tracerConfig,
+        traceState: parentContext.spanContext?.traceState,
       );
     }
 
@@ -77,6 +78,7 @@ class CompositeSampler implements Sampler {
           : SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
       attributes: combinedAttributes,
+      traceState: parentContext.spanContext?.traceState,
     );
   }
 }

--- a/lib/src/trace/sampling/counting_sampler.dart
+++ b/lib/src/trace/sampling/counting_sampler.dart
@@ -43,9 +43,10 @@ class CountingSampler implements Sampler {
         spanKind: spanKind,
         attributes: attributes,
       )) {
-        return const SamplingResult(
+        return SamplingResult(
           decision: SamplingDecision.recordAndSample,
           source: SamplingDecisionSource.tracerConfig,
+          traceState: parentContext.spanContext?.traceState,
         );
       }
     }
@@ -59,6 +60,7 @@ class CountingSampler implements Sampler {
           ? SamplingDecision.recordAndSample
           : SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
+      traceState: parentContext.spanContext?.traceState,
     );
   }
 }
@@ -98,6 +100,7 @@ abstract class SamplingCondition implements Sampler {
           ? SamplingDecision.recordAndSample
           : SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
+      traceState: parentContext.spanContext?.traceState,
     );
   }
 }

--- a/lib/src/trace/sampling/probability_sampler.dart
+++ b/lib/src/trace/sampling/probability_sampler.dart
@@ -63,17 +63,21 @@ class ProbabilitySampler implements Sampler {
     required Attributes? attributes,
     required List<SpanLink>? links,
   }) {
+    final parentTraceState = parentContext.spanContext?.traceState;
+
     // Short circuit for always/never sample
     if (probability >= 1.0) {
-      return const SamplingResult(
+      return SamplingResult(
         decision: SamplingDecision.recordAndSample,
         source: SamplingDecisionSource.tracerConfig,
+        traceState: parentTraceState,
       );
     }
     if (probability <= 0.0) {
-      return const SamplingResult(
+      return SamplingResult(
         decision: SamplingDecision.drop,
         source: SamplingDecisionSource.tracerConfig,
+        traceState: parentTraceState,
       );
     }
 
@@ -83,6 +87,7 @@ class ProbabilitySampler implements Sampler {
       decision:
           decision ? SamplingDecision.recordAndSample : SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
+      traceState: parentTraceState,
     );
   }
 }

--- a/lib/src/trace/sampling/rate_limiting_sampler.dart
+++ b/lib/src/trace/sampling/rate_limiting_sampler.dart
@@ -64,18 +64,22 @@ class RateLimitingSampler implements Sampler {
     // Update tokens first
     _updateTokens();
 
+    final parentTraceState = parentContext.spanContext?.traceState;
+
     // If we have tokens available, sample the trace
     if (_tokenBalance >= 1.0) {
       _tokenBalance -= 1.0;
-      return const SamplingResult(
+      return SamplingResult(
         decision: SamplingDecision.recordAndSample,
         source: SamplingDecisionSource.tracerConfig,
+        traceState: parentTraceState,
       );
     }
 
-    return const SamplingResult(
+    return SamplingResult(
       decision: SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
+      traceState: parentTraceState,
     );
   }
 

--- a/lib/src/trace/sampling/sampler.dart
+++ b/lib/src/trace/sampling/sampler.dart
@@ -54,15 +54,29 @@ class SamplingResult {
   /// information about the sampling decision.
   final Attributes? attributes;
 
+  /// The TraceState to associate with the Span through the new
+  /// SpanContext (Trace SDK spec, ShouldSample).
+  ///
+  /// Samplers SHOULD normally return the passed-in parent TraceState
+  /// (reachable via `parentContext.spanContext?.traceState`) if they do
+  /// not intend to change it — all built-in samplers do. Returning an
+  /// empty TraceState clears the span's TraceState. Returning null means
+  /// the sampler has no opinion and the SDK keeps the TraceState
+  /// inherited from the parent, so samplers written before this field
+  /// existed keep their inheritance behavior.
+  final TraceState? traceState;
+
   /// Creates a new sampling result.
   ///
   /// @param decision The sampling decision
   /// @param source The source of the sampling decision
   /// @param attributes Optional attributes to add to the span
+  /// @param traceState Optional TraceState for the new SpanContext
   const SamplingResult({
     required this.decision,
     required this.source,
     this.attributes,
+    this.traceState,
   });
 }
 

--- a/lib/src/trace/sampling/trace_id_ratio_sampler.dart
+++ b/lib/src/trace/sampling/trace_id_ratio_sampler.dart
@@ -53,19 +53,23 @@ class TraceIdRatioSampler implements Sampler {
     required Attributes? attributes,
     required List<SpanLink>? links,
   }) {
+    final parentTraceState = parentContext.spanContext?.traceState;
+
     // If ratio is 0, never sample
     if (ratio == 0.0) {
-      return const SamplingResult(
+      return SamplingResult(
         decision: SamplingDecision.drop,
         source: SamplingDecisionSource.tracerConfig,
+        traceState: parentTraceState,
       );
     }
 
     // If ratio is 1, always sample
     if (ratio == 1.0) {
-      return const SamplingResult(
+      return SamplingResult(
         decision: SamplingDecision.recordAndSample,
         source: SamplingDecisionSource.tracerConfig,
+        traceState: parentTraceState,
       );
     }
 
@@ -80,6 +84,7 @@ class TraceIdRatioSampler implements Sampler {
           ? SamplingDecision.recordAndSample
           : SamplingDecision.drop,
       source: SamplingDecisionSource.tracerConfig,
+      traceState: parentTraceState,
     );
   }
 }

--- a/lib/src/trace/span.dart
+++ b/lib/src/trace/span.dart
@@ -80,7 +80,17 @@ class Span implements APISpan {
         OTelLog.debug('SDKSpan: Delegate.end() completed for span $name');
       }
 
-      // Notify span processors that this span has ended
+      // Notify span processors that this span has ended. Per the Trace
+      // SDK spec (Sampling), span processors MUST receive only spans
+      // with IsRecording == true — a dropped span ends silently.
+      if (!_isRecording) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+            'SDKSpan: Span $name is not recording; skipping processor onEnd',
+          );
+        }
+        return;
+      }
       final provider = _sdkTracer.provider;
       if (OTelLog.isDebug()) {
         OTelLog.debug(
@@ -116,31 +126,52 @@ class Span implements APISpan {
     }
   }
 
-  @override
-  set attributes(Attributes newAttributes) =>
-      _delegate.attributes = newAttributes;
+  // All mutators below are gated on the sampling decision: when a span is
+  // not recording, "all this data is discarded right away" and mutation
+  // attempts are no-ops (Trace API spec, IsRecording). The delegate only
+  // guards against mutation after end, so the gate lives here.
 
   @override
-  void addAttributes(Attributes attributes) =>
-      _delegate.addAttributes(attributes);
+  set attributes(Attributes newAttributes) {
+    if (!_isRecording) return;
+    _delegate.attributes = newAttributes;
+  }
 
   @override
-  void addEvent(SpanEvent spanEvent) => _delegate.addEvent(spanEvent);
+  void addAttributes(Attributes attributes) {
+    if (!_isRecording) return;
+    _delegate.addAttributes(attributes);
+  }
 
   @override
-  void addEventNow(String name, [Attributes? attributes]) =>
-      _delegate.addEventNow(name, attributes);
+  void addEvent(SpanEvent spanEvent) {
+    if (!_isRecording) return;
+    _delegate.addEvent(spanEvent);
+  }
 
   @override
-  void addEvents(Map<String, Attributes?> spanEvents) =>
-      _delegate.addEvents(spanEvents);
+  void addEventNow(String name, [Attributes? attributes]) {
+    if (!_isRecording) return;
+    _delegate.addEventNow(name, attributes);
+  }
 
   @override
-  void addLink(SpanContext spanContext, [Attributes? attributes]) =>
-      _delegate.addLink(spanContext, attributes);
+  void addEvents(Map<String, Attributes?> spanEvents) {
+    if (!_isRecording) return;
+    _delegate.addEvents(spanEvents);
+  }
 
   @override
-  void addSpanLink(SpanLink spanLink) => _delegate.addSpanLink(spanLink);
+  void addLink(SpanContext spanContext, [Attributes? attributes]) {
+    if (!_isRecording) return;
+    _delegate.addLink(spanContext, attributes);
+  }
+
+  @override
+  void addSpanLink(SpanLink spanLink) {
+    if (!_isRecording) return;
+    _delegate.addSpanLink(spanLink);
+  }
 
   @override
   DateTime? get endTime => _delegate.endTime;
@@ -166,40 +197,55 @@ class Span implements APISpan {
     StackTrace? stackTrace,
     Attributes? attributes,
     bool? escaped,
-  }) =>
-      _delegate.recordException(
-        exception,
-        stackTrace: stackTrace,
-        attributes: attributes,
-        escaped: escaped,
-      );
+  }) {
+    if (!_isRecording) return;
+    _delegate.recordException(
+      exception,
+      stackTrace: stackTrace,
+      attributes: attributes,
+      escaped: escaped,
+    );
+  }
 
   @override
-  void setBoolAttribute(String name, bool value) =>
-      _delegate.setBoolAttribute(name, value);
+  void setBoolAttribute(String name, bool value) {
+    if (!_isRecording) return;
+    _delegate.setBoolAttribute(name, value);
+  }
 
   @override
-  void setBoolListAttribute(String name, List<bool> value) =>
-      _delegate.setBoolListAttribute(name, value);
+  void setBoolListAttribute(String name, List<bool> value) {
+    if (!_isRecording) return;
+    _delegate.setBoolListAttribute(name, value);
+  }
 
   @override
-  void setDoubleAttribute(String name, double value) =>
-      _delegate.setDoubleAttribute(name, value);
+  void setDoubleAttribute(String name, double value) {
+    if (!_isRecording) return;
+    _delegate.setDoubleAttribute(name, value);
+  }
 
   @override
-  void setDoubleListAttribute(String name, List<double> value) =>
-      _delegate.setDoubleListAttribute(name, value);
+  void setDoubleListAttribute(String name, List<double> value) {
+    if (!_isRecording) return;
+    _delegate.setDoubleListAttribute(name, value);
+  }
 
   @override
-  void setIntAttribute(String name, int value) =>
-      _delegate.setIntAttribute(name, value);
+  void setIntAttribute(String name, int value) {
+    if (!_isRecording) return;
+    _delegate.setIntAttribute(name, value);
+  }
 
   @override
-  void setIntListAttribute(String name, List<int> value) =>
-      _delegate.setIntListAttribute(name, value);
+  void setIntListAttribute(String name, List<int> value) {
+    if (!_isRecording) return;
+    _delegate.setIntListAttribute(name, value);
+  }
 
   @override
   void setStatus(SpanStatusCode statusCode, [String? description]) {
+    if (!_isRecording) return;
     _delegate.setStatus(statusCode, description);
     if (OTelLog.isDebug()) {
       OTelLog.debug(
@@ -209,16 +255,22 @@ class Span implements APISpan {
   }
 
   @override
-  void setStringAttribute<T>(String name, String value) =>
-      _delegate.setStringAttribute<T>(name, value);
+  void setStringAttribute<T>(String name, String value) {
+    if (!_isRecording) return;
+    _delegate.setStringAttribute<T>(name, value);
+  }
 
   @override
-  void setStringListAttribute<T>(String name, List<String> value) =>
-      _delegate.setStringListAttribute<T>(name, value);
+  void setStringListAttribute<T>(String name, List<String> value) {
+    if (!_isRecording) return;
+    _delegate.setStringListAttribute<T>(name, value);
+  }
 
   @override
-  void setDateTimeAsStringAttribute(String name, DateTime value) =>
-      _delegate.setDateTimeAsStringAttribute(name, value);
+  void setDateTimeAsStringAttribute(String name, DateTime value) {
+    if (!_isRecording) return;
+    _delegate.setDateTimeAsStringAttribute(name, value);
+  }
 
   @override
   SpanContext get spanContext => _delegate.spanContext;
@@ -243,6 +295,7 @@ class Span implements APISpan {
 
   @override
   void updateName(String name) {
+    if (!_isRecording) return;
     _delegate.updateName(name);
 
     final provider = _sdkTracer.provider;

--- a/lib/src/trace/span.dart
+++ b/lib/src/trace/span.dart
@@ -33,13 +33,22 @@ class Span implements APISpan {
   final APISpan _delegate;
   final Tracer _sdkTracer;
 
+  /// The recording state decided by the sampler at creation time.
+  ///
+  /// Per the Trace SDK spec (ShouldSample), a DROP decision creates a span
+  /// with `IsRecording == false`; the delegate APISpan does not carry this
+  /// state, so the SDK span holds it.
+  final bool _isRecording;
+
   /// Private constructor for creating Span instances.
   ///
   /// @param delegate The API Span implementation to delegate to
   /// @param sdkTracer The SDK Tracer that created this Span
-  Span._(APISpan delegate, Tracer sdkTracer)
+  /// @param isRecording Whether this span records data (sampling decision)
+  Span._(APISpan delegate, Tracer sdkTracer, {bool isRecording = true})
       : _delegate = delegate,
-        _sdkTracer = sdkTracer {
+        _sdkTracer = sdkTracer,
+        _isRecording = isRecording {
     if (OTelLog.isDebug()) {
       OTelLog.debug('SDKSpan: Created new span with name ${delegate.name}');
     }
@@ -140,7 +149,7 @@ class Span implements APISpan {
   bool get isEnded => _delegate.isEnded;
 
   @override
-  bool get isRecording => _delegate.isRecording;
+  bool get isRecording => _isRecording && _delegate.isRecording;
 
   @override
   SpanKind get kind => _delegate.kind;

--- a/lib/src/trace/span_create.dart
+++ b/lib/src/trace/span_create.dart
@@ -14,11 +14,14 @@ class SDKSpanCreate {
   ///
   /// @param delegateSpan The API Span implementation to delegate to
   /// @param sdkTracer The SDK Tracer that created this Span
+  /// @param isRecording Whether the span records data, per the sampling
+  ///   decision made at creation time (see the Trace SDK spec, ShouldSample).
   /// @return A new Span instance
   static Span create({
     required APISpan delegateSpan,
     required Tracer sdkTracer,
+    bool isRecording = true,
   }) {
-    return Span._(delegateSpan, sdkTracer);
+    return Span._(delegateSpan, sdkTracer, isRecording: isRecording);
   }
 }

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -480,9 +480,12 @@ class Tracer implements APITracer {
 
     // Notify processors. Per the Trace SDK spec (Sampling), span
     // processors MUST receive only spans with IsRecording == true.
+    // OnStart receives "the parent Context of the span that the SDK
+    // determined", so pass the resolved effectiveContext, never the raw
+    // (possibly null) context argument.
     if (recording) {
       for (final processor in _provider.spanProcessors) {
-        processor.onStart(sdkSpan, context);
+        processor.onStart(sdkSpan, effectiveContext);
       }
     }
 

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -246,8 +246,9 @@ class Tracer implements APITracer {
   ///
   /// [isRecording] defaults to null, which means the sampler's decision
   /// determines whether the span records. Passing false forces a
-  /// non-recording span; passing true cannot resurrect a span the
-  /// sampler decided to drop.
+  /// non-recording span and clears the Sampled flag (the SDK MUST NOT
+  /// produce Sampled == true with IsRecording == false); passing true
+  /// cannot resurrect a span the sampler decided to drop.
   @override
   Span startSpan(
     String name, {
@@ -424,12 +425,23 @@ class Tracer implements APITracer {
     // resurrect a dropped one (spec: DROP => IsRecording will be false).
     final recording = shouldRecord && (isRecording ?? true);
 
+    // The SDK MUST NOT allow Sampled == true with IsRecording == false
+    // (Trace SDK spec, Sampling — the combination causes gaps in the
+    // distributed trace). A forced non-recording span is never sampled.
+    if (!recording) {
+      sampled = false;
+    }
+
     if (sampled != null) {
       // The Sampled trace flag reflects the sampling decision only —
       // RECORD_ONLY records without setting the flag.
       traceFlags = OTel.traceFlags(
         sampled ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
       );
+    } else if (!recording && (traceFlags?.isSampled ?? false)) {
+      // No sampler configured and flags inherited from the parent:
+      // still clear Sampled on a forced non-recording span.
+      traceFlags = OTel.traceFlags(TraceFlags.NONE_FLAG);
     }
 
     // Always create a new span context with a new span ID

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -411,6 +411,16 @@ class Tracer implements APITracer {
           sampled = true;
       }
 
+      // Per the Trace SDK spec (ShouldSample), the Tracestate returned
+      // by the sampler is associated with the Span through the new
+      // SpanContext. An explicitly empty TraceState clears it; null
+      // means the sampler has no opinion (samplers written before
+      // SamplingResult.traceState existed keep parent inheritance).
+      final samplerTraceState = samplingResult.traceState;
+      if (samplerTraceState != null) {
+        parentTraceState = samplerTraceState.isEmpty ? null : samplerTraceState;
+      }
+
       // Add sampler attributes if provided
       if (samplingResult.attributes != null) {
         if (attributes == null) {

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -209,6 +209,16 @@ class Tracer implements APITracer {
     }
   }
 
+  /// Creates a span without making it active in any context.
+  ///
+  /// Per the Trace SDK spec (SDK Span creation), this goes through the
+  /// same pipeline as [startSpan]: the sampler is queried and the span
+  /// processors are notified. Unlike [startSpan], an explicitly provided
+  /// [spanContext] is used verbatim as the new span's SpanContext
+  /// (identity, flags, and TraceState) rather than only donating its
+  /// trace ID — the sampler still controls IsRecording and processor
+  /// delivery, and the forbidden Sampled==true with IsRecording==false
+  /// combination is corrected by clearing the Sampled flag.
   @override
   Span createSpan({
     required String name,
@@ -226,20 +236,19 @@ class Tracer implements APITracer {
       OTelLog.debug('Tracer: Creating span with name: $name, kind: $kind');
     }
 
-    final delegateSpan = _delegate.createSpan(
+    return _startSpanInternal(
       name: name,
+      context: context,
       spanContext: spanContext,
       parentSpan: parentSpan,
       kind: kind,
       attributes: attributes,
       links: links,
-      startTime: startTime,
       spanEvents: spanEvents,
+      startTime: startTime,
       isRecording: isRecording,
-      context: context,
+      honorExplicitSpanContext: true,
     );
-
-    return SDKSpanCreate.create(delegateSpan: delegateSpan, sdkTracer: this);
   }
 
   /// Starts a new span.
@@ -280,6 +289,12 @@ class Tracer implements APITracer {
   /// ("SDK Span creation"): resolve the parent, generate a new SpanId,
   /// query the sampler's ShouldSample, create the span according to the
   /// decision, and notify the span processors.
+  ///
+  /// When [honorExplicitSpanContext] is true (the [createSpan] path) and
+  /// [spanContext] is provided, that SpanContext is used verbatim for
+  /// the new span instead of minting a new SpanId and deriving flags
+  /// from the sampling decision; the decision still governs IsRecording
+  /// and processor delivery.
   Span _startSpanInternal({
     required String name,
     Context? context,
@@ -291,6 +306,7 @@ class Tracer implements APITracer {
     List<SpanEvent>? spanEvents,
     DateTime? startTime,
     bool? isRecording,
+    bool honorExplicitSpanContext = false,
   }) {
     // Get parent context from either the passed context or parent span.
     // Use a content-based check rather than `effectiveContext != Context.root`
@@ -463,16 +479,34 @@ class Tracer implements APITracer {
       traceFlags = OTel.traceFlags(TraceFlags.NONE_FLAG);
     }
 
-    // Always create a new span context with a new span ID
-    // For root spans, ensure we set an invalid parent span ID (zeros)
-    final newSpanContext = OTel.spanContext(
-      traceId: traceId,
-      spanId: OTel.spanId(), // Always generate a new span ID
-      parentSpanId: parentSpanId ??
-          OTel.spanIdInvalid(), // Use invalid span ID for root spans
-      traceFlags: traceFlags,
-      traceState: parentTraceState,
-    );
+    final SpanContext newSpanContext;
+    if (honorExplicitSpanContext && spanContext != null) {
+      // createSpan contract: an explicitly provided SpanContext is used
+      // verbatim. Only the forbidden Sampled==true with
+      // IsRecording==false combination is corrected (Trace SDK spec,
+      // Sampling: the SDK MUST NOT allow it).
+      newSpanContext = (!recording && spanContext.traceFlags.isSampled)
+          ? OTel.spanContext(
+              traceId: spanContext.traceId,
+              spanId: spanContext.spanId,
+              parentSpanId: spanContext.parentSpanId,
+              traceFlags: OTel.traceFlags(TraceFlags.NONE_FLAG),
+              traceState: spanContext.traceState,
+              isRemote: spanContext.isRemote,
+            )
+          : spanContext;
+    } else {
+      // Always create a new span context with a new span ID
+      // For root spans, ensure we set an invalid parent span ID (zeros)
+      newSpanContext = OTel.spanContext(
+        traceId: traceId,
+        spanId: OTel.spanId(), // Always generate a new span ID
+        parentSpanId: parentSpanId ??
+            OTel.spanIdInvalid(), // Use invalid span ID for root spans
+        traceFlags: traceFlags,
+        traceState: parentTraceState,
+      );
+    }
 
     // Create the delegate span with our newly created span context.
     // (The API's startSpan forwards verbatim to createSpan; calling

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -353,14 +353,23 @@ class Tracer implements APITracer {
       parentSpanId = parentContext.spanId;
     }
 
-    // Inherit trace flags from parent — explicit parentSpan wins over context
-    // for consistency with traceId resolution above.
+    // Inherit trace flags and TraceState from parent — explicit parentSpan
+    // wins over context for consistency with traceId resolution above.
+    // Per the Trace API spec (Span creation), "the child span MUST inherit
+    // all TraceState values of its parent by default"; this applies to
+    // local and remote parents alike.
     TraceFlags? traceFlags;
+    TraceState? parentTraceState;
     if (parentSpan != null && parentSpan.spanContext.isValid) {
       traceFlags = parentSpan.spanContext.traceFlags;
+      parentTraceState = parentSpan.spanContext.traceState;
     } else if (parentContext != null && parentContext.isValid) {
       traceFlags = parentContext.traceFlags;
+      parentTraceState = parentContext.traceState;
     }
+    // An explicit spanContext argument can also donate a TraceState when
+    // no parent supplied one (it already donates the traceId above).
+    parentTraceState ??= spanContext?.traceState;
 
     if (OTelLog.isDebug()) {
       if (parentSpanId != null) {
@@ -452,6 +461,7 @@ class Tracer implements APITracer {
       parentSpanId: parentSpanId ??
           OTel.spanIdInvalid(), // Use invalid span ID for root spans
       traceFlags: traceFlags,
+      traceState: parentTraceState,
     );
 
     // Create the delegate span with our newly created span context.

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -257,6 +257,34 @@ class Tracer implements APITracer {
       OTelLog.debug('Tracer: Starting span with name: $name, kind: $kind');
     }
 
+    return _startSpanInternal(
+      name: name,
+      context: context,
+      spanContext: spanContext,
+      parentSpan: parentSpan,
+      kind: kind,
+      attributes: attributes,
+      links: links,
+      isRecording: isRecording,
+    );
+  }
+
+  /// Shared SDK span-creation pipeline, per the Trace SDK spec
+  /// ("SDK Span creation"): resolve the parent, generate a new SpanId,
+  /// query the sampler's ShouldSample, create the span according to the
+  /// decision, and notify the span processors.
+  Span _startSpanInternal({
+    required String name,
+    Context? context,
+    SpanContext? spanContext,
+    APISpan? parentSpan,
+    SpanKind kind = SpanKind.internal,
+    Attributes? attributes,
+    List<SpanLink>? links,
+    List<SpanEvent>? spanEvents,
+    DateTime? startTime,
+    bool? isRecording,
+  }) {
     // Get parent context from either the passed context or parent span.
     // Use a content-based check rather than `effectiveContext != Context.root`
     // — Context.root can carry the propagated context inside an isolate
@@ -393,15 +421,20 @@ class Tracer implements APITracer {
       traceFlags: traceFlags,
     );
 
-    // Create the delegate span with our newly created span context
-    final delegateSpan = _delegate.startSpan(
-      name,
+    // Create the delegate span with our newly created span context.
+    // (The API's startSpan forwards verbatim to createSpan; calling
+    // createSpan directly also lets this pipeline carry spanEvents and
+    // an explicit startTime.)
+    final delegateSpan = _delegate.createSpan(
+      name: name,
       context: effectiveContext,
       spanContext: newSpanContext,
       parentSpan: effectiveParentSpan,
       kind: kind,
       attributes: attributes,
       links: links,
+      spanEvents: spanEvents,
+      startTime: startTime,
       isRecording: isRecording ?? shouldRecord,
     );
 
@@ -409,6 +442,7 @@ class Tracer implements APITracer {
     final sdkSpan = SDKSpanCreate.create(
       delegateSpan: delegateSpan,
       sdkTracer: this,
+      isRecording: isRecording ?? shouldRecord,
     );
 
     // Notify processors

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -219,7 +219,7 @@ class Tracer implements APITracer {
     List<SpanLink>? links,
     List<SpanEvent>? spanEvents,
     DateTime? startTime,
-    bool? isRecording = true,
+    bool? isRecording,
     Context? context,
   }) {
     if (OTelLog.isDebug()) {
@@ -242,6 +242,12 @@ class Tracer implements APITracer {
     return SDKSpanCreate.create(delegateSpan: delegateSpan, sdkTracer: this);
   }
 
+  /// Starts a new span.
+  ///
+  /// [isRecording] defaults to null, which means the sampler's decision
+  /// determines whether the span records. Passing false forces a
+  /// non-recording span; passing true cannot resurrect a span the
+  /// sampler decided to drop.
   @override
   Span startSpan(
     String name, {
@@ -251,7 +257,7 @@ class Tracer implements APITracer {
     SpanKind kind = SpanKind.internal,
     Attributes? attributes,
     List<SpanLink>? links,
-    bool? isRecording = true,
+    bool? isRecording,
   }) {
     if (OTelLog.isDebug()) {
       OTelLog.debug('Tracer: Starting span with name: $name, kind: $kind');
@@ -367,6 +373,7 @@ class Tracer implements APITracer {
 
     // Apply sampling decision if we have a sampler
     var shouldRecord = true;
+    bool? sampled; // null: no sampler configured, keep inherited flags
     if (sampler != null) {
       final samplingResult = sampler!.shouldSample(
         parentContext: effectiveContext,
@@ -382,7 +389,6 @@ class Tracer implements APITracer {
       //   DROP              -> IsRecording false, Sampled MUST NOT be set
       //   RECORD_ONLY       -> IsRecording true,  Sampled MUST NOT be set
       //   RECORD_AND_SAMPLE -> IsRecording true,  Sampled MUST be set
-      bool sampled;
       switch (samplingResult.decision) {
         case SamplingDecision.drop:
           shouldRecord = false;
@@ -394,12 +400,6 @@ class Tracer implements APITracer {
           shouldRecord = true;
           sampled = true;
       }
-
-      // The Sampled trace flag reflects the sampling decision only —
-      // RECORD_ONLY records without setting the flag.
-      traceFlags = OTel.traceFlags(
-        sampled ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
-      );
 
       // Add sampler attributes if provided
       if (samplingResult.attributes != null) {
@@ -417,6 +417,19 @@ class Tracer implements APITracer {
           'Sampling decision for span $name: ${samplingResult.decision}',
         );
       }
+    }
+
+    // The sampler owns the recording decision. A caller may pass
+    // isRecording: false to force a non-recording span, but can never
+    // resurrect a dropped one (spec: DROP => IsRecording will be false).
+    final recording = shouldRecord && (isRecording ?? true);
+
+    if (sampled != null) {
+      // The Sampled trace flag reflects the sampling decision only —
+      // RECORD_ONLY records without setting the flag.
+      traceFlags = OTel.traceFlags(
+        sampled ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
+      );
     }
 
     // Always create a new span context with a new span ID
@@ -443,19 +456,22 @@ class Tracer implements APITracer {
       links: links,
       spanEvents: spanEvents,
       startTime: startTime,
-      isRecording: isRecording ?? shouldRecord,
+      isRecording: recording,
     );
 
     // Wrap it in our SDK span which will handle processing
     final sdkSpan = SDKSpanCreate.create(
       delegateSpan: delegateSpan,
       sdkTracer: this,
-      isRecording: isRecording ?? shouldRecord,
+      isRecording: recording,
     );
 
-    // Notify processors
-    for (final processor in _provider.spanProcessors) {
-      processor.onStart(sdkSpan, context);
+    // Notify processors. Per the Trace SDK spec (Sampling), span
+    // processors MUST receive only spans with IsRecording == true.
+    if (recording) {
+      for (final processor in _provider.spanProcessors) {
+        processor.onStart(sdkSpan, context);
+      }
     }
 
     return sdkSpan;

--- a/lib/src/trace/tracer.dart
+++ b/lib/src/trace/tracer.dart
@@ -377,21 +377,29 @@ class Tracer implements APITracer {
         links: links,
       );
 
-      // Update the isRecording flag based on the sampling decision
-      shouldRecord = samplingResult.decision != SamplingDecision.drop;
-
-      // Update trace flags based on sampling decision
-      if (traceFlags == null) {
-        traceFlags = OTel.traceFlags(
-          shouldRecord ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
-        );
-      } else if (shouldRecord && !traceFlags.isSampled) {
-        // Upgrade to sampled if necessary
-        traceFlags = OTel.traceFlags(TraceFlags.SAMPLED_FLAG);
-      } else if (!shouldRecord && traceFlags.isSampled) {
-        // Downgrade to not sampled if necessary
-        traceFlags = OTel.traceFlags(TraceFlags.NONE_FLAG);
+      // Map the decision onto the (IsRecording, Sampled) pair, per the
+      // Trace SDK spec (ShouldSample):
+      //   DROP              -> IsRecording false, Sampled MUST NOT be set
+      //   RECORD_ONLY       -> IsRecording true,  Sampled MUST NOT be set
+      //   RECORD_AND_SAMPLE -> IsRecording true,  Sampled MUST be set
+      bool sampled;
+      switch (samplingResult.decision) {
+        case SamplingDecision.drop:
+          shouldRecord = false;
+          sampled = false;
+        case SamplingDecision.recordOnly:
+          shouldRecord = true;
+          sampled = false;
+        case SamplingDecision.recordAndSample:
+          shouldRecord = true;
+          sampled = true;
       }
+
+      // The Sampled trace flag reflects the sampling decision only —
+      // RECORD_ONLY records without setting the flag.
+      traceFlags = OTel.traceFlags(
+        sampled ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
+      );
 
       // Add sampler attributes if provided
       if (samplingResult.attributes != null) {

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -148,9 +148,9 @@ void main() {
       test('DROP does not set Sampled ($parentDesc parent)', () async {
         await initWith(sampler: FixedDecisionSampler(SamplingDecision.drop));
         final span = OTel.tracer().startSpan(
-              'drop-span',
-              context: parentContextWith(sampled: parentSampled),
-            );
+          'drop-span',
+          context: parentContextWith(sampled: parentSampled),
+        );
         expect(span.spanContext.traceFlags.isSampled, isFalse);
         span.end();
       });
@@ -160,9 +160,9 @@ void main() {
           sampler: FixedDecisionSampler(SamplingDecision.recordOnly),
         );
         final span = OTel.tracer().startSpan(
-              'record-only-span',
-              context: parentContextWith(sampled: parentSampled),
-            );
+          'record-only-span',
+          context: parentContextWith(sampled: parentSampled),
+        );
         expect(span.spanContext.traceFlags.isSampled, isFalse);
         expect(span.isRecording, isTrue);
         span.end();
@@ -173,9 +173,9 @@ void main() {
           sampler: FixedDecisionSampler(SamplingDecision.recordAndSample),
         );
         final span = OTel.tracer().startSpan(
-              'sampled-span',
-              context: parentContextWith(sampled: parentSampled),
-            );
+          'sampled-span',
+          context: parentContextWith(sampled: parentSampled),
+        );
         expect(span.spanContext.traceFlags.isSampled, isTrue);
         expect(span.isRecording, isTrue);
         span.end();
@@ -266,10 +266,10 @@ void main() {
       OTel.tracerProvider().sampler = null;
 
       final span = OTel.tracer().startSpan(
-            'forced-off',
-            context: parentContextWith(sampled: true),
-            isRecording: false,
-          );
+        'forced-off',
+        context: parentContextWith(sampled: true),
+        isRecording: false,
+      );
 
       expect(span.isRecording, isFalse);
       expect(span.spanContext.traceFlags.isSampled, isFalse);
@@ -294,9 +294,9 @@ void main() {
         await initWith(sampler: FixedDecisionSampler(decision));
         for (final forced in <bool?>[null, true, false]) {
           final span = OTel.tracer().startSpan(
-                'combination-check',
-                isRecording: forced,
-              );
+            'combination-check',
+            isRecording: forced,
+          );
           final forbidden =
               span.spanContext.traceFlags.isSampled && !span.isRecording;
           expect(forbidden, isFalse,
@@ -425,9 +425,9 @@ void main() {
 
       // Local parent: the child of childOfRemote inherits transitively.
       final grandChild = OTel.tracer().startSpan(
-            'grandchild',
-            parentSpan: childOfRemote,
-          );
+        'grandchild',
+        parentSpan: childOfRemote,
+      );
       expect(grandChild.spanContext.traceState?.get('vendor'), 'value');
       grandChild.end();
       childOfRemote.end();
@@ -534,8 +534,7 @@ void main() {
       OTel.tracerProvider().addSpanProcessor(recorder);
     }
 
-    test('the default sampler is ParentBased with an AlwaysOn root',
-        () async {
+    test('the default sampler is ParentBased with an AlwaysOn root', () async {
       await initWithDefaults();
       final sampler = OTel.tracerProvider().sampler;
       expect(sampler, isA<ParentBasedSampler>());
@@ -559,9 +558,9 @@ void main() {
       test('child of a $kindDesc sampled parent is sampled', () async {
         await initWithDefaults();
         final span = OTel.tracer().startSpan(
-              'child-$kindDesc-sampled',
-              context: parentContextWith(sampled: true, isRemote: isRemote),
-            );
+          'child-$kindDesc-sampled',
+          context: parentContextWith(sampled: true, isRemote: isRemote),
+        );
         expect(span.spanContext.traceFlags.isSampled, isTrue);
         expect(span.isRecording, isTrue);
         span.end();
@@ -571,9 +570,9 @@ void main() {
       test('child of a $kindDesc unsampled parent is dropped', () async {
         await initWithDefaults();
         final span = OTel.tracer().startSpan(
-              'child-$kindDesc-unsampled',
-              context: parentContextWith(sampled: false, isRemote: isRemote),
-            );
+          'child-$kindDesc-unsampled',
+          context: parentContextWith(sampled: false, isRemote: isRemote),
+        );
         expect(span.spanContext.traceFlags.isSampled, isFalse);
         expect(span.isRecording, isFalse);
         span.end();
@@ -599,8 +598,7 @@ void main() {
       expect(exporter.spans, isEmpty);
     });
 
-    test('createSpan notifies processors and exports sampled spans',
-        () async {
+    test('createSpan notifies processors and exports sampled spans', () async {
       await initWith();
       final span = OTel.tracer().createSpan(name: 'created-sampled');
 
@@ -638,9 +636,9 @@ void main() {
         spanId: OTel.spanIdFrom('0011223344556677'),
       );
       final span = OTel.tracer().createSpan(
-            name: 'created-explicit',
-            spanContext: explicit,
-          );
+        name: 'created-explicit',
+        spanContext: explicit,
+      );
 
       expect(span.spanContext.traceId, equals(explicit.traceId));
       expect(span.spanContext.spanId, equals(explicit.spanId));

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -248,6 +248,18 @@ void main() {
       expect(exporter.spans, isEmpty);
     });
 
+    test('reaction table row (false, true) is unreachable', () async {
+      // The spec marks IsRecording==false with Sampled==true "Not
+      // allowed"; the sweep below plus the dedicated tests above pin it.
+      await initWith(sampler: const AlwaysOffSampler());
+      final span = OTel.tracer().startSpan('unreachable-row');
+      expect(
+        !span.isRecording && span.spanContext.traceFlags.isSampled,
+        isFalse,
+      );
+      span.end();
+    });
+
     test('no default path produces the forbidden combination', () async {
       for (final decision in SamplingDecision.values) {
         await initWith(sampler: FixedDecisionSampler(decision));
@@ -264,6 +276,105 @@ void main() {
           span.end();
         }
       }
+    });
+  });
+
+  group('recording/sampled reaction table (#122)', () {
+    // Trace SDK spec, Sampling:
+    // | IsRecording | Sampled | Processor receives? | Exporter receives? |
+    // | true        | true    | true                | true               |
+    // | true        | false   | true                | false              |
+    // | false       | true    | Not allowed         | Not allowed        |
+    // | false       | false   | false               | false              |
+
+    test('RECORD_AND_SAMPLE: processors and exporters receive the span',
+        () async {
+      await initWith(
+        sampler: FixedDecisionSampler(SamplingDecision.recordAndSample),
+      );
+      final span = OTel.tracer().startSpan('row-true-true');
+      span.end();
+      await OTel.tracerProvider().forceFlush();
+
+      expect(recorder.started, hasLength(1));
+      expect(recorder.ended, hasLength(1));
+      expect(exporter.spans.map((s) => s.name), contains('row-true-true'));
+    });
+
+    test('RECORD_ONLY: processors receive the span, exporters do not',
+        () async {
+      await initWith(
+        sampler: FixedDecisionSampler(SamplingDecision.recordOnly),
+      );
+      final span = OTel.tracer().startSpan('row-true-false');
+      expect(span.isRecording, isTrue);
+      expect(span.spanContext.traceFlags.isSampled, isFalse);
+      span.end();
+      await OTel.tracerProvider().forceFlush();
+
+      expect(recorder.started, hasLength(1));
+      expect(recorder.ended, hasLength(1));
+      expect(exporter.spans, isEmpty,
+          reason: 'exporters SHOULD NOT receive unsampled spans');
+    });
+
+    test('DROP: neither processors nor exporters receive the span', () async {
+      await initWith(sampler: FixedDecisionSampler(SamplingDecision.drop));
+      final span = OTel.tracer().startSpan('row-false-false');
+      span.end();
+      await OTel.tracerProvider().forceFlush();
+
+      expect(recorder.started, isEmpty);
+      expect(recorder.ended, isEmpty);
+      expect(exporter.spans, isEmpty);
+    });
+
+    test('BatchSpanProcessor also gates unsampled spans off the exporter',
+        () async {
+      await OTel.reset();
+      final batchExporter = InMemorySpanExporter();
+      await OTel.initialize(
+        serviceName: 'sampling-pipeline-test',
+        spanProcessor: BatchSpanProcessor(
+          batchExporter,
+          const BatchSpanProcessorConfig(
+            scheduleDelay: Duration(milliseconds: 20),
+          ),
+        ),
+        sampler: FixedDecisionSampler(SamplingDecision.recordOnly),
+        enableMetrics: false,
+        enableLogs: false,
+      );
+
+      OTel.tracer().startSpan('batch-unsampled').end();
+      await OTel.tracerProvider().forceFlush();
+      expect(batchExporter.spans, isEmpty);
+
+      // Sanity check: a sampled span does flow through the same pipeline.
+      OTel.tracerProvider().sampler =
+          FixedDecisionSampler(SamplingDecision.recordAndSample);
+      OTel.tracer().startSpan('batch-sampled').end();
+      await OTel.tracerProvider().forceFlush();
+      expect(batchExporter.spans.map((s) => s.name), contains('batch-sampled'));
+    });
+
+    test('onStart receives the resolved parent context, never null', () async {
+      await initWith();
+      final parentContext = parentContextWith(sampled: true);
+      final span = OTel.tracer().startSpan('ctx-check', context: parentContext);
+      expect(recorder.startContexts, hasLength(1));
+      expect(recorder.startContexts.single, isNotNull);
+      expect(
+        recorder.startContexts.single!.spanContext,
+        equals(parentContext.spanContext),
+      );
+      span.end();
+
+      // With no explicit context the resolved Context.current is passed.
+      recorder.startContexts.clear();
+      final rootSpan = OTel.tracer().startSpan('ctx-check-root');
+      expect(recorder.startContexts.single, isNotNull);
+      rootSpan.end();
     });
   });
 }

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -377,4 +377,39 @@ void main() {
       rootSpan.end();
     });
   });
+
+  group('TraceState inheritance (#124)', () {
+    test('child spans inherit the parent TraceState', () async {
+      await initWith();
+      final traceState = OTel.traceState({'vendor': 'value', 'ot': 'th:0'});
+
+      // Remote parent (e.g. extracted from W3C headers).
+      final remoteCtx = parentContextWith(
+        sampled: true,
+        isRemote: true,
+        traceState: traceState,
+      );
+      final childOfRemote =
+          OTel.tracer().startSpan('child-of-remote', context: remoteCtx);
+      expect(childOfRemote.spanContext.traceState?.get('vendor'), 'value');
+      expect(childOfRemote.spanContext.traceState?.get('ot'), 'th:0');
+
+      // Local parent: the child of childOfRemote inherits transitively.
+      final grandChild = OTel.tracer().startSpan(
+            'grandchild',
+            parentSpan: childOfRemote,
+          );
+      expect(grandChild.spanContext.traceState?.get('vendor'), 'value');
+      grandChild.end();
+      childOfRemote.end();
+    });
+
+    test('span without a parent has no inherited TraceState', () async {
+      await initWith();
+      final root = OTel.tracer().startSpan('root');
+      expect(root.spanContext.traceState?.entries ?? const <String, String>{},
+          isEmpty);
+      root.end();
+    });
+  });
 }

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -582,4 +582,72 @@ void main() {
       });
     }
   });
+
+  group('createSpan goes through the sampling pipeline (#129)', () {
+    test('createSpan queries the sampler - a DROP span is inert', () async {
+      await initWith(sampler: const AlwaysOffSampler());
+      final span = OTel.tracer().createSpan(name: 'created-dropped');
+
+      expect(span.isRecording, isFalse);
+      expect(span.spanContext.traceFlags.isSampled, isFalse);
+      span.setStringAttribute<String>('key', 'value');
+      expect(span.attributes.toList(), isEmpty);
+
+      span.end();
+      expect(recorder.started, isEmpty);
+      expect(recorder.ended, isEmpty);
+      expect(exporter.spans, isEmpty);
+    });
+
+    test('createSpan notifies processors and exports sampled spans',
+        () async {
+      await initWith();
+      final span = OTel.tracer().createSpan(name: 'created-sampled');
+
+      expect(span.isRecording, isTrue);
+      expect(span.spanContext.traceFlags.isSampled, isTrue);
+      expect(recorder.started, hasLength(1),
+          reason: 'processors must see createSpan spans start');
+
+      span.end();
+      await OTel.tracerProvider().forceFlush();
+      expect(recorder.ended, hasLength(1));
+      expect(exporter.spans.map((s) => s.name), contains('created-sampled'));
+    });
+
+    test('createSpan RECORD_ONLY reaches processors but not exporters',
+        () async {
+      await initWith(
+        sampler: FixedDecisionSampler(SamplingDecision.recordOnly),
+      );
+      final span = OTel.tracer().createSpan(name: 'created-record-only');
+      expect(span.isRecording, isTrue);
+      expect(span.spanContext.traceFlags.isSampled, isFalse);
+      span.end();
+      await OTel.tracerProvider().forceFlush();
+
+      expect(recorder.started, hasLength(1));
+      expect(recorder.ended, hasLength(1));
+      expect(exporter.spans, isEmpty);
+    });
+
+    test('an explicit spanContext is honored verbatim', () async {
+      await initWith();
+      final explicit = OTel.spanContext(
+        traceId: OTel.traceIdFrom('00112233445566778899aabbccddeeff'),
+        spanId: OTel.spanIdFrom('0011223344556677'),
+      );
+      final span = OTel.tracer().createSpan(
+            name: 'created-explicit',
+            spanContext: explicit,
+          );
+
+      expect(span.spanContext.traceId, equals(explicit.traceId));
+      expect(span.spanContext.spanId, equals(explicit.spanId));
+      // The sampler still ran and the processors saw the span.
+      expect(span.isRecording, isTrue);
+      expect(recorder.started, hasLength(1));
+      span.end();
+    });
+  });
 }

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -153,4 +153,63 @@ void main() {
       });
     }
   });
+
+  group('DROP decision (#120)', () {
+    setUp(() async {
+      await initWith(sampler: const AlwaysOffSampler());
+    });
+
+    test('creates a non-recording span', () {
+      final span = OTel.tracer().startSpan('dropped');
+      expect(span.isRecording, isFalse);
+      expect(span.spanContext.traceFlags.isSampled, isFalse);
+      span.end();
+    });
+
+    test('every mutation is a no-op', () {
+      final span = OTel.tracer().startSpan('dropped');
+      span.setStringAttribute<String>('string.key', 'value');
+      span.setBoolAttribute('bool.key', true);
+      span.setIntAttribute('int.key', 7);
+      span.setDoubleAttribute('double.key', 1.5);
+      span.addAttributes(OTel.attributesFromMap({'more.key': 'v'}));
+      span.attributes = OTel.attributesFromMap({'replaced.key': 'v'});
+      span.addEventNow('event-1');
+      span.addEvents({'event-2': null});
+      span.recordException(Exception('boom'));
+      span.setStatus(SpanStatusCode.Error, 'failed');
+      span.updateName('renamed');
+      span.addSpanLink(
+        OTel.spanLink(
+          OTel.spanContext(traceId: OTel.traceId(), spanId: OTel.spanId()),
+        ),
+      );
+
+      expect(span.attributes.toList(), isEmpty);
+      expect(span.spanEvents ?? const <SpanEvent>[], isEmpty);
+      expect(span.spanLinks ?? const <SpanLink>[], isEmpty);
+      expect(span.name, equals('dropped'));
+      expect(span.status, isNot(equals(SpanStatusCode.Error)));
+      span.end();
+    });
+
+    test('processors never see the span and nothing is exported', () async {
+      final span = OTel.tracer().startSpan('dropped');
+      span.end();
+      await OTel.tracerProvider().forceFlush();
+
+      expect(recorder.started, isEmpty);
+      expect(recorder.ended, isEmpty);
+      expect(recorder.nameUpdates, isEmpty);
+      expect(exporter.spans, isEmpty);
+    });
+
+    test('isRecording: true cannot resurrect a dropped span', () {
+      final span = OTel.tracer().startSpan('dropped', isRecording: true);
+      expect(span.isRecording, isFalse);
+      span.end();
+      expect(recorder.started, isEmpty);
+      expect(recorder.ended, isEmpty);
+    });
+  });
 }

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -518,4 +518,68 @@ void main() {
       span.end();
     });
   });
+
+  group('default sampler is ParentBased(root=AlwaysOn) (#126)', () {
+    /// Initializes without a sampler argument so the SDK default applies.
+    Future<void> initWithDefaults() async {
+      await OTel.reset();
+      exporter = InMemorySpanExporter();
+      recorder = RecordingSpanProcessor();
+      await OTel.initialize(
+        serviceName: 'sampling-pipeline-test',
+        spanProcessor: SimpleSpanProcessor(exporter),
+        enableMetrics: false,
+        enableLogs: false,
+      );
+      OTel.tracerProvider().addSpanProcessor(recorder);
+    }
+
+    test('the default sampler is ParentBased with an AlwaysOn root',
+        () async {
+      await initWithDefaults();
+      final sampler = OTel.tracerProvider().sampler;
+      expect(sampler, isA<ParentBasedSampler>());
+      expect(sampler!.description, 'ParentBased{root=AlwaysOnSampler}');
+    });
+
+    test('root spans are sampled', () async {
+      await initWithDefaults();
+      final span = OTel.tracer().startSpan('root');
+      expect(span.spanContext.traceFlags.isSampled, isTrue);
+      expect(span.isRecording, isTrue);
+      span.end();
+      expect(exporter.spans.map((s) => s.name), contains('root'));
+    });
+
+    // The ParentBased decision table, end to end through startSpan:
+    // remote/local x sampled/unsampled.
+    for (final isRemote in [true, false]) {
+      final kindDesc = isRemote ? 'remote' : 'local';
+
+      test('child of a $kindDesc sampled parent is sampled', () async {
+        await initWithDefaults();
+        final span = OTel.tracer().startSpan(
+              'child-$kindDesc-sampled',
+              context: parentContextWith(sampled: true, isRemote: isRemote),
+            );
+        expect(span.spanContext.traceFlags.isSampled, isTrue);
+        expect(span.isRecording, isTrue);
+        span.end();
+        expect(exporter.spans, hasLength(1));
+      });
+
+      test('child of a $kindDesc unsampled parent is dropped', () async {
+        await initWithDefaults();
+        final span = OTel.tracer().startSpan(
+              'child-$kindDesc-unsampled',
+              context: parentContextWith(sampled: false, isRemote: isRemote),
+            );
+        expect(span.spanContext.traceFlags.isSampled, isFalse);
+        expect(span.isRecording, isFalse);
+        span.end();
+        expect(recorder.started, isEmpty);
+        expect(exporter.spans, isEmpty);
+      });
+    }
+  });
 }

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -212,4 +212,58 @@ void main() {
       expect(recorder.ended, isEmpty);
     });
   });
+
+  group('Sampled=true with IsRecording=false is forbidden (#123)', () {
+    test('forced non-recording span clears Sampled (sampler path)', () async {
+      await initWith(
+        sampler: FixedDecisionSampler(SamplingDecision.recordAndSample),
+      );
+      final span = OTel.tracer().startSpan('forced-off', isRecording: false);
+
+      expect(span.isRecording, isFalse);
+      expect(span.spanContext.traceFlags.isSampled, isFalse,
+          reason: 'The SDK MUST NOT allow Sampled==true with '
+              'IsRecording==false');
+      span.end();
+      expect(recorder.started, isEmpty);
+      expect(recorder.ended, isEmpty);
+      expect(exporter.spans, isEmpty);
+    });
+
+    test('forced non-recording span clears inherited Sampled (no sampler)',
+        () async {
+      await initWith();
+      // Remove the sampler so trace flags are inherited from the parent.
+      OTel.tracerProvider().sampler = null;
+
+      final span = OTel.tracer().startSpan(
+            'forced-off',
+            context: parentContextWith(sampled: true),
+            isRecording: false,
+          );
+
+      expect(span.isRecording, isFalse);
+      expect(span.spanContext.traceFlags.isSampled, isFalse);
+      span.end();
+      expect(exporter.spans, isEmpty);
+    });
+
+    test('no default path produces the forbidden combination', () async {
+      for (final decision in SamplingDecision.values) {
+        await initWith(sampler: FixedDecisionSampler(decision));
+        for (final forced in <bool?>[null, true, false]) {
+          final span = OTel.tracer().startSpan(
+                'combination-check',
+                isRecording: forced,
+              );
+          final forbidden =
+              span.spanContext.traceFlags.isSampled && !span.isRecording;
+          expect(forbidden, isFalse,
+              reason: 'decision=$decision isRecording=$forced produced '
+                  'Sampled==true with IsRecording==false');
+          span.end();
+        }
+      }
+    });
+  });
 }

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -1,0 +1,156 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the sampling decision pipeline, per the OpenTelemetry Trace SDK
+// spec v1.60.0 (Sampling / ShouldSample / SDK Span creation):
+// - each SamplingDecision maps to its own (IsRecording, Sampled) pair
+// - the recording/sampled reaction table for processors and exporters
+// - TraceState inheritance and SamplingResult.traceState propagation
+// - the ParentBased decision table and the default sampler
+// - createSpan routing through the sampler + processor pipeline
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+import '../../../testing_utils/in_memory_span_exporter.dart';
+
+/// A sampler that always returns a fixed decision (optionally with a fixed
+/// TraceState or attributes).
+class FixedDecisionSampler implements Sampler {
+  final SamplingDecision decision;
+
+  FixedDecisionSampler(this.decision);
+
+  @override
+  String get description => 'FixedDecisionSampler{$decision}';
+
+  @override
+  SamplingResult shouldSample({
+    required Context parentContext,
+    required String traceId,
+    required String name,
+    required SpanKind spanKind,
+    required Attributes? attributes,
+    required List<SpanLink>? links,
+  }) {
+    return SamplingResult(
+      decision: decision,
+      source: SamplingDecisionSource.tracerConfig,
+    );
+  }
+}
+
+/// A span processor that records every notification it receives.
+class RecordingSpanProcessor implements SpanProcessor {
+  final List<Span> started = [];
+  final List<Context?> startContexts = [];
+  final List<Span> ended = [];
+  final List<String> nameUpdates = [];
+
+  @override
+  Future<void> onStart(Span span, Context? parentContext) async {
+    started.add(span);
+    startContexts.add(parentContext);
+  }
+
+  @override
+  Future<void> onEnd(Span span) async {
+    ended.add(span);
+  }
+
+  @override
+  Future<void> onNameUpdate(Span span, String newName) async {
+    nameUpdates.add(newName);
+  }
+
+  @override
+  Future<void> forceFlush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}
+
+late InMemorySpanExporter exporter;
+late RecordingSpanProcessor recorder;
+
+/// Resets OTel and initializes it with [sampler], a SimpleSpanProcessor
+/// backed by an in-memory exporter, and a recording processor spy.
+Future<void> initWith({Sampler? sampler}) async {
+  await OTel.reset();
+  exporter = InMemorySpanExporter();
+  recorder = RecordingSpanProcessor();
+  await OTel.initialize(
+    serviceName: 'sampling-pipeline-test',
+    spanProcessor: SimpleSpanProcessor(exporter),
+    sampler: sampler ?? ParentBasedSampler(const AlwaysOnSampler()),
+    enableMetrics: false,
+    enableLogs: false,
+  );
+  OTel.tracerProvider().addSpanProcessor(recorder);
+}
+
+/// Builds a Context carrying a parent SpanContext with the given flags.
+Context parentContextWith({
+  required bool sampled,
+  bool isRemote = false,
+  TraceState? traceState,
+}) {
+  final spanContext = OTel.spanContext(
+    traceId: OTel.traceId(),
+    spanId: OTel.spanId(),
+    traceFlags: OTel.traceFlags(
+      sampled ? TraceFlags.SAMPLED_FLAG : TraceFlags.NONE_FLAG,
+    ),
+    traceState: traceState,
+    isRemote: isRemote,
+  );
+  return OTel.context().withSpanContext(spanContext);
+}
+
+void main() {
+  tearDownAll(() async {
+    await OTel.reset();
+  });
+
+  group('SamplingDecision to Sampled flag mapping (#121)', () {
+    for (final parentSampled in [true, false]) {
+      final parentDesc = parentSampled ? 'sampled' : 'unsampled';
+
+      test('DROP does not set Sampled ($parentDesc parent)', () async {
+        await initWith(sampler: FixedDecisionSampler(SamplingDecision.drop));
+        final span = OTel.tracer().startSpan(
+              'drop-span',
+              context: parentContextWith(sampled: parentSampled),
+            );
+        expect(span.spanContext.traceFlags.isSampled, isFalse);
+        span.end();
+      });
+
+      test('RECORD_ONLY does not set Sampled ($parentDesc parent)', () async {
+        await initWith(
+          sampler: FixedDecisionSampler(SamplingDecision.recordOnly),
+        );
+        final span = OTel.tracer().startSpan(
+              'record-only-span',
+              context: parentContextWith(sampled: parentSampled),
+            );
+        expect(span.spanContext.traceFlags.isSampled, isFalse);
+        expect(span.isRecording, isTrue);
+        span.end();
+      });
+
+      test('RECORD_AND_SAMPLE sets Sampled ($parentDesc parent)', () async {
+        await initWith(
+          sampler: FixedDecisionSampler(SamplingDecision.recordAndSample),
+        );
+        final span = OTel.tracer().startSpan(
+              'sampled-span',
+              context: parentContextWith(sampled: parentSampled),
+            );
+        expect(span.spanContext.traceFlags.isSampled, isTrue);
+        expect(span.isRecording, isTrue);
+        span.end();
+      });
+    }
+  });
+}

--- a/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
+++ b/test/unit/trace/sampling/sampling_decision_pipeline_test.dart
@@ -15,7 +15,7 @@ import 'package:test/test.dart';
 import '../../../testing_utils/in_memory_span_exporter.dart';
 
 /// A sampler that always returns a fixed decision (optionally with a fixed
-/// TraceState or attributes).
+/// TraceState).
 class FixedDecisionSampler implements Sampler {
   final SamplingDecision decision;
 
@@ -36,6 +36,35 @@ class FixedDecisionSampler implements Sampler {
     return SamplingResult(
       decision: decision,
       source: SamplingDecisionSource.tracerConfig,
+    );
+  }
+}
+
+/// A spec-conformant custom sampler that rewrites the TraceState, in the
+/// style of a consistent-probability sampler writing `ot=th:...`.
+class TraceStateWritingSampler implements Sampler {
+  /// When null, returns an empty TraceState (which clears the span's).
+  final Map<String, String> Function(TraceState? parent)? rewrite;
+
+  TraceStateWritingSampler({this.rewrite});
+
+  @override
+  String get description => 'TraceStateWritingSampler';
+
+  @override
+  SamplingResult shouldSample({
+    required Context parentContext,
+    required String traceId,
+    required String name,
+    required SpanKind spanKind,
+    required Attributes? attributes,
+    required List<SpanLink>? links,
+  }) {
+    final parent = parentContext.spanContext?.traceState;
+    return SamplingResult(
+      decision: SamplingDecision.recordAndSample,
+      source: SamplingDecisionSource.tracerConfig,
+      traceState: OTel.traceState(rewrite?.call(parent) ?? const {}),
     );
   }
 }
@@ -410,6 +439,83 @@ void main() {
       expect(root.spanContext.traceState?.entries ?? const <String, String>{},
           isEmpty);
       root.end();
+    });
+  });
+
+  group('SamplingResult.traceState (#125)', () {
+    test('built-in samplers return the passed-in TraceState unchanged', () {
+      final parentTraceState = OTel.traceState({'vendor': 'value'});
+      final parentContext =
+          parentContextWith(sampled: true, traceState: parentTraceState);
+
+      final samplers = <Sampler>[
+        const AlwaysOnSampler(),
+        const AlwaysOffSampler(),
+        ParentBasedSampler(const AlwaysOnSampler()),
+        TraceIdRatioSampler(1.0),
+        ProbabilitySampler(1.0),
+        CountingSampler(1),
+        const CompositeSampler.and([AlwaysOnSampler()]),
+      ];
+      for (final sampler in samplers) {
+        final result = sampler.shouldSample(
+          parentContext: parentContext,
+          traceId: OTel.traceId().toString(),
+          name: 'span',
+          spanKind: SpanKind.internal,
+          attributes: null,
+          links: null,
+        );
+        expect(result.traceState?.get('vendor'), 'value',
+            reason: '${sampler.description} must return the passed-in '
+                'TraceState');
+      }
+    });
+
+    test('the sampler-returned TraceState lands on the new SpanContext',
+        () async {
+      await initWith(
+        sampler: TraceStateWritingSampler(
+          rewrite: (parent) => {...?parent?.entries, 'ot': 'th:8'},
+        ),
+      );
+      final parentCtx = parentContextWith(
+        sampled: true,
+        traceState: OTel.traceState({'vendor': 'value'}),
+      );
+      final span = OTel.tracer().startSpan('rewritten', context: parentCtx);
+
+      expect(span.spanContext.traceState?.get('ot'), 'th:8');
+      expect(span.spanContext.traceState?.get('vendor'), 'value');
+      span.end();
+    });
+
+    test('an empty returned TraceState clears the inherited one', () async {
+      await initWith(sampler: TraceStateWritingSampler());
+      final parentCtx = parentContextWith(
+        sampled: true,
+        traceState: OTel.traceState({'vendor': 'value'}),
+      );
+      final span = OTel.tracer().startSpan('cleared', context: parentCtx);
+
+      expect(span.spanContext.traceState?.entries ?? const <String, String>{},
+          isEmpty);
+      span.end();
+    });
+
+    test('a null traceState (legacy sampler) keeps parent inheritance',
+        () async {
+      await initWith(
+        sampler: FixedDecisionSampler(SamplingDecision.recordAndSample),
+      );
+      final parentCtx = parentContextWith(
+        sampled: true,
+        traceState: OTel.traceState({'vendor': 'value'}),
+      );
+      final span = OTel.tracer().startSpan('inherited', context: parentCtx);
+
+      expect(span.spanContext.traceState?.get('vendor'), 'value');
+      span.end();
     });
   });
 }


### PR DESCRIPTION
## Summary

First set from the spec-compliance worklist (#256): the trace **sampling P0 block**. The SDK now honors sampler decisions end to end per [trace/sdk.md — Sampling](https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampling).

One behavior-neutral refactor threads the `SamplingDecision` through span creation, then one commit per issue:

- **#120** — a `Drop` decision produces a non-recording span: mutators no-op, processors are never notified, nothing exports.
- **#121** — `RecordOnly` records without setting the W3C `Sampled` flag.
- **#122** — built-in processors implement the spec reaction table: `onStart`/`onEnd` receive only recording spans; Simple/Batch processors pass only Sampled spans to exporters. `onStart` now receives the parent `Context` the SDK determined (the resolved `effectiveContext`, never the raw nullable argument) — this also resolves #243.
- **#123** — the forbidden `Sampled=true` + `IsRecording=false` combination is unrepresentable; forcing `isRecording: false` clears the Sampled flag.
- **#124** — child spans inherit the parent `TraceState`.
- **#125** — `SamplingResult` gains a `traceState` field so samplers can modify or replace it (`null` = keep inherited; explicitly empty = clear). `shouldSample`'s signature is unchanged, so existing custom samplers keep working.
- **#126** — the default sampler is now `ParentBased(root: AlwaysOn)` per the spec default, replacing bare `AlwaysOn`.
- **#129** — `createSpan` routes through the sampler and span processors instead of bypassing the pipeline; an explicit `spanContext` is used verbatim while still honoring the recording decision.

## Breaking / behavioral changes

- Unsampled and dropped spans no longer reach exporters; dropped spans no longer reach processors (previously everything exported regardless of the sampler).
- Default sampler change (`AlwaysOn` → `ParentBased(root: AlwaysOn)`): children of unsampled parents now respect the parent decision. `sampler: const AlwaysOnSampler()` restores the old behavior.
- `startSpan(isRecording:)` redefined: default `null` lets the sampler decide; `false` downgrades and clears Sampled; `true` cannot resurrect a `Drop`.

CHANGELOG entries included.

## Testing

- New `sampling_decision_pipeline_test.dart` covers the full reaction table (36 tests), plus TraceState inheritance/override, the ParentBased decision table (remote/local × sampled/unsampled), and the `createSpan` pipeline.
- Full `test/unit` suite green on this branch; `dart analyze` clean.

## Notes for reviewers

- Commit-per-issue for reviewability; the first commit is a behavior-neutral refactor.
- Sampler `Decision`/`TraceState` behavior cross-checked against opentelemetry-java and -go.

Fixes #120, fixes #121, fixes #122, fixes #123, fixes #124, fixes #125, fixes #126, fixes #129. Closes #243.

> Maintainer-reviewed AI-assisted change: implementation drafted with Claude, reviewed, tested, and submitted under maintainer ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
