### PR TITLE
fix(#262): OtlpHttpMetricExporter never registered its pending exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`OtlpHttpMetricExporter.forceFlush()` and `shutdown()` no longer return
-  while an export is still in flight.** The exporter kept a `_pendingExports`
-  list and both methods drained it, but `export()` never added to it, so the
-  list was always empty and both returned immediately.
-
-  `shutdown()` then closed the HTTP client underneath the live request, so an
-  export that was about to succeed died as a `ClientException` and was
-  reported as failed. The exporter's own retry loop documents the opposite
-  intent — "Allow the export to continue even during shutdown, so we complete
-  in-flight requests" — which was unreachable. The span and log-record HTTP
-  exporters already registered their exports; the metric exporter now matches.
-
-  Behaviour change: a metric export in flight when `shutdown()` is called is
-  now awaited and can succeed, where previously it was severed and reported
-  as a failure.
+- **`OtlpHttpMetricExporter.forceFlush()` and `shutdown()` now await
+  in-flight exports** (#262). Both returned immediately, and `shutdown()`
+  closed the HTTP client under the live request — failing an export that
+  was about to succeed. Now matches the span and log HTTP exporters.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.14-wip]
 
+### Fixed
+
+- **`OtlpHttpMetricExporter.forceFlush()` and `shutdown()` no longer return
+  while an export is still in flight.** The exporter kept a `_pendingExports`
+  list and both methods drained it, but `export()` never added to it, so the
+  list was always empty and both returned immediately.
+
+  `shutdown()` then closed the HTTP client underneath the live request, so an
+  export that was about to succeed died as a `ClientException` and was
+  reported as failed. The exporter's own retry loop documents the opposite
+  intent — "Allow the export to continue even during shutdown, so we complete
+  in-flight requests" — which was unreachable. The span and log-record HTTP
+  exporters already registered their exports; the metric exporter now matches.
+
+  Behaviour change: a metric export in flight when `shutdown()` is called is
+  now awaited and can succeed, where previously it was severed and reported
+  as a failure.
+
 ### Changed
 
 - **BREAKING**: `OTelEnv` configuration functions (`getOtlpConfig`, `getBspConfig`, `getServiceConfig`, `getLogRecordLimits`, etc.) now return strongly-typed Dart Records instead of `Map<String, dynamic>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.14-wip]
 
-### Fixed
-
-- **`OtlpHttpMetricExporter.forceFlush()` and `shutdown()` now await
-  in-flight exports** (#262). Both returned immediately, and `shutdown()`
-  closed the HTTP client under the live request — failing an export that
-  was about to succeed. Now matches the span and log HTTP exporters.
-
 ### Changed
 
 - **BREAKING**: `OTelEnv` configuration functions (`getOtlpConfig`, `getBspConfig`, `getServiceConfig`, `getLogRecordLimits`, etc.) now return strongly-typed Dart Records instead of `Map<String, dynamic>`.
@@ -38,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4318 (#220).
 
 ### Fixed
+
+- **`OtlpHttpMetricExporter.forceFlush()` and `shutdown()` now await
+  in-flight exports** (#262). Both returned immediately, and `shutdown()`
+  closed the HTTP client under the live request — failing an export that
+  was about to succeed. Now matches the span and log HTTP exporters.
 
 - `Tracer.enabled` now returns `false` when `TracerProvider` has no span
   processor(s) registered, per the Trace SDK spec, sparing span-creation cost

--- a/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/http/otlp_http_metric_exporter.dart
@@ -87,8 +87,14 @@ class OtlpHttpMetricExporter implements MetricExporter {
       );
     }
 
+    final exportFuture = _export(metrics);
+
+    // Register before awaiting: forceFlush() and shutdown() both drain
+    // _pendingExports, so an export that is not in the list is invisible to
+    // them and they return while it is still in flight.
+    _pendingExports.add(exportFuture);
     try {
-      final result = await _export(metrics);
+      final result = await exportFuture;
       if (OTelLog.isDebug()) {
         OTelLog.debug('OtlpHttpMetricExporter: Export completed successfully');
       }
@@ -108,6 +114,8 @@ class OtlpHttpMetricExporter implements MetricExporter {
         // Re-throw other errors
         rethrow;
       }
+    } finally {
+      _pendingExports.remove(exportFuture);
     }
   }
 

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
@@ -228,21 +228,29 @@ void main() {
   // Shutdown-during-export paths
   // ---------------------------------------------------------------
   group('shutdown during export', () {
-    test('export catches shutdown-interrupted StateError', () async {
-      // Use a slow server so we can shutdown during export
+    test('shutdown drains an in-flight export rather than severing it',
+        () async {
+      // Use a slow server so shutdown lands while the request is in flight.
       await startServer(delay: const Duration(milliseconds: 200));
       final exp = createExporter();
 
-      // Start export in background
       final exportFuture = exp.export(makeMetrics());
 
-      // Give it a moment to start the HTTP request, then shutdown
       await Future<void>.delayed(const Duration(milliseconds: 50));
       await exp.shutdown();
 
-      // The export should return false (interrupted) not throw
-      final result = await exportFuture;
-      expect(result, isFalse);
+      // The FIRST attempt is deliberately allowed to finish: _export only
+      // honours the shutdown flag on retry attempts, "so we complete
+      // in-flight requests". shutdown() waits for it, so the request reaches
+      // the server and succeeds.
+      //
+      // This asserted isFalse until the exporter began registering exports in
+      // _pendingExports. Before that, shutdown() saw an empty list, returned
+      // immediately and closed the HTTP client underneath the live request,
+      // which failed as a ClientException and retried into the shutdown
+      // check. Losing a delivered export that way was the bug, not the
+      // contract.
+      expect(await exportFuture, isTrue);
     });
 
     test('_export at start detects shutdown', () async {
@@ -282,8 +290,14 @@ void main() {
       () async {
         // When wasShutdownDuringRetry is true and ClientException caught,
         // the export throws a StateError
+        // Every attempt fails, so the outcome cannot depend on whether
+        // shutdown lands before or after a particular retry: either the
+        // shutdown check aborts the retry, or the retries exhaust. Both
+        // return false. With a single 503 the second attempt could succeed
+        // if the machine was loaded enough to delay shutdown past it, which
+        // made this test fail only in full-suite runs.
         await startServer(
-          codes: [503],
+          codes: [503, 503, 503, 503],
           delay: const Duration(milliseconds: 100),
         );
         final exp = OtlpHttpMetricExporter(

--- a/test/unit/trace/export/otlp/http/otlp_http_exporter_lifecycle_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_exporter_lifecycle_test.dart
@@ -8,6 +8,7 @@
 @Timeout(Duration(seconds: 60))
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
@@ -16,20 +17,29 @@ import 'package:test/test.dart';
 void main() {
   late HttpServer server;
   late int port;
-  var slowMillis = 0;
   late List<int> statusCodes;
+
+  // The forceFlush tests need an export to be provably in flight. Gate the
+  // stub server on completers rather than delaying its response and racing a
+  // sleep against it: [requestReceived] fires once the server has the
+  // request, and the response is withheld until [holdResponse] is completed.
+  Completer<void>? requestReceived;
+  Completer<void>? holdResponse;
 
   setUp(() async {
     await OTel.reset();
     OTelLog.logFunction = (_) {};
-    slowMillis = 0;
     statusCodes = [];
+    requestReceived = null;
+    holdResponse = null;
     server = await HttpServer.bind('localhost', 0);
     port = server.port;
     server.listen((request) async {
-      if (slowMillis > 0) {
-        await Future<void>.delayed(Duration(milliseconds: slowMillis));
-      }
+      final received = requestReceived;
+      if (received != null && !received.isCompleted) received.complete();
+      // Retries reuse the same gate; awaiting an already-completed future is
+      // a no-op, so a held response only blocks the first attempt.
+      await holdResponse?.future;
       final code = statusCodes.isNotEmpty ? statusCodes.removeAt(0) : 200;
       request.response.statusCode = code;
       await request.drain<void>();
@@ -45,6 +55,10 @@ void main() {
   });
 
   tearDown(() async {
+    // Release anything still parked in the handler before tearing the server
+    // down, so a failed test cannot leave the listener awaiting forever.
+    final held = holdResponse;
+    if (held != null && !held.isCompleted) held.complete();
     await server.close(force: true);
     await OTel.shutdown();
     await OTel.reset();
@@ -90,13 +104,28 @@ void main() {
     });
 
     test('forceFlush waits for a pending export', () async {
-      slowMillis = 60;
+      final received = requestReceived = Completer<void>();
+      final release = holdResponse = Completer<void>();
       final exporter = OtlpHttpSpanExporter(
         OtlpHttpExporterConfig(endpoint: 'http://localhost:$port'),
       );
       final pending = exporter.export(spans());
-      await Future<void>.delayed(const Duration(milliseconds: 5));
-      await exporter.forceFlush();
+      // The server has the request, so the export is in flight as a fact
+      // rather than as a hope about elapsed time.
+      await received.future;
+      var flushCompleted = false;
+      final flush = exporter.forceFlush().whenComplete(() {
+        flushCompleted = true;
+      });
+      await pumpEventQueue();
+      expect(
+        flushCompleted,
+        isFalse,
+        reason: 'forceFlush must not complete while an export is pending',
+      );
+      release.complete();
+      await flush;
+      expect(flushCompleted, isTrue);
       await pending;
       await exporter.shutdown();
     });
@@ -131,13 +160,28 @@ void main() {
     });
 
     test('forceFlush waits for a pending export', () async {
-      slowMillis = 60;
+      final received = requestReceived = Completer<void>();
+      final release = holdResponse = Completer<void>();
       final exporter = OtlpHttpMetricExporter(
         OtlpHttpMetricExporterConfig(endpoint: 'http://localhost:$port'),
       );
       final pending = exporter.export(metricData());
-      await Future<void>.delayed(const Duration(milliseconds: 5));
-      await exporter.forceFlush();
+      // The server has the request, so the export is in flight as a fact
+      // rather than as a hope about elapsed time.
+      await received.future;
+      var flushCompleted = false;
+      final flush = exporter.forceFlush().whenComplete(() {
+        flushCompleted = true;
+      });
+      await pumpEventQueue();
+      expect(
+        flushCompleted,
+        isFalse,
+        reason: 'forceFlush must not complete while an export is pending',
+      );
+      release.complete();
+      await flush;
+      expect(flushCompleted, isTrue);
       await pending;
       await exporter.shutdown();
     });
@@ -158,7 +202,8 @@ void main() {
 
   group('OtlpHttpLogRecordExporter lifecycle', () {
     test('forceFlush waits for a pending export', () async {
-      slowMillis = 60;
+      final received = requestReceived = Completer<void>();
+      final release = holdResponse = Completer<void>();
       final exporter = OtlpHttpLogRecordExporter(
         OtlpHttpLogRecordExporterConfig(endpoint: 'http://localhost:$port'),
       );
@@ -169,8 +214,22 @@ void main() {
         body: 'pending',
       );
       final pending = exporter.export([record]);
-      await Future<void>.delayed(const Duration(milliseconds: 5));
-      await exporter.forceFlush();
+      // The server has the request, so the export is in flight as a fact
+      // rather than as a hope about elapsed time.
+      await received.future;
+      var flushCompleted = false;
+      final flush = exporter.forceFlush().whenComplete(() {
+        flushCompleted = true;
+      });
+      await pumpEventQueue();
+      expect(
+        flushCompleted,
+        isFalse,
+        reason: 'forceFlush must not complete while an export is pending',
+      );
+      release.complete();
+      await flush;
+      expect(flushCompleted, isTrue);
       await pending;
       await exporter.shutdown();
       await exporter.forceFlush();


### PR DESCRIPTION
Fixes #262.

Started as a flaky test. The flake was real, but it was hiding a bug the test could never have caught.

## The tests asserted nothing

All three `forceFlush waits for a pending export` tests established "an export is in flight" by racing a sleep:

```dart
slowMillis = 60;                 // stub server delays its response
final pending = exporter.export(spans());
await Future<void>.delayed(const Duration(milliseconds: 5));
await exporter.forceFlush();
await pending;
```

On a loaded machine the 5 ms sleep overshoots the 60 ms window — red in a full-suite run, green 3/3 alone. But the deeper problem is that **there is no `expect` in the body**. A `forceFlush` that returned instantly passed exactly as well as one that waited. These tests could only ever fail for unrelated timing, never for the behaviour they are named after.

Gating the stub server on a completer makes in-flight a **fact**: the server signals receipt, the test asserts `forceFlush` has *not* completed, then releases the response.

## With a real assertion, the metric exporter failed immediately

```
Expected: false
  Actual: <true>
forceFlush must not complete while an export is pending
```

`OtlpHttpMetricExporter` declares `_pendingExports` and drains it in **both** `forceFlush()` and `shutdown()` — but `export()` **never added to it**. The list was always empty, so both returned while the request was still open. The span and log-record HTTP exporters register theirs; the metric exporter now does too.

The consequence was worse than an early return. `shutdown()` closed the HTTP client underneath the live request, so an export about to succeed died as a `ClientException` and was reported failed — the exact opposite of what the retry loop documents:

> Allow the export to continue even during shutdown, so we complete in-flight requests

That intent was unreachable.

## Two shutdown tests encoded the accident

Both pass on unmodified `main`, so both failures are consequences of this fix, not pre-existing. Updated, with the reasoning in the test bodies:

- One asserted `isFalse` for an export that shutdown had severed. A delivered export should not be thrown away, so it now asserts `isTrue` and is renamed to say what it checks.
- The other was a second load-dependent flake: with a single `503` the retry could succeed if load delayed shutdown past it. Four `503`s make the outcome timing-independent — abort or exhaust, both `false`.

## ⚠️ Behaviour change

A metric export in flight when `shutdown()` is called is now **awaited and may succeed**, where previously it was severed and reported as a failure. This matches the span and log-record exporters, the OTel contract, and the exporter's own stated intent — but it is a real semantic change and worth a deliberate look before merge.

## Verification

- Full suite green at CI concurrency (`./tool/test.sh --concurrency 4`): **2063 passed, 13 skipped**
- `dart analyze` clean, lib and test
- The three `forceFlush` tests now fail if `forceFlush` stops waiting — verified by the metric exporter failing before the fix

## Note

The lifecycle test is mirrored into a downstream conformance suite, so fixing it there would have been overwritten on the next regeneration. The fix belongs here.