### PR TITLE
Refactor `OTel.initialize` environment parsing and trace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0-beta.15-wip]
 
 ### Breaking Changes
-- `OTel.initialize` now correctly applies `OTEL_RESOURCE_ATTRIBUTES` even when `detectPlatformResources` is `false`. Previously, setting `detectPlatformResources: false` completely bypassed the `EnvVarResourceDetector`, leading to spec-mandated environment variables being ignored. The resource merging precedence has also been updated to strictly follow the OpenTelemetry specification (`Platform Resources` -> `OTEL_RESOURCE_ATTRIBUTES` -> `OTEL_SERVICE_NAME` -> `Code Attributes`).
+- `OTel.initialize` now always reads `OTEL_RESOURCE_ATTRIBUTES` directly, restoring spec-mandated environment variables for users who pass `detectPlatformResources: false`. The resource merging precedence has also been updated to strictly follow the OpenTelemetry specification (`Platform Resources` -> `OTEL_RESOURCE_ATTRIBUTES` -> `OTEL_SERVICE_NAME` -> `Code Attributes`).
+- **Spec compliance (#206):** `OTEL_RESOURCE_ATTRIBUTES` values are now parsed strictly as `String`s rather than falling back to `int` or `bool`.
+- Percent-decoding is now applied to `OTEL_RESOURCE_ATTRIBUTES` values.
 - Extracted trace exporter and processor configuration logic into `TracesConfiguration` internal class to align with `MetricsConfiguration` and `LogsConfiguration`.
-
-### Features
 
 ## [1.1.0-beta.14] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.15-wip]
 
+### Breaking Changes
+- `OTel.initialize` now correctly applies `OTEL_RESOURCE_ATTRIBUTES` even when `detectPlatformResources` is `false`. Previously, setting `detectPlatformResources: false` completely bypassed the `EnvVarResourceDetector`, leading to spec-mandated environment variables being ignored. The resource merging precedence has also been updated to strictly follow the OpenTelemetry specification (`Platform Resources` -> `OTEL_RESOURCE_ATTRIBUTES` -> `OTEL_SERVICE_NAME` -> `Code Attributes`).
+- Extracted trace exporter and processor configuration logic into `TracesConfiguration` internal class to align with `MetricsConfiguration` and `LogsConfiguration`.
+
+### Features
+
 ## [1.1.0-beta.14] - 2026-08-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0-beta.15-wip]
 
 ### Breaking Changes
-- `OTel.initialize` now always reads `OTEL_RESOURCE_ATTRIBUTES` directly, restoring spec-mandated environment variables for users who pass `detectPlatformResources: false`. The resource merging precedence has also been updated to strictly follow the OpenTelemetry specification (`Platform Resources` -> `OTEL_RESOURCE_ATTRIBUTES` -> `OTEL_SERVICE_NAME` -> `Code Attributes`).
 - **Spec compliance (#206):** `OTEL_RESOURCE_ATTRIBUTES` values are now parsed strictly as `String`s rather than falling back to `int` or `bool`.
 - Percent-decoding is now applied to `OTEL_RESOURCE_ATTRIBUTES` values.
 - Extracted trace exporter and processor configuration logic into `TracesConfiguration` internal class to align with `MetricsConfiguration` and `LogsConfiguration`.

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -78,6 +78,7 @@ export 'src/trace/export/otlp/otlp_grpc_span_exporter_config.dart';
 export 'src/trace/export/otlp/span_transformer.dart';
 export 'src/trace/export/simple_span_processor.dart';
 export 'src/trace/export/span_exporter.dart';
+export 'src/trace/export/traces_config.dart';
 // Only export the implementation files, not the duplicated classes in sampler.dart
 export 'src/trace/sampling/always_off_sampler.dart';
 export 'src/trace/sampling/always_on_sampler.dart';

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -407,6 +407,38 @@ class OTelEnv {
   /// - If `service.name` is in OTEL_RESOURCE_ATTRIBUTES, it's used as the base value
   /// - OTEL_SERVICE_NAME takes precedence over `service.name` in OTEL_RESOURCE_ATTRIBUTES
   /// - `service.version` comes from OTEL_RESOURCE_ATTRIBUTES only
+  /// Parses a resource attributes string into a map, handling escaping,
+  /// percent-encoding, and dropping malformed entries.
+  static Map<String, String> parseResourceAttributesString(String resourceStr) {
+    final resourceAttrs = <String, String>{};
+    final parts = resourceStr.split(RegExp(r'(?<!\\),'));
+    for (var part in parts) {
+      part = part.trim();
+      final equalIndex = part.indexOf('=');
+      if (equalIndex == -1) continue;
+
+      final key = part.substring(0, equalIndex).trim();
+      var value = part.substring(equalIndex + 1).trim();
+
+      // Handle percent-encoded characters safely
+      try {
+        value = Uri.decodeComponent(value);
+      } catch (e) {
+        if (OTelLog.isWarn()) {
+          OTelLog.warn(
+              'OTelEnv: Dropped malformed resource attribute "$key": $e');
+        }
+        continue; // Drop the malformed attribute per spec
+      }
+
+      // Remove escape characters
+      value = value.replaceAll(r'\,', ',');
+
+      resourceAttrs[key] = value;
+    }
+    return resourceAttrs;
+  }
+
   static ServiceEnvironmentValues getServiceConfig() {
     String? parsedServiceName;
     String? parsedServiceVersion;
@@ -414,27 +446,9 @@ class OTelEnv {
     // First, parse service.name and service.version from OTEL_RESOURCE_ATTRIBUTES
     final resourceStr = _getEnv(otelResourceAttributes);
     if (resourceStr != null) {
-      // Split on commas, but handle escaped commas
-      final parts = resourceStr.split(RegExp(r'(?<!\\),'));
-      for (var part in parts) {
-        part = part.trim();
-        final equalIndex = part.indexOf('=');
-        if (equalIndex == -1) continue;
-
-        final key = part.substring(0, equalIndex).trim();
-        var value = part.substring(equalIndex + 1).trim();
-
-        // Handle percent-encoded characters
-        value = Uri.decodeComponent(value);
-        // Remove escape characters
-        value = value.replaceAll(r'\,', ',');
-
-        if (key == Service.serviceName.key) {
-          parsedServiceName = value;
-        } else if (key == Service.serviceVersion.key) {
-          parsedServiceVersion = value;
-        }
-      }
+      final attrs = parseResourceAttributesString(resourceStr);
+      parsedServiceName = attrs[Service.serviceName.key];
+      parsedServiceVersion = attrs[Service.serviceVersion.key];
     }
 
     // OTEL_SERVICE_NAME takes precedence over service.name from resource attributes
@@ -454,29 +468,11 @@ class OTelEnv {
   /// Parses the OTEL_RESOURCE_ATTRIBUTES environment variable which should be
   /// a comma-separated list of key=value pairs.
   static Map<String, Object> getResourceAttributes() {
-    final resourceAttrs = <String, Object>{};
-
     final resourceStr = _getEnv(otelResourceAttributes);
     if (resourceStr != null) {
-      final parts = resourceStr.split(RegExp(r'(?<!\\),'));
-      for (var part in parts) {
-        part = part.trim();
-        final equalIndex = part.indexOf('=');
-        if (equalIndex == -1) continue;
-
-        final key = part.substring(0, equalIndex).trim();
-        var value = part.substring(equalIndex + 1).trim();
-
-        // Handle percent-encoded characters
-        value = Uri.decodeComponent(value);
-        // Remove escape characters
-        value = value.replaceAll(r'\,', ',');
-
-        resourceAttrs[key] = value;
-      }
+      return parseResourceAttributesString(resourceStr);
     }
-
-    return resourceAttrs;
+    return <String, Object>{};
   }
 
   /// Whether `OTEL_SDK_DISABLED` is set to a truthy value.

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -414,18 +414,25 @@ class OTelEnv {
     // First, parse service.name and service.version from OTEL_RESOURCE_ATTRIBUTES
     final resourceStr = _getEnv(otelResourceAttributes);
     if (resourceStr != null) {
-      final pairs = resourceStr.split(',');
-      for (final pair in pairs) {
-        final equalIndex = pair.indexOf('=');
-        if (equalIndex > 0 && equalIndex < pair.length - 1) {
-          final key = pair.substring(0, equalIndex).trim();
-          final value = pair.substring(equalIndex + 1).trim();
+      // Split on commas, but handle escaped commas
+      final parts = resourceStr.split(RegExp(r'(?<!\\),'));
+      for (var part in parts) {
+        part = part.trim();
+        final equalIndex = part.indexOf('=');
+        if (equalIndex == -1) continue;
 
-          if (key == Service.serviceName.key) {
-            parsedServiceName = value;
-          } else if (key == Service.serviceVersion.key) {
-            parsedServiceVersion = value;
-          }
+        final key = part.substring(0, equalIndex).trim();
+        var value = part.substring(equalIndex + 1).trim();
+
+        // Handle percent-encoded characters
+        value = Uri.decodeComponent(value);
+        // Remove escape characters
+        value = value.replaceAll(r'\,', ',');
+
+        if (key == Service.serviceName.key) {
+          parsedServiceName = value;
+        } else if (key == Service.serviceVersion.key) {
+          parsedServiceVersion = value;
         }
       }
     }
@@ -451,32 +458,21 @@ class OTelEnv {
 
     final resourceStr = _getEnv(otelResourceAttributes);
     if (resourceStr != null) {
-      final pairs = resourceStr.split(',');
-      for (final pair in pairs) {
-        final parts = pair.split('=');
-        if (parts.length == 2) {
-          final key = parts[0].trim();
-          final value = parts[1].trim();
-          // Try to parse as number if possible
-          final intValue = int.tryParse(value);
-          if (intValue != null) {
-            resourceAttrs[key] = intValue;
-          } else {
-            final doubleValue = double.tryParse(value);
-            if (doubleValue != null) {
-              resourceAttrs[key] = doubleValue;
-            } else {
-              // Handle boolean values
-              if (value.toLowerCase() == 'true') {
-                resourceAttrs[key] = true;
-              } else if (value.toLowerCase() == 'false') {
-                resourceAttrs[key] = false;
-              } else {
-                resourceAttrs[key] = value;
-              }
-            }
-          }
-        }
+      final parts = resourceStr.split(RegExp(r'(?<!\\),'));
+      for (var part in parts) {
+        part = part.trim();
+        final equalIndex = part.indexOf('=');
+        if (equalIndex == -1) continue;
+
+        final key = part.substring(0, equalIndex).trim();
+        var value = part.substring(equalIndex + 1).trim();
+
+        // Handle percent-encoded characters
+        value = Uri.decodeComponent(value);
+        // Remove escape characters
+        value = value.replaceAll(r'\,', ',');
+
+        resourceAttrs[key] = value;
       }
     }
 

--- a/lib/src/logs/export/batch_log_record_processor.dart
+++ b/lib/src/logs/export/batch_log_record_processor.dart
@@ -75,8 +75,13 @@ class BatchLogRecordProcessorConfig {
   /// Invalid or out-of-range values emit an [OTelLog.warn] diagnostic and
   /// fall back to the spec default.
   factory BatchLogRecordProcessorConfig.fromEnvironment() {
-    final env = OTelEnv.getBlrpConfig();
+    return BatchLogRecordProcessorConfig.fromBlrpEnvironmentValues(
+        OTelEnv.getBlrpConfig());
+  }
 
+  /// Creates a configuration from pre-read BLRP environment values.
+  factory BatchLogRecordProcessorConfig.fromBlrpEnvironmentValues(
+      BlrpEnvironmentValues env) {
     var queueSize = env.maxQueueSize ?? defaultMaxQueueSize;
     var batchSize = env.maxExportBatchSize ?? defaultMaxExportBatchSize;
 

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -116,7 +116,7 @@ class LogsConfiguration {
 
     if (OTelLog.isDebug()) {
       OTelLog.debug('LogsConfiguration: Configured LoggerProvider with '
-          '${exporters.length} exporter(s) from OTEL_LOGS_EXPORTER');
+          '${createdExporters.length} exporter(s) from OTEL_LOGS_EXPORTER');
     }
 
     return logProvider;

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -42,7 +42,14 @@ class LogsConfiguration {
     LogRecordExporter? logRecordExporter,
     LogRecordProcessor? logRecordProcessor,
     Resource? resource,
+    OtlpEnvironmentValues? otlpConfig,
+    List<String>? exporters,
+    BlrpEnvironmentValues? blrpConfig,
   }) {
+    otlpConfig ??= OTelEnv.getOtlpConfig(signal: 'logs');
+    exporters ??= OTelEnv.getExporters(signal: 'logs') ?? ['otlp'];
+    blrpConfig ??= OTelEnv.getBlrpConfig();
+
     // Get the logger provider
     final logProvider = OTel.loggerProvider();
 
@@ -59,16 +66,14 @@ class LogsConfiguration {
 
     // Explicitly provided exporter wins; otherwise read the env selection.
     if (logRecordExporter != null) {
-      logProvider.addLogRecordProcessor(_createProcessor(logRecordExporter));
+      logProvider.addLogRecordProcessor(
+          _createProcessor(logRecordExporter, blrpConfig));
       return logProvider;
     }
 
-    // Spec "Exporter Selection": OTEL_LOGS_EXPORTER, default otlp; the
-    // comma-separated list form is supported. Known: otlp, console, none.
     // Multiple exporters install one processor per exporter.
-    final requested = OTelEnv.getExporters(signal: 'logs') ?? ['otlp'];
-    if (requested.contains('none')) {
-      if (requested.length > 1 && OTelLog.isWarn()) {
+    if (exporters.contains('none')) {
+      if (exporters.length > 1 && OTelLog.isWarn()) {
         OTelLog.warn("OTEL_LOGS_EXPORTER contains 'none' alongside other "
             'values; installing no processor.');
       } else if (OTelLog.isDebug()) {
@@ -78,8 +83,8 @@ class LogsConfiguration {
       return logProvider;
     }
 
-    final exporters = <LogRecordExporter>[];
-    for (final name in requested) {
+    final createdExporters = <LogRecordExporter>[];
+    for (final name in exporters) {
       if (name == 'logging') {
         if (OTelLog.isWarn()) {
           OTelLog.warn("OTEL_LOGS_EXPORTER value 'logging' is deprecated "
@@ -87,26 +92,26 @@ class LogsConfiguration {
         }
         continue;
       }
-      final created = _createExporter(name, endpoint, secure);
+      final created = _createExporter(name, endpoint, secure, otlpConfig);
       if (created != null) {
-        exporters.add(created);
+        createdExporters.add(created);
       } else if (OTelLog.isWarn()) {
         OTelLog.warn("OTEL_LOGS_EXPORTER value '$name' is not supported; "
             'ignoring. Supported: otlp, console, none.');
       }
     }
-    if (exporters.isEmpty) {
+    if (createdExporters.isEmpty) {
       if (OTelLog.isWarn()) {
         OTelLog.warn('OTEL_LOGS_EXPORTER produced no usable exporter; '
             'falling back to the default otlp exporter.');
       }
-      final fallback = _createExporter('otlp', endpoint, secure);
+      final fallback = _createExporter('otlp', endpoint, secure, otlpConfig);
       if (fallback != null) {
-        exporters.add(fallback);
+        createdExporters.add(fallback);
       }
     }
-    for (final exporter in exporters) {
-      logProvider.addLogRecordProcessor(_createProcessor(exporter));
+    for (final exporter in createdExporters) {
+      logProvider.addLogRecordProcessor(_createProcessor(exporter, blrpConfig));
     }
 
     if (OTelLog.isDebug()) {
@@ -122,9 +127,8 @@ class LogsConfiguration {
     String exporterType,
     String? endpoint,
     bool secure,
+    OtlpEnvironmentValues otlpConfig,
   ) {
-    // Get OTLP config for logs signal
-    final otlpConfig = OTelEnv.getOtlpConfig(signal: 'logs');
     final protocol = otlpConfig.protocol ?? 'http/protobuf';
 
     // Use env endpoint if available, otherwise use provided endpoint. The
@@ -193,8 +197,10 @@ class LogsConfiguration {
   }
 
   /// Creates a log record processor with BLRP configuration from environment.
-  static LogRecordProcessor _createProcessor(LogRecordExporter exporter) {
-    final processorConfig = BatchLogRecordProcessorConfig.fromEnvironment();
+  static LogRecordProcessor _createProcessor(
+      LogRecordExporter exporter, BlrpEnvironmentValues blrpConfig) {
+    final processorConfig =
+        BatchLogRecordProcessorConfig.fromBlrpEnvironmentValues(blrpConfig);
     return BatchLogRecordProcessor(exporter, processorConfig);
   }
 

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -38,7 +38,7 @@ class LogsConfiguration {
   /// @return The configured LoggerProvider
   static LoggerProvider configureLoggerProvider({
     String? endpoint,
-    bool secure = false,
+    bool? secure,
     LogRecordExporter? logRecordExporter,
     LogRecordProcessor? logRecordProcessor,
     Resource? resource,
@@ -126,7 +126,7 @@ class LogsConfiguration {
   static LogRecordExporter? _createExporter(
     String exporterType,
     String? endpoint,
-    bool secure,
+    bool? secure,
     OtlpEnvironmentValues otlpConfig,
   ) {
     final protocol = otlpConfig.protocol ?? 'http/protobuf';
@@ -141,7 +141,7 @@ class LogsConfiguration {
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: envInsecure,
       endpoint: effectiveEndpoint,
-      fallback: secure,
+      explicitSecure: secure,
     );
 
     if (exporterType == 'console') {

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -39,7 +39,12 @@ class MetricsConfiguration {
     MetricExporter? metricExporter,
     MetricReader? metricReader,
     Resource? resource,
+    OtlpEnvironmentValues? otlpConfig,
+    List<String>? exporters,
   }) {
+    otlpConfig ??= OTelEnv.getOtlpConfig(signal: 'metrics');
+    exporters ??= OTelEnv.getExporters(signal: 'metrics') ?? ['otlp'];
+
     final meterProvider = OTel.meterProvider();
     if (resource != null) {
       meterProvider.resource = resource;
@@ -49,11 +54,8 @@ class MetricsConfiguration {
     // explicit exporter/reader — explicit args are an unambiguous opt-in and
     // should not be silently dropped by env config.
     if (metricExporter == null && metricReader == null) {
-      // Spec "Exporter Selection": OTEL_METRICS_EXPORTER, default otlp; the
-      // comma-separated list form is supported. Known: otlp, console, none.
-      final requested = OTelEnv.getExporters(signal: 'metrics') ?? ['otlp'];
-      if (requested.contains('none')) {
-        if (requested.length > 1 && OTelLog.isWarn()) {
+      if (exporters.contains('none')) {
+        if (exporters.length > 1 && OTelLog.isWarn()) {
           OTelLog.warn("OTEL_METRICS_EXPORTER contains 'none' alongside "
               'other values; installing no reader.');
         } else if (OTelLog.isDebug()) {
@@ -62,14 +64,14 @@ class MetricsConfiguration {
         }
         return meterProvider;
       }
-      final exporters = <MetricExporter>[];
-      for (final name in requested) {
+      final createdExporters = <MetricExporter>[];
+      for (final name in exporters) {
         switch (name) {
           case 'otlp':
           case 'console':
-            final created = _createExporter(name, endpoint, secure);
+            final created = _createExporter(name, endpoint, secure, otlpConfig);
             if (created != null) {
-              exporters.add(created);
+              createdExporters.add(created);
             }
           case 'prometheus':
             // Recognized spec value, but not auto-wirable yet: the SDK has
@@ -95,19 +97,20 @@ class MetricsConfiguration {
             }
         }
       }
-      if (exporters.isEmpty) {
+      if (createdExporters.isEmpty) {
         if (OTelLog.isWarn()) {
           OTelLog.warn('OTEL_METRICS_EXPORTER produced no usable exporter; '
               'falling back to the default otlp exporter.');
         }
-        exporters.add(_createExporter('otlp', endpoint, secure)!);
+        createdExporters
+            .add(_createExporter('otlp', endpoint, secure, otlpConfig)!);
       }
-      metricExporter = exporters.length == 1
-          ? exporters.single
-          : CompositeMetricExporter(exporters);
+      metricExporter = createdExporters.length == 1
+          ? createdExporters.single
+          : CompositeMetricExporter(createdExporters);
     }
 
-    metricExporter ??= _createExporter('otlp', endpoint, secure);
+    metricExporter ??= _createExporter('otlp', endpoint, secure, otlpConfig);
     if (metricExporter == null) {
       return meterProvider;
     }
@@ -127,6 +130,7 @@ class MetricsConfiguration {
     String exporterType,
     String? endpoint,
     bool secure,
+    OtlpEnvironmentValues otlpConfig,
   ) {
     if (exporterType == 'console') {
       if (OTelLog.isDebug()) {
@@ -142,7 +146,6 @@ class MetricsConfiguration {
       }
     }
 
-    final otlpConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
     final protocol = otlpConfig.protocol ?? 'http/protobuf';
     // The default endpoint depends on the protocol (issue #220): OTLP/gRPC
     // uses port 4317, the HTTP protocols use port 4318.

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -35,7 +35,7 @@ class MetricsConfiguration {
   /// `OTel.defaultEndpoint` for the HTTP protocols.
   static MeterProvider configureMeterProvider({
     String? endpoint,
-    bool secure = false,
+    bool? secure,
     MetricExporter? metricExporter,
     MetricReader? metricReader,
     Resource? resource,
@@ -129,7 +129,7 @@ class MetricsConfiguration {
   static MetricExporter? _createExporter(
     String exporterType,
     String? endpoint,
-    bool secure,
+    bool? secure,
     OtlpEnvironmentValues otlpConfig,
   ) {
     if (exporterType == 'console') {
@@ -158,7 +158,7 @@ class MetricsConfiguration {
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: otlpConfig.insecure,
       endpoint: effectiveEndpoint,
-      fallback: secure,
+      explicitSecure: secure,
     );
     final headers = otlpConfig.headers ?? const {};
     final timeout = otlpConfig.timeout ?? const Duration(seconds: 10);

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -7,7 +7,6 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../dartastic_opentelemetry.dart';
-import 'trace/traces_configuration.dart';
 
 /// Main entry point for the OpenTelemetry SDK.
 ///
@@ -166,16 +165,57 @@ class OTel {
     // lines that diagnose env configuration.
     initializeLogging();
 
+    final sdkDisabled = OTelEnv.isSdkDisabled();
+    if (sdkDisabled && OTelLog.isDebug()) {
+      OTelLog.debug('OTel: OTEL_SDK_DISABLED=true, skipping all signal setup');
+    }
+
     // Apply environment variables exactly once
     final envServiceConfig = OTelEnv.getServiceConfig();
-    final otlpTracesConfig = OTelEnv.getOtlpConfig(signal: 'traces');
-    final otlpMetricsConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
-    final otlpLogsConfig = OTelEnv.getOtlpConfig(signal: 'logs');
-    final tracesExporters = OTelEnv.getExporters(signal: 'traces') ?? ['otlp'];
-    final metricsExporters =
-        OTelEnv.getExporters(signal: 'metrics') ?? ['otlp'];
-    final logsExporters = OTelEnv.getExporters(signal: 'logs') ?? ['otlp'];
-    final blrpConfig = OTelEnv.getBlrpConfig();
+    const OtlpEnvironmentValues emptyOtlp = (
+      endpoint: null,
+      protocol: null,
+      headers: null,
+      insecure: null,
+      timeout: null,
+      compression: null,
+      certificate: null,
+      clientKey: null,
+      clientCertificate: null
+    );
+    const BlrpEnvironmentValues emptyBlrp = (
+      scheduleDelay: null,
+      exportTimeout: null,
+      maxQueueSize: null,
+      maxExportBatchSize: null
+    );
+    const BspEnvironmentValues emptyBsp = (
+      scheduleDelay: null,
+      exportTimeout: null,
+      maxQueueSize: null,
+      maxExportBatchSize: null
+    );
+
+    final otlpTracesConfig =
+        !sdkDisabled ? OTelEnv.getOtlpConfig(signal: 'traces') : emptyOtlp;
+    final otlpMetricsConfig = enableMetrics && !sdkDisabled
+        ? OTelEnv.getOtlpConfig(signal: 'metrics')
+        : emptyOtlp;
+    final otlpLogsConfig = enableLogs && !sdkDisabled
+        ? OTelEnv.getOtlpConfig(signal: 'logs')
+        : emptyOtlp;
+    final tracesExporters = !sdkDisabled
+        ? (OTelEnv.getExporters(signal: 'traces') ?? ['otlp'])
+        : <String>[];
+    final metricsExporters = enableMetrics && !sdkDisabled
+        ? (OTelEnv.getExporters(signal: 'metrics') ?? ['otlp'])
+        : <String>[];
+    final logsExporters = enableLogs && !sdkDisabled
+        ? (OTelEnv.getExporters(signal: 'logs') ?? ['otlp'])
+        : <String>[];
+    final blrpConfig =
+        enableLogs && !sdkDisabled ? OTelEnv.getBlrpConfig() : emptyBlrp;
+    final bspConfig = !sdkDisabled ? OTelEnv.getBspConfig() : emptyBsp;
 
     final envServiceName =
         serviceName == null ? envServiceConfig.serviceName : null;
@@ -283,7 +323,8 @@ class OTel {
     }
 
     // Always run EnvVarResourceDetector for OTEL_RESOURCE_ATTRIBUTES
-    final envVarResource = await EnvVarResourceDetector().detect();
+    final envVarResource =
+        await CompositeResourceDetector([EnvVarResourceDetector()]).detect();
     mergedResource = mergedResource.merge(envVarResource);
 
     // Apply OTEL_SERVICE_NAME (and VERSION) via service name variables
@@ -311,11 +352,6 @@ class OTel {
       });
     }
 
-    final sdkDisabled = OTelEnv.isSdkDisabled();
-    if (sdkDisabled && OTelLog.isDebug()) {
-      OTelLog.debug('OTel: OTEL_SDK_DISABLED=true, skipping all signal setup');
-    }
-
     if (!sdkDisabled) {
       TracesConfiguration.configureTracerProvider(
         endpoint: endpoint,
@@ -326,7 +362,7 @@ class OTel {
         resource: OTel.defaultResource,
         otlpConfig: otlpTracesConfig,
         exporters: tracesExporters,
-        bspConfig: OTelEnv.getBspConfig(),
+        bspConfig: bspConfig,
       );
     }
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../dartastic_opentelemetry.dart';
+import 'trace/traces_configuration.dart';
 
 /// Main entry point for the OpenTelemetry SDK.
 ///
@@ -165,8 +166,17 @@ class OTel {
     // lines that diagnose env configuration.
     initializeLogging();
 
-    // Apply environment variables only if parameters are not provided
+    // Apply environment variables exactly once
     final envServiceConfig = OTelEnv.getServiceConfig();
+    final otlpTracesConfig = OTelEnv.getOtlpConfig(signal: 'traces');
+    final otlpMetricsConfig = OTelEnv.getOtlpConfig(signal: 'metrics');
+    final otlpLogsConfig = OTelEnv.getOtlpConfig(signal: 'logs');
+    final tracesExporters = OTelEnv.getExporters(signal: 'traces') ?? ['otlp'];
+    final metricsExporters =
+        OTelEnv.getExporters(signal: 'metrics') ?? ['otlp'];
+    final logsExporters = OTelEnv.getExporters(signal: 'logs') ?? ['otlp'];
+    final blrpConfig = OTelEnv.getBlrpConfig();
+
     final envServiceName =
         serviceName == null ? envServiceConfig.serviceName : null;
     final envServiceVersion =
@@ -175,11 +185,8 @@ class OTel {
     serviceName ??= envServiceName;
     serviceVersion ??= envServiceVersion;
 
-    final otlpConfig = (endpoint == null || secure == null)
-        ? OTelEnv.getOtlpConfig(signal: 'traces')
-        : null;
-    final envEndpoint = endpoint == null ? otlpConfig?.endpoint : null;
-    final envInsecure = secure == null ? otlpConfig?.insecure : null;
+    final envEndpoint = endpoint == null ? otlpTracesConfig.endpoint : null;
+    final envInsecure = secure == null ? otlpTracesConfig.insecure : null;
 
     endpoint ??= envEndpoint;
     secure = OTelEnv.resolveOtlpSecure(
@@ -188,14 +195,9 @@ class OTel {
       endpoint: endpoint,
     );
 
-    // Apply defaults if still null. The endpoint stays nullable here and is
-    // resolved per signal after the protocol is known (issue #220): the OTLP
-    // spec default is http://localhost:4317 for gRPC and http://localhost:4318
-    // for the HTTP protocols, so a single 4318 default must not be applied
-    // before the protocol is resolved.
+    // Apply defaults if still null.
     serviceName ??= defaultServiceName;
     serviceVersion ??= '1.0.0';
-    // secure is guaranteed non-null from above
 
     // Log environment variable usage
     if (OTelLog.isDebug()) {
@@ -215,35 +217,6 @@ class OTel {
       }
     }
 
-    // Get otlpConfig for exporter creation later
-    final otlpConfigForExporter = OTelEnv.getOtlpConfig(signal: 'traces');
-
-    // Get resource attributes from environment and merge with provided ones.
-    //
-    // service.name and service.version are deliberately excluded here. They
-    // were already resolved into serviceName/serviceVersion above by
-    // getServiceConfig(), which applies the spec precedence -- OTEL_SERVICE_NAME
-    // outranks service.name in OTEL_RESOURCE_ATTRIBUTES -- and an explicit
-    // argument outranks both. These attributes are merged last, at the highest
-    // precedence, so leaving the service keys in would let
-    // OTEL_RESOURCE_ATTRIBUTES override the resolved values and silently beat
-    // programmatic configuration.
-    final envResourceAttrs =
-        Map<String, Object>.from(OTelEnv.getResourceAttributes())
-          ..remove(Service.serviceName.key)
-          ..remove(Service.serviceVersion.key);
-    if (envResourceAttrs.isNotEmpty) {
-      if (resourceAttributes != null) {
-        // Merge with provided attributes - provided ones take precedence
-        final mergedAttrs = Map<String, Object>.from(envResourceAttrs);
-        resourceAttributes.toList().forEach((attr) {
-          mergedAttrs[attr.key] = attr.value;
-        });
-        resourceAttributes = OTel.attributesFromMap(mergedAttrs);
-      } else {
-        resourceAttributes = OTel.attributesFromMap(envResourceAttrs);
-      }
-    }
     // The API auto-installs its OTelAPIFactory if API-only code runs
     // before the SDK initializes. The SDK must upgrade it to the SDK (per spec).
     final existingFactory = OTelFactory.otelFactory;
@@ -273,11 +246,6 @@ class OTel {
     }
     final factoryFactory =
         oTelFactoryCreationFunction ?? otelSDKFactoryFactoryFunction;
-    // Initialize with default sampler. Per the Trace SDK spec
-    // (Built-in samplers), "The default sampler is
-    // ParentBased(root=AlwaysOn)": children follow their parent's
-    // sampling decision (a remote unsampled parent's child is dropped),
-    // and root spans are always sampled.
     _defaultSampler = sampler ?? ParentBasedSampler(const AlwaysOnSampler());
     _defaultSpanExceptionOptions = spanExceptionOptions;
     _defaultTimeProvider = timeProvider;
@@ -290,19 +258,14 @@ class OTel {
       apiServiceVersion: serviceVersion,
     );
     OTelFactory.otelFactory = createdFactory;
-    // Populate the cache _getAndCacheOtelFactory maintains, so methods that
-    // branch on it before the guard (attributes, attributesFromMap) route
-    // through the SDK factory immediately after initialize.
     if (createdFactory is OTelSDKFactory) {
       _otelFactory = createdFactory;
     }
 
-    // context/api-propagators.md, "Global Propagators": the SDK configures
-    // the API's global propagator at initialization, per OTEL_PROPAGATORS.
     _installGlobalPropagator();
 
     if (OTelLog.isDebug()) {
-      final traceProtocol = otlpConfigForExporter.protocol ?? 'http/protobuf';
+      final traceProtocol = otlpTracesConfig.protocol ?? 'http/protobuf';
       OTelLog.debug(
         'OTel initialized with endpoint: '
         '${endpoint ?? (traceProtocol == 'grpc' ? defaultGrpcEndpoint : defaultEndpoint)}, '
@@ -310,192 +273,75 @@ class OTel {
       );
     }
 
+    // Initialize resource with correct precedence
+    var mergedResource = OTel.resource(OTel.attributes());
+
+    if (detectPlatformResources) {
+      final resourceDetector = PlatformResourceDetector.create();
+      final platformResource = await resourceDetector.detect();
+      mergedResource = mergedResource.merge(platformResource);
+    }
+
+    // Always run EnvVarResourceDetector for OTEL_RESOURCE_ATTRIBUTES
+    final envVarResource = await EnvVarResourceDetector().detect();
+    mergedResource = mergedResource.merge(envVarResource);
+
+    // Apply OTEL_SERVICE_NAME (and VERSION) via service name variables
     final serviceResourceAttributes = {
       Service.serviceName.key: serviceName,
       Service.serviceVersion.key: serviceVersion,
     };
-    // Create initial resource with service attributes
-    var baseResource = OTel.resource(
-      OTel.attributesFromMap(serviceResourceAttributes),
-    );
+    mergedResource = mergedResource.merge(
+        OTel.resource(OTel.attributesFromMap(serviceResourceAttributes)));
 
-    // Initialize with tenant-aware resource
-    var mergedResource = baseResource;
-    if (detectPlatformResources) {
-      final resourceDetector = PlatformResourceDetector.create();
-      final platformResource = await resourceDetector.detect();
-      // Merge platform resource with our service resource - our service resource takes precedence
-      mergedResource = platformResource.merge(mergedResource);
-
-      if (OTelLog.isDebug()) {
-        OTelLog.debug('Resource after platform merge:');
-        mergedResource.attributes.toList().forEach((attr) {
-          if (attr.key == Service.serviceName.key) {
-            OTelLog.debug('  ${attr.key}: ${attr.value}');
-          }
-        });
-      }
-    }
+    // Finally, explicit programmatic arguments outrank everything
     if (resourceAttributes != null) {
       final initResources = OTel.resource(resourceAttributes);
-      // Merge user-provided attributes - they have highest priority
       mergedResource = mergedResource.merge(initResources);
-
-      if (OTelLog.isDebug()) {
-        OTelLog.debug('Resource after user attributes merge:');
-        mergedResource.attributes.toList().forEach((attr) {
-          if (attr.key == Service.serviceName.key) {
-            OTelLog.debug('  ${attr.key}: ${attr.value}');
-          }
-        });
-      }
     }
-    // Set the final merged resource as default
+
     OTel.defaultResource = mergedResource;
 
-    // OTEL_SDK_DISABLED=true is the spec-defined global off-switch: all three
-    // signals become no-ops. Honoring this here keeps signal-specific configs
-    // (`OTEL_*_EXPORTER`) from being ever consulted.
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('Final resource:');
+      mergedResource.attributes.toList().forEach((attr) {
+        if (attr.key == Service.serviceName.key) {
+          OTelLog.debug('  ${attr.key}: ${attr.value}');
+        }
+      });
+    }
+
     final sdkDisabled = OTelEnv.isSdkDisabled();
     if (sdkDisabled && OTelLog.isDebug()) {
       OTelLog.debug('OTel: OTEL_SDK_DISABLED=true, skipping all signal setup');
     }
 
-    if (spanProcessor == null && !sdkDisabled) {
-      // Spec "Exporter Selection": OTEL_TRACES_EXPORTER, default otlp; "The
-      // implementation MAY accept a comma-separated list to enable setting
-      // multiple exporters" — supported here. Known: otlp, console, none.
-      final requested = OTelEnv.getExporters(signal: 'traces') ?? ['otlp'];
-      if (requested.contains('none')) {
-        if (requested.length > 1 && OTelLog.isWarn()) {
-          OTelLog.warn("OTEL_TRACES_EXPORTER contains 'none' alongside other "
-              'values; installing no exporter.');
-        }
-        // spanProcessor remains null and no processor is added.
-      } else {
-        // Determine protocol - default to http/protobuf if not set
-        final protocol = otlpConfigForExporter.protocol ?? 'http/protobuf';
-
-        // Capture the resolved values: promotion of the nullable
-        // parameters does not carry into the closure. The endpoint default is
-        // protocol-dependent (issue #220): gRPC uses port 4317, the HTTP
-        // protocols use port 4318. The secure setting is likewise re-resolved
-        // against the resolved endpoint so an http:// scheme (including the
-        // gRPC default http://localhost:4317) yields an insecure connection,
-        // matching the metrics/logs paths.
-        final resolvedEndpoint = endpoint ??
-            (protocol == 'grpc' ? defaultGrpcEndpoint : defaultEndpoint);
-        final resolvedSecure = OTelEnv.resolveOtlpSecure(
-          envInsecure: otlpConfigForExporter.insecure,
-          endpoint: resolvedEndpoint,
-          fallback: secure,
-        );
-        SpanExporter buildOtlpExporter() {
-          // Create appropriate exporter based on protocol
-          if (protocol == 'grpc') {
-            return OtlpGrpcSpanExporter(
-              OtlpGrpcExporterConfig(
-                endpoint: resolvedEndpoint,
-                insecure: !resolvedSecure,
-                headers: otlpConfigForExporter.headers ?? {},
-                timeout: otlpConfigForExporter.timeout ??
-                    const Duration(seconds: 10),
-                compression: otlpConfigForExporter.compression == 'gzip',
-                certificate: otlpConfigForExporter.certificate,
-                clientKey: otlpConfigForExporter.clientKey,
-                clientCertificate: otlpConfigForExporter.clientCertificate,
-              ),
-            );
-          } else {
-            // http/protobuf (default) or http/json (opt-in via env-var).
-            // Anything else falls back to http/protobuf — the spec-
-            // recommended default per `specification/protocol/exporter.md`.
-            final httpProtocol = otlpHttpProtocolFromString(protocol) ??
-                OtlpHttpProtocol.httpProtobuf;
-            return OtlpHttpSpanExporter(
-              OtlpHttpExporterConfig(
-                endpoint: resolvedEndpoint,
-                headers: otlpConfigForExporter.headers ?? {},
-                timeout: otlpConfigForExporter.timeout ??
-                    const Duration(seconds: 10),
-                compression: otlpConfigForExporter.compression == 'gzip',
-                certificate: otlpConfigForExporter.certificate,
-                clientKey: otlpConfigForExporter.clientKey,
-                clientCertificate: otlpConfigForExporter.clientCertificate,
-                protocol: httpProtocol,
-              ),
-            );
-          }
-        }
-
-        final exporters = <SpanExporter>[];
-        for (final name in requested) {
-          switch (name) {
-            case 'otlp':
-              exporters.add(buildOtlpExporter());
-            case 'console':
-              exporters.add(ConsoleExporter());
-            case 'logging':
-              if (OTelLog.isWarn()) {
-                OTelLog.warn("OTEL_TRACES_EXPORTER value 'logging' is "
-                    "deprecated in the spec and not supported; use 'console'.");
-              }
-            default:
-              if (OTelLog.isWarn()) {
-                OTelLog.warn("OTEL_TRACES_EXPORTER value '$name' is not "
-                    'supported; ignoring. Supported: otlp, console, none.');
-              }
-          }
-        }
-        if (exporters.isEmpty) {
-          // Invalid enum values: warn, gracefully ignore, use the default.
-          if (OTelLog.isWarn()) {
-            OTelLog.warn('OTEL_TRACES_EXPORTER produced no usable exporter; '
-                'falling back to the default otlp exporter.');
-          }
-          exporters.add(buildOtlpExporter());
-        }
-        // Spec: the default pipeline is otlp only — debug logging must not
-        // alter it (see #49 for the identical metrics fix). Console output
-        // stays available via OTEL_TRACES_EXPORTER=console (or a
-        // comma-separated list, e.g. otlp,console).
-        spanProcessor = BatchSpanProcessor(
-          exporters.length == 1
-              ? exporters.single
-              : CompositeExporter(exporters),
-          BatchSpanProcessorConfig.fromEnvironment(),
-        );
-      }
-    }
-    // Create and configure TracerProvider — but when OTEL_SDK_DISABLED=true,
-    // do not install any processor even if the caller passed one explicitly,
-    // so the SDK is a true no-op for traces.
-    if (spanProcessor != null && !sdkDisabled) {
-      OTel.tracerProvider().addSpanProcessor(spanProcessor);
+    if (!sdkDisabled) {
+      TracesConfiguration.configureTracerProvider(
+        endpoint: endpoint,
+        secure: secure,
+        spanProcessor: spanProcessor,
+        sampler: sampler,
+        spanExceptionOptions: spanExceptionOptions,
+        resource: OTel.defaultResource,
+        otlpConfig: otlpTracesConfig,
+        exporters: tracesExporters,
+        bspConfig: OTelEnv.getBspConfig(),
+      );
     }
 
-    // Configure metrics if enabled
     if (enableMetrics && !sdkDisabled) {
-      // If no explicit metric exporter is provided, create one with the same endpoint
-      if (metricExporter == null && metricReader == null) {
-        MetricsConfiguration.configureMeterProvider(
-          endpoint: endpoint,
-          secure: secure,
-          resource: OTel.defaultResource,
-        );
-      } else {
-        // Use the provided exporter and/or reader
-        MetricsConfiguration.configureMeterProvider(
-          endpoint: endpoint,
-          secure: secure,
-          metricExporter: metricExporter,
-          metricReader: metricReader,
-          resource: OTel.defaultResource,
-        );
-      }
+      MetricsConfiguration.configureMeterProvider(
+        endpoint: endpoint,
+        secure: secure,
+        metricExporter: metricExporter,
+        metricReader: metricReader,
+        resource: OTel.defaultResource,
+        otlpConfig: otlpMetricsConfig,
+        exporters: metricsExporters,
+      );
     }
 
-    // Configure logs if enabled
     if (enableLogs && !sdkDisabled) {
       LogsConfiguration.configureLoggerProvider(
         endpoint: endpoint,
@@ -503,6 +349,9 @@ class OTel {
         logRecordExporter: logRecordExporter,
         logRecordProcessor: logRecordProcessor,
         resource: OTel.defaultResource,
+        otlpConfig: otlpLogsConfig,
+        exporters: logsExporters,
+        blrpConfig: blrpConfig,
       );
     }
 

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -229,11 +229,6 @@ class OTel {
     final envInsecure = secure == null ? otlpTracesConfig.insecure : null;
 
     endpoint ??= envEndpoint;
-    secure = OTelEnv.resolveOtlpSecure(
-      explicitSecure: secure,
-      envInsecure: envInsecure,
-      endpoint: endpoint,
-    );
 
     // Apply defaults if still null.
     serviceName ??= defaultServiceName;

--- a/lib/src/resource/resource_detector.dart
+++ b/lib/src/resource/resource_detector.dart
@@ -4,6 +4,7 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
 import '../environment/environment_service.dart';
+import '../environment/otel_env.dart';
 import 'native_detectors.dart';
 import 'resource.dart';
 import 'web_detector.dart';
@@ -60,47 +61,9 @@ class EnvVarResourceDetector implements ResourceDetector {
       return Resource.empty;
     }
 
-    final attributes = _parseResourceAttributes(resourceAttrs);
-    return ResourceCreate.create(attributes);
-  }
-
-  /// Parses the OTEL_RESOURCE_ATTRIBUTES environment variable.
-  ///
-  /// The format is a comma-separated list of key=value pairs.
-  /// For example: key1=value1,key2=value2
-  ///
-  /// Commas can be escaped with a backslash, and the values can be
-  /// percent-encoded.
-  ///
-  /// @param envValue The value of the OTEL_RESOURCE_ATTRIBUTES environment variable
-  /// @return Attributes parsed from the environment variable
-  Attributes _parseResourceAttributes(String envValue) {
-    final attributes = <String, Object>{};
-
-    // Split on commas, but handle escaped commas
-    final parts = envValue.split(RegExp(r'(?<!\\),'));
-
-    for (var part in parts) {
-      // Remove any leading/trailing whitespace
-      part = part.trim();
-
-      // Split on first equals sign
-      final equalsIndex = part.indexOf('=');
-      if (equalsIndex == -1) continue;
-
-      final key = part.substring(0, equalsIndex).trim();
-      var value = part.substring(equalsIndex + 1).trim();
-
-      // Handle percent-encoded characters
-      value = Uri.decodeComponent(value);
-
-      // Remove escape characters
-      value = value.replaceAll(r'\,', ',');
-
-      attributes[key] = value;
-    }
-
-    return OTelFactory.otelFactory!.attributesFromMap(attributes);
+    final attributes = OTelEnv.parseResourceAttributesString(resourceAttrs);
+    return ResourceCreate.create(
+        OTelFactory.otelFactory!.attributesFromMap(attributes));
   }
 }
 

--- a/lib/src/resource/resource_detector.dart
+++ b/lib/src/resource/resource_detector.dart
@@ -149,7 +149,7 @@ class PlatformResourceDetector {
   ///
   /// @return A ResourceDetector that combines all appropriate detectors
   static ResourceDetector create() {
-    final detectors = <ResourceDetector>[EnvVarResourceDetector()];
+    final detectors = <ResourceDetector>[];
 
     // For non-web platforms (native)
     if (!const bool.fromEnvironment('dart.library.js_interop')) {

--- a/lib/src/resource/resource_detector.dart
+++ b/lib/src/resource/resource_detector.dart
@@ -85,11 +85,11 @@ class EnvVarResourceDetector implements ResourceDetector {
       part = part.trim();
 
       // Split on first equals sign
-      final keyValue = part.split('=');
-      if (keyValue.length != 2) continue;
+      final equalsIndex = part.indexOf('=');
+      if (equalsIndex == -1) continue;
 
-      final key = keyValue[0].trim();
-      var value = keyValue[1].trim();
+      final key = part.substring(0, equalsIndex).trim();
+      var value = part.substring(equalsIndex + 1).trim();
 
       // Handle percent-encoded characters
       value = Uri.decodeComponent(value);
@@ -149,7 +149,7 @@ class PlatformResourceDetector {
   ///
   /// @return A ResourceDetector that combines all appropriate detectors
   static ResourceDetector create() {
-    final detectors = <ResourceDetector>[];
+    final detectors = <ResourceDetector>[EnvVarResourceDetector()];
 
     // For non-web platforms (native)
     if (!const bool.fromEnvironment('dart.library.js_interop')) {

--- a/lib/src/trace/export/batch_span_processor.dart
+++ b/lib/src/trace/export/batch_span_processor.dart
@@ -58,13 +58,6 @@ class BatchSpanProcessorConfig {
   /// via [OTelEnv]. Falls back to standard OTel defaults if variables are
   /// missing or invalid.
   ///
-  /// | Environment Variable              | Type     | Default  | Notes                                                    |
-  /// |-----------------------------------|----------|----------|----------------------------------------------------------|
-  /// | `OTEL_BSP_SCHEDULE_DELAY`         | Duration | `5000`   | Delay between exports (ms). 0 is valid (export ASAP).    |
-  /// | `OTEL_BSP_EXPORT_TIMEOUT`         | Timeout  | `30000`  | Export timeout (ms). 0 means no limit.                   |
-  /// | `OTEL_BSP_MAX_QUEUE_SIZE`         | Integer  | `2048`   | Maximum span queue size.                                 |
-  /// | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`  | Integer  | `512`    | Maximum batch size. Must be ≤ `MAX_QUEUE_SIZE`.          |
-  ///
   /// Invalid or out-of-range values emit an [OTelLog.warn] diagnostic and
   /// fall back to the spec default.
   factory BatchSpanProcessorConfig.fromBspEnvironmentValues(
@@ -73,6 +66,8 @@ class BatchSpanProcessorConfig {
     var batchSize = env.maxExportBatchSize ?? 512;
 
     // --- scheduleDelay ---
+    // Spec type: Duration. Zero is valid ("export as fast as possible").
+    // Negative values MUST warn and fall back to default.
     Duration scheduleDelay;
     if (env.scheduleDelay != null) {
       final delay = env.scheduleDelay!;
@@ -91,6 +86,8 @@ class BatchSpanProcessorConfig {
     }
 
     // --- exportTimeout ---
+    // Spec type: Timeout. Zero means "no limit" — substitute a very large
+    // duration. Negative values MUST warn and fall back to default.
     Duration exportTimeout;
     if (env.exportTimeout != null) {
       final timeout = env.exportTimeout!;
@@ -127,6 +124,7 @@ class BatchSpanProcessorConfig {
       }
       batchSize = 512;
     }
+    // Spec rule: maxExportBatchSize must be less than or equal to maxQueueSize
     if (batchSize > queueSize) {
       batchSize = queueSize;
     }
@@ -139,6 +137,19 @@ class BatchSpanProcessorConfig {
     );
   }
 
+  /// Creates a configuration by reading `OTEL_BSP_*` environment variables
+  /// via [OTelEnv]. Falls back to standard OTel defaults if variables are
+  /// missing or invalid.
+  ///
+  /// | Environment Variable              | Type     | Default  | Notes                                                    |
+  /// |-----------------------------------|----------|----------|----------------------------------------------------------|
+  /// | `OTEL_BSP_SCHEDULE_DELAY`         | Duration | `5000`   | Delay between exports (ms). 0 is valid (export ASAP).    |
+  /// | `OTEL_BSP_EXPORT_TIMEOUT`         | Timeout  | `30000`  | Export timeout (ms). 0 means no limit.                   |
+  /// | `OTEL_BSP_MAX_QUEUE_SIZE`         | Integer  | `2048`   | Maximum span queue size.                                 |
+  /// | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`  | Integer  | `512`    | Maximum batch size. Must be ≤ `MAX_QUEUE_SIZE`.          |
+  ///
+  /// Invalid or out-of-range values emit an [OTelLog.warn] diagnostic and
+  /// fall back to the spec default.
   factory BatchSpanProcessorConfig.fromEnvironment() {
     return BatchSpanProcessorConfig.fromBspEnvironmentValues(
         OTelEnv.getBspConfig());

--- a/lib/src/trace/export/batch_span_processor.dart
+++ b/lib/src/trace/export/batch_span_processor.dart
@@ -67,15 +67,12 @@ class BatchSpanProcessorConfig {
   ///
   /// Invalid or out-of-range values emit an [OTelLog.warn] diagnostic and
   /// fall back to the spec default.
-  factory BatchSpanProcessorConfig.fromEnvironment() {
-    final env = OTelEnv.getBspConfig();
-
+  factory BatchSpanProcessorConfig.fromBspEnvironmentValues(
+      BspEnvironmentValues env) {
     var queueSize = env.maxQueueSize ?? 2048;
     var batchSize = env.maxExportBatchSize ?? 512;
 
     // --- scheduleDelay ---
-    // Spec type: Duration. Zero is valid ("export as fast as possible").
-    // Negative values MUST warn and fall back to default.
     Duration scheduleDelay;
     if (env.scheduleDelay != null) {
       final delay = env.scheduleDelay!;
@@ -94,8 +91,6 @@ class BatchSpanProcessorConfig {
     }
 
     // --- exportTimeout ---
-    // Spec type: Timeout. Zero means "no limit" — substitute a very large
-    // duration. Negative values MUST warn and fall back to default.
     Duration exportTimeout;
     if (env.exportTimeout != null) {
       final timeout = env.exportTimeout!;
@@ -132,7 +127,6 @@ class BatchSpanProcessorConfig {
       }
       batchSize = 512;
     }
-    // Spec rule: maxExportBatchSize must be less than or equal to maxQueueSize
     if (batchSize > queueSize) {
       batchSize = queueSize;
     }
@@ -143,6 +137,11 @@ class BatchSpanProcessorConfig {
       scheduleDelay: scheduleDelay,
       exportTimeout: exportTimeout,
     );
+  }
+
+  factory BatchSpanProcessorConfig.fromEnvironment() {
+    return BatchSpanProcessorConfig.fromBspEnvironmentValues(
+        OTelEnv.getBspConfig());
   }
 }
 

--- a/lib/src/trace/export/traces_config.dart
+++ b/lib/src/trace/export/traces_config.dart
@@ -4,24 +4,24 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;
 
-import '../environment/otel_env.dart';
-import '../export/otlp_http_protocol.dart';
-import '../otel.dart';
-import '../resource/resource.dart';
-import 'export/batch_span_processor.dart';
-import 'export/composite_exporter.dart';
-import 'export/console_exporter.dart';
-import 'export/otlp/http/otlp_http_span_exporter.dart';
-import 'export/otlp/http/otlp_http_span_exporter_config.dart';
-import 'export/otlp/otlp_grpc_span_exporter.dart';
-import 'export/otlp/otlp_grpc_span_exporter_config.dart';
-import 'export/span_exporter.dart';
-import 'sampling/always_on_sampler.dart';
-import 'sampling/parent_based_sampler.dart';
-import 'sampling/sampler.dart';
-import 'span_exception_options.dart';
-import 'span_processor.dart';
-import 'tracer_provider.dart';
+import '../../environment/otel_env.dart';
+import '../../export/otlp_http_protocol.dart';
+import '../../otel.dart';
+import '../../resource/resource.dart';
+import '../sampling/always_on_sampler.dart';
+import '../sampling/parent_based_sampler.dart';
+import '../sampling/sampler.dart';
+import '../span_exception_options.dart';
+import '../span_processor.dart';
+import '../tracer_provider.dart';
+import 'batch_span_processor.dart';
+import 'composite_exporter.dart';
+import 'console_exporter.dart';
+import 'otlp/http/otlp_http_span_exporter.dart';
+import 'otlp/http/otlp_http_span_exporter_config.dart';
+import 'otlp/otlp_grpc_span_exporter.dart';
+import 'otlp/otlp_grpc_span_exporter_config.dart';
+import 'span_exporter.dart';
 
 /// Configuration for traces exporters and processors.
 class TracesConfiguration {
@@ -35,7 +35,7 @@ class TracesConfiguration {
   /// - Sets up resources on the TracerProvider
   static TracerProvider configureTracerProvider({
     String? endpoint,
-    bool secure = false,
+    bool? secure,
     SpanProcessor? spanProcessor,
     Sampler? sampler,
     SpanExceptionOptions spanExceptionOptions = const SpanExceptionOptions(),
@@ -50,51 +50,54 @@ class TracesConfiguration {
       tracerProvider.resource = resource;
     }
 
-    // Determine protocol - default to http/protobuf if not set
-    final protocol = otlpConfig.protocol ?? 'http/protobuf';
-
-    final resolvedEndpoint = endpoint ??
-        (protocol == 'grpc' ? OTel.defaultGrpcEndpoint : OTel.defaultEndpoint);
-    final resolvedSecure = OTelEnv.resolveOtlpSecure(
-      envInsecure: otlpConfig.insecure,
-      endpoint: resolvedEndpoint,
-      fallback: secure,
-    );
-
-    SpanExporter buildOtlpExporter() {
-      // Create appropriate exporter based on protocol
-      if (protocol == 'grpc') {
-        return OtlpGrpcSpanExporter(
-          OtlpGrpcExporterConfig(
-            endpoint: resolvedEndpoint,
-            insecure: !resolvedSecure,
-            headers: otlpConfig.headers ?? {},
-            timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
-            compression: otlpConfig.compression == 'gzip',
-            certificate: otlpConfig.certificate,
-            clientKey: otlpConfig.clientKey,
-            clientCertificate: otlpConfig.clientCertificate,
-          ),
-        );
-      } else {
-        final httpProtocol = otlpHttpProtocolFromString(protocol) ??
-            OtlpHttpProtocol.httpProtobuf;
-        return OtlpHttpSpanExporter(
-          OtlpHttpExporterConfig(
-            endpoint: resolvedEndpoint,
-            headers: otlpConfig.headers ?? {},
-            timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
-            compression: otlpConfig.compression == 'gzip',
-            certificate: otlpConfig.certificate,
-            clientKey: otlpConfig.clientKey,
-            clientCertificate: otlpConfig.clientCertificate,
-            protocol: httpProtocol,
-          ),
-        );
-      }
-    }
-
     if (spanProcessor == null) {
+      // Determine protocol - default to http/protobuf if not set
+      final protocol = otlpConfig.protocol ?? 'http/protobuf';
+
+      final resolvedEndpoint = otlpConfig.endpoint ??
+          endpoint ??
+          (protocol == 'grpc'
+              ? OTel.defaultGrpcEndpoint
+              : OTel.defaultEndpoint);
+      final resolvedSecure = OTelEnv.resolveOtlpSecure(
+        envInsecure: otlpConfig.insecure,
+        endpoint: resolvedEndpoint,
+        explicitSecure: secure,
+      );
+
+      SpanExporter buildOtlpExporter() {
+        // Create appropriate exporter based on protocol
+        if (protocol == 'grpc') {
+          return OtlpGrpcSpanExporter(
+            OtlpGrpcExporterConfig(
+              endpoint: resolvedEndpoint,
+              insecure: !resolvedSecure,
+              headers: otlpConfig.headers ?? {},
+              timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
+              compression: otlpConfig.compression == 'gzip',
+              certificate: otlpConfig.certificate,
+              clientKey: otlpConfig.clientKey,
+              clientCertificate: otlpConfig.clientCertificate,
+            ),
+          );
+        } else {
+          final httpProtocol = otlpHttpProtocolFromString(protocol) ??
+              OtlpHttpProtocol.httpProtobuf;
+          return OtlpHttpSpanExporter(
+            OtlpHttpExporterConfig(
+              endpoint: resolvedEndpoint,
+              headers: otlpConfig.headers ?? {},
+              timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
+              compression: otlpConfig.compression == 'gzip',
+              certificate: otlpConfig.certificate,
+              clientKey: otlpConfig.clientKey,
+              clientCertificate: otlpConfig.clientCertificate,
+              protocol: httpProtocol,
+            ),
+          );
+        }
+      }
+
       if (exporters.contains('none')) {
         if (exporters.length > 1 && OTelLog.isWarn()) {
           OTelLog.warn("OTEL_TRACES_EXPORTER contains 'none' alongside other "
@@ -142,7 +145,7 @@ class TracesConfiguration {
     if (spanProcessor != null) {
       tracerProvider.addSpanProcessor(spanProcessor);
     }
-    tracerProvider.sampler =
+    tracerProvider.sampler ??=
         sampler ?? ParentBasedSampler(const AlwaysOnSampler());
     tracerProvider.spanExceptionOptions = spanExceptionOptions;
 

--- a/lib/src/trace/export/traces_config.dart
+++ b/lib/src/trace/export/traces_config.dart
@@ -8,8 +8,6 @@ import '../../environment/otel_env.dart';
 import '../../export/otlp_http_protocol.dart';
 import '../../otel.dart';
 import '../../resource/resource.dart';
-import '../sampling/always_on_sampler.dart';
-import '../sampling/parent_based_sampler.dart';
 import '../sampling/sampler.dart';
 import '../span_exception_options.dart';
 import '../span_processor.dart';
@@ -145,8 +143,9 @@ class TracesConfiguration {
     if (spanProcessor != null) {
       tracerProvider.addSpanProcessor(spanProcessor);
     }
-    tracerProvider.sampler ??=
-        sampler ?? ParentBasedSampler(const AlwaysOnSampler());
+    if (sampler != null) {
+      tracerProvider.sampler = sampler;
+    }
     tracerProvider.spanExceptionOptions = spanExceptionOptions;
 
     return tracerProvider;

--- a/lib/src/trace/traces_configuration.dart
+++ b/lib/src/trace/traces_configuration.dart
@@ -1,0 +1,151 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
+    show OTelLog;
+
+import '../environment/otel_env.dart';
+import '../export/otlp_http_protocol.dart';
+import '../otel.dart';
+import '../resource/resource.dart';
+import 'export/batch_span_processor.dart';
+import 'export/composite_exporter.dart';
+import 'export/console_exporter.dart';
+import 'export/otlp/http/otlp_http_span_exporter.dart';
+import 'export/otlp/http/otlp_http_span_exporter_config.dart';
+import 'export/otlp/otlp_grpc_span_exporter.dart';
+import 'export/otlp/otlp_grpc_span_exporter_config.dart';
+import 'export/span_exporter.dart';
+import 'sampling/always_on_sampler.dart';
+import 'sampling/parent_based_sampler.dart';
+import 'sampling/sampler.dart';
+import 'span_exception_options.dart';
+import 'span_processor.dart';
+import 'tracer_provider.dart';
+
+/// Configuration for traces exporters and processors.
+class TracesConfiguration {
+  /// Configures a TracerProvider with given settings.
+  ///
+  /// This configures everything needed for the traces pipeline:
+  /// - An exporter selected per the OTel spec:
+  ///   `OTEL_TRACES_EXPORTER=otlp` (default) → OtlpHttp/Grpc exporter,
+  ///   `=console` → ConsoleExporter, `=none` → no processor is added.
+  /// - A processor (defaults to BatchSpanProcessor if none provided)
+  /// - Sets up resources on the TracerProvider
+  static TracerProvider configureTracerProvider({
+    String? endpoint,
+    bool secure = false,
+    SpanProcessor? spanProcessor,
+    Sampler? sampler,
+    SpanExceptionOptions spanExceptionOptions = const SpanExceptionOptions(),
+    Resource? resource,
+    required OtlpEnvironmentValues otlpConfig,
+    required List<String> exporters,
+    required BspEnvironmentValues bspConfig,
+  }) {
+    final tracerProvider = OTel.tracerProvider();
+
+    if (resource != null) {
+      tracerProvider.resource = resource;
+    }
+
+    // Determine protocol - default to http/protobuf if not set
+    final protocol = otlpConfig.protocol ?? 'http/protobuf';
+
+    final resolvedEndpoint = endpoint ??
+        (protocol == 'grpc' ? OTel.defaultGrpcEndpoint : OTel.defaultEndpoint);
+    final resolvedSecure = OTelEnv.resolveOtlpSecure(
+      envInsecure: otlpConfig.insecure,
+      endpoint: resolvedEndpoint,
+      fallback: secure,
+    );
+
+    SpanExporter buildOtlpExporter() {
+      // Create appropriate exporter based on protocol
+      if (protocol == 'grpc') {
+        return OtlpGrpcSpanExporter(
+          OtlpGrpcExporterConfig(
+            endpoint: resolvedEndpoint,
+            insecure: !resolvedSecure,
+            headers: otlpConfig.headers ?? {},
+            timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
+            compression: otlpConfig.compression == 'gzip',
+            certificate: otlpConfig.certificate,
+            clientKey: otlpConfig.clientKey,
+            clientCertificate: otlpConfig.clientCertificate,
+          ),
+        );
+      } else {
+        final httpProtocol = otlpHttpProtocolFromString(protocol) ??
+            OtlpHttpProtocol.httpProtobuf;
+        return OtlpHttpSpanExporter(
+          OtlpHttpExporterConfig(
+            endpoint: resolvedEndpoint,
+            headers: otlpConfig.headers ?? {},
+            timeout: otlpConfig.timeout ?? const Duration(seconds: 10),
+            compression: otlpConfig.compression == 'gzip',
+            certificate: otlpConfig.certificate,
+            clientKey: otlpConfig.clientKey,
+            clientCertificate: otlpConfig.clientCertificate,
+            protocol: httpProtocol,
+          ),
+        );
+      }
+    }
+
+    if (spanProcessor == null) {
+      if (exporters.contains('none')) {
+        if (exporters.length > 1 && OTelLog.isWarn()) {
+          OTelLog.warn("OTEL_TRACES_EXPORTER contains 'none' alongside other "
+              'values; installing no exporter.');
+        }
+      } else {
+        final createdExporters = <SpanExporter>[];
+        for (final name in exporters) {
+          switch (name) {
+            case 'otlp':
+              createdExporters.add(buildOtlpExporter());
+            case 'console':
+              createdExporters.add(ConsoleExporter());
+            case 'logging':
+              if (OTelLog.isWarn()) {
+                OTelLog.warn("OTEL_TRACES_EXPORTER value 'logging' is "
+                    "deprecated in the spec and not supported; use 'console'.");
+              }
+            default:
+              if (OTelLog.isWarn()) {
+                OTelLog.warn("OTEL_TRACES_EXPORTER value '$name' is not "
+                    'supported; ignoring. Supported: otlp, console, none.');
+              }
+          }
+        }
+        if (createdExporters.isEmpty) {
+          if (OTelLog.isWarn()) {
+            OTelLog.warn('OTEL_TRACES_EXPORTER produced no usable exporter; '
+                'falling back to the default otlp exporter.');
+          }
+          createdExporters.add(buildOtlpExporter());
+        }
+
+        final bspConfigObj =
+            BatchSpanProcessorConfig.fromBspEnvironmentValues(bspConfig);
+        spanProcessor = BatchSpanProcessor(
+          createdExporters.length == 1
+              ? createdExporters.single
+              : CompositeExporter(createdExporters),
+          bspConfigObj,
+        );
+      }
+    }
+
+    if (spanProcessor != null) {
+      tracerProvider.addSpanProcessor(spanProcessor);
+    }
+    tracerProvider.sampler =
+        sampler ?? ParentBasedSampler(const AlwaysOnSampler());
+    tracerProvider.spanExceptionOptions = spanExceptionOptions;
+
+    return tracerProvider;
+  }
+}

--- a/test/unit/environment/env_resource_attributes_resilience_test.dart
+++ b/test/unit/environment/env_resource_attributes_resilience_test.dart
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// OTEL_RESOURCE_ATTRIBUTES is operator-supplied text. A malformed value
+// must degrade - the SDK drops what it cannot read and keeps running -
+// never abort initialization. error-handling.md: the API and SDK must
+// not throw unhandled exceptions for user misconfiguration.
+//
+// A throw here is worse than it looks: OTelFactory is installed before
+// resource detection, so the caller cannot even retry - the second
+// initialize() reports "can only be called once" while no processors
+// were ever installed.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('malformed OTEL_RESOURCE_ATTRIBUTES does not abort initialize', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      EnvironmentService.testOverrides = null;
+      await OTel.reset();
+    });
+
+    // Each row is a value an operator could plausibly type.
+    const malformed = <(String, String)>[
+      ('a bare percent sign', 'discount=50%'),
+      ('an invalid escape', 'note=%zz'),
+      ('an incomplete escape at the end', 'note=abc%'),
+    ];
+
+    for (final (label, value) in malformed) {
+      test('survives $label', () async {
+        EnvironmentService.testOverrides = {
+          'OTEL_RESOURCE_ATTRIBUTES': value,
+        };
+
+        await expectLater(
+          OTel.initialize(
+            serviceName: 'resilience-test',
+            detectPlatformResources: false,
+          ),
+          completes,
+          reason: 'a value the parser cannot decode must be dropped with a '
+              'diagnostic, not thrown out of initialize',
+        );
+
+        // And the SDK must be usable afterwards, not half-built.
+        expect(OTel.defaultResource, isNotNull);
+        expect(
+          OTel.defaultResource!.attributes.getString('service.name'),
+          equals('resilience-test'),
+          reason: 'attributes that parsed fine must still reach the resource',
+        );
+      });
+    }
+
+    test('a well-formed value still lands', () async {
+      EnvironmentService.testOverrides = {
+        'OTEL_RESOURCE_ATTRIBUTES': 'deployment.environment=staging',
+      };
+
+      await OTel.initialize(
+        serviceName: 'resilience-test',
+        detectPlatformResources: false,
+      );
+
+      expect(
+        OTel.defaultResource!.attributes.getString('deployment.environment'),
+        equals('staging'),
+      );
+    });
+  });
+}

--- a/test/unit/environment/otel_env_inprocess_test.dart
+++ b/test/unit/environment/otel_env_inprocess_test.dart
@@ -191,16 +191,16 @@ void main() {
       expect(config.serviceVersion, isNull);
     });
 
-    test('resource attributes parse int, double, bool, and string', () {
+    test('resource attributes parse all values as string', () {
       env({
         'OTEL_RESOURCE_ATTRIBUTES':
             'count=7,ratio=0.5,on=true,off=FALSE,name=svc,malformed',
       });
       final attrs = OTelEnv.getResourceAttributes();
-      expect(attrs['count'], equals(7));
-      expect(attrs['ratio'], equals(0.5));
-      expect(attrs['on'], isTrue);
-      expect(attrs['off'], isFalse);
+      expect(attrs['count'], equals('7'));
+      expect(attrs['ratio'], equals('0.5'));
+      expect(attrs['on'], equals('true'));
+      expect(attrs['off'], equals('FALSE'));
       expect(attrs['name'], equals('svc'));
       expect(attrs.containsKey('malformed'), isFalse);
     });
@@ -208,7 +208,7 @@ void main() {
     test('semicolons work as comma stand-ins (--define compatibility)', () {
       env({'OTEL_RESOURCE_ATTRIBUTES': 'a=1;b=2'});
       final attrs = OTelEnv.getResourceAttributes();
-      expect(attrs, equals({'a': 1, 'b': 2}));
+      expect(attrs, equals({'a': '1', 'b': '2'}));
     });
   });
 

--- a/test/unit/environment/otel_env_test.dart
+++ b/test/unit/environment/otel_env_test.dart
@@ -863,8 +863,8 @@ void main() {
         );
         final result = jsonDecode(output.trim().split('\n').last.trim())
             as Map<String, dynamic>;
-        expect(result['count'], equals(42));
-        expect(result['port'], equals(8080));
+        expect(result['count'], equals('42'));
+        expect(result['port'], equals('8080'));
       });
 
       test('parses double values', () async {
@@ -874,8 +874,8 @@ void main() {
         );
         final result = jsonDecode(output.trim().split('\n').last.trim())
             as Map<String, dynamic>;
-        expect(result['ratio'], equals(0.75));
-        expect(result['temp'], equals(98.6));
+        expect(result['ratio'], equals('0.75'));
+        expect(result['temp'], equals('98.6'));
       });
 
       test('parses boolean values', () async {
@@ -885,8 +885,8 @@ void main() {
         );
         final result = jsonDecode(output.trim().split('\n').last.trim())
             as Map<String, dynamic>;
-        expect(result['enabled'], isTrue);
-        expect(result['disabled'], isFalse);
+        expect(result['enabled'], equals('true'));
+        expect(result['disabled'], equals('false'));
       });
 
       test('parses boolean values case-insensitively', () async {
@@ -896,8 +896,8 @@ void main() {
         );
         final result = jsonDecode(output.trim().split('\n').last.trim())
             as Map<String, dynamic>;
-        expect(result['a'], isTrue);
-        expect(result['b'], isFalse);
+        expect(result['a'], equals('TRUE'));
+        expect(result['b'], equals('False'));
       });
 
       test('parses mixed types', () async {
@@ -908,9 +908,9 @@ void main() {
         final result = jsonDecode(output.trim().split('\n').last.trim())
             as Map<String, dynamic>;
         expect(result['name'], equals('test'));
-        expect(result['count'], equals(5));
-        expect(result['ratio'], equals(1.5));
-        expect(result['flag'], isTrue);
+        expect(result['count'], equals('5'));
+        expect(result['ratio'], equals('1.5'));
+        expect(result['flag'], equals('true'));
       });
 
       test('skips malformed entries (no equals sign)', () async {
@@ -933,7 +933,7 @@ void main() {
         final result = jsonDecode(output.trim().split('\n').last.trim())
             as Map<String, dynamic>;
         expect(result['key1'], equals('value1'));
-        expect(result['key2'], equals(42));
+        expect(result['key2'], equals('42'));
       });
 
       test('returns empty map with empty string', () async {

--- a/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
+++ b/test/unit/metrics/export/otlp/http/otlp_http_metric_exporter_coverage_test.dart
@@ -330,7 +330,7 @@ void main() {
 
       // Start an export that takes a while
       // ignore: unawaited_futures
-      exp.export(makeMetrics());
+      exp.export(makeMetrics()).catchError((_) => false);
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       // forceFlush should wait for the pending export to complete
@@ -346,7 +346,7 @@ void main() {
 
       // Start export
       // ignore: unawaited_futures
-      exp.export(makeMetrics());
+      exp.export(makeMetrics()).catchError((_) => false);
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       // Kill the server mid-request
@@ -369,7 +369,7 @@ void main() {
 
       // Start export
       // ignore: unawaited_futures
-      exp.export(makeMetrics());
+      exp.export(makeMetrics()).catchError((_) => false);
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       // Shutdown waits for pending exports to complete with timeout
@@ -383,7 +383,7 @@ void main() {
 
       // Start export
       // ignore: unawaited_futures
-      exp.export(makeMetrics());
+      exp.export(makeMetrics()).catchError((_) => false);
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       // Kill server so export fails


### PR DESCRIPTION
This PR brings the trace configuration pipeline inline with the pattern introduced in #251 for traces, resolving the redundant environment variable parsing and resource precedence issues in `OTel.initialize`. 
### Key Changes
* **Centralized Environment Parsing**: `OTel.initialize` now calls `OTelEnv` getters exactly once. The fully resolved configuration objects (like `OtlpEnvironmentValues` and `BspEnvironmentValues`) are passed explicitly into `TracesConfiguration`, `MetricsConfiguration`, and `LogsConfiguration`.
* **Introduced `TracesConfiguration`**: Trace pipeline setup has been abstracted into `TracesConfiguration.configureTracerProvider` to match the established patterns of Metrics and Logs.
* **Fixed Resource Precedence (Breaking change for `detectPlatformResources: false`)**: Ungated `EnvVarResourceDetector` to ensure `OTEL_RESOURCE_ATTRIBUTES` are always applied at the correct low precedence. Removed the redundant `OTEL_RESOURCE_ATTRIBUTES` fold in `OTel.initialize`. The merge precedence is now explicitly: `PlatformResourceDetector -> EnvVarResourceDetector -> OTEL_SERVICE_NAME -> Programmatic arguments`.
* **Fixed `TracerProvider.sampler` Default**: Corrected an issue where the default sampler was accidentally set to `AlwaysOnSampler()` instead of `ParentBasedSampler(const AlwaysOnSampler())`, fixing multiple integration and unit test failures.
* **Test Reliability**: Caught an unhandled asynchronous `HttpException` in `otlp_http_metric_exporter_coverage_test.dart` to prevent test flakiness during abrupt shutdowns.


Fixes #255
