### PR TITLE
fix(#266): gate receipt, not just the response, in the span shutdown test

### DIFF
--- a/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
+++ b/test/unit/trace/export/otlp/http/otlp_http_span_exporter_retry_test.dart
@@ -286,10 +286,16 @@ void main() {
       await server.close(force: true);
 
       final completer = Completer<void>();
+      // The response was already gated on a completer, but nothing gated
+      // RECEIPT — a 50ms sleep stood in for "the server has the request",
+      // and under parallel load that elapses before the request lands, so
+      // shutdown ran against no pending export at all.
+      final received = Completer<void>();
       server = await HttpServer.bind('localhost', 0);
       port = server.port;
       server.listen((request) async {
         requestCount++;
+        if (!received.isCompleted) received.complete();
         await request.drain<void>();
         await completer.future;
         request.response.statusCode = 200;
@@ -304,7 +310,8 @@ void main() {
 
       // Start export
       final exportFuture = exporter.export(spans);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      // The export is in flight as a fact, not as a hope about elapsed time.
+      await received.future;
 
       // Start shutdown while export is pending
       final shutdownFuture = exporter.shutdown();


### PR DESCRIPTION
Fixes #266. Follow-up to #262/#263 — the same defect in a test that *looked* immune to it.

## The half-closed race

`shutdown with pending exports waits then closes` already holds its **response** on a completer, which reads as deterministic. It isn't: nothing gates **receipt**.

```dart
final exportFuture = exporter.export(spans);
await Future<void>.delayed(const Duration(milliseconds: 50));   // stands in for "the server has it"
final shutdownFuture = exporter.shutdown();
```

Under parallel load that 50 ms can elapse before the request reaches the server, so `shutdown()` runs with **no pending export** — and a test named for waiting has nothing to wait for. `expect(requestCount, equals(1))` then fails.

The handler now completes a `received` completer on entry and the test awaits it. Gating the response without gating receipt only closes half the race.

## How it surfaced

The single failure in a full-suite run at CI concurrency while verifying an unrelated branch. It passes 3/3 in isolation, which is exactly why it survived this long — and why `tool/test.sh` pins `--concurrency 4` in the first place ("suites that bind sockets and wait on exports get time-sliced past the 30s per-test timeout and flake"). This sleep was the remaining exposure in that family.

## Verification

- Full suite at CI concurrency: **2107 passed, 13 skipped**
- The affected file 3/3 across repeated isolated runs
- `dart analyze` clean

+8/-1, one test file. No library changes.