### PR TITLE
fix(config): honor the programmatic secure parameter in logs and metrics (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.15-wip]
 
+### Fixed
+
+- **The programmatic `secure` parameter is honored by the logs and metrics
+  configurations** (#253). `LogsConfiguration.configureLoggerProvider` and
+  `MetricsConfiguration.configureMeterProvider` declared `bool secure = false`
+  and passed it as the lowest-precedence fallback, so the parameter was a
+  no-op whenever the endpoint carried a scheme — which both defaults do. It is
+  now `bool? secure`: a non-null value is the caller's explicit choice and
+  outranks `OTEL_EXPORTER_OTLP_INSECURE`, while `null` (the default) defers to
+  the endpoint scheme, then the environment, then the built-in default.
+
+  `OTel.initialize` now forwards the caller's original value rather than the
+  boolean it resolved for the traces signal. Without that, a plaintext generic
+  endpoint could turn TLS **off** for a signal the operator had pointed at an
+  `https://` endpoint via `OTEL_EXPORTER_OTLP_{LOGS,METRICS}_ENDPOINT`.
+
 ## [1.1.0-beta.14] - 2026-08-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outranks `OTEL_EXPORTER_OTLP_INSECURE`, while `null` (the default) defers to
   the endpoint scheme, then the environment, then the built-in default.
 
+  Precedence now follows `protocol/exporter.md`: the endpoint **scheme**
+  decides when there is one (an `https` or `http` scheme "takes precedence
+  over the `insecure` configuration setting"), so the setting applies only
+  to OTLP/gRPC with a scheme-less endpoint such as `my-collector:4317` —
+  the one case where nothing else can express the choice. Previously an
+  explicit value outranked the scheme, meaning `secure: true` alongside an
+  `http://` endpoint produced TLS against the spec. Fixes #225.
+
   `OTel.initialize` now forwards the caller's original value rather than the
   boolean it resolved for the traces signal. Without that, a plaintext generic
   endpoint could turn TLS **off** for a signal the operator had pointed at an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **The `secure` parameter now works for logs and metrics** (#253, #225). It
-  was ignored, and a plaintext traces endpoint could disable TLS for a signal
-  you had pointed at an `https://` one. `secure` is now `bool?`: leave it unset
-  and the endpoint decides. It applies only to OTLP/gRPC endpoints written
-  without a scheme, such as `my-collector:4317` — an `https://` or `http://`
-  endpoint always wins, and OTLP/HTTP always follows its URL.
+- **The `secure` parameter now works for logs and metrics** (#253, #225).
+  Previously `secure` overrode the gRPC endpoint scheme; now the scheme
+  (`http:`, `https:`) takes precedence and `secure` applies only to
+  scheme-less endpoints.
 
 ## [1.1.0-beta.14] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,27 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **The programmatic `secure` parameter is honored by the logs and metrics
-  configurations** (#253). `LogsConfiguration.configureLoggerProvider` and
-  `MetricsConfiguration.configureMeterProvider` declared `bool secure = false`
-  and passed it as the lowest-precedence fallback, so the parameter was a
-  no-op whenever the endpoint carried a scheme — which both defaults do. It is
-  now `bool? secure`: a non-null value is the caller's explicit choice and
-  outranks `OTEL_EXPORTER_OTLP_INSECURE`, while `null` (the default) defers to
-  the endpoint scheme, then the environment, then the built-in default.
-
-  Precedence now follows `protocol/exporter.md`: the endpoint **scheme**
-  decides when there is one (an `https` or `http` scheme "takes precedence
-  over the `insecure` configuration setting"), so the setting applies only
-  to OTLP/gRPC with a scheme-less endpoint such as `my-collector:4317` —
-  the one case where nothing else can express the choice. Previously an
-  explicit value outranked the scheme, meaning `secure: true` alongside an
-  `http://` endpoint produced TLS against the spec. Fixes #225.
-
-  `OTel.initialize` now forwards the caller's original value rather than the
-  boolean it resolved for the traces signal. Without that, a plaintext generic
-  endpoint could turn TLS **off** for a signal the operator had pointed at an
-  `https://` endpoint via `OTEL_EXPORTER_OTLP_{LOGS,METRICS}_ENDPOINT`.
+- **The `secure` parameter now works for logs and metrics** (#253, #225). It
+  was ignored, and a plaintext traces endpoint could disable TLS for a signal
+  you had pointed at an `https://` one. `secure` is now `bool?`: leave it unset
+  and the endpoint decides. It applies only to OTLP/gRPC endpoints written
+  without a scheme, such as `my-collector:4317` — an `https://` or `http://`
+  endpoint always wins, and OTLP/HTTP always follows its URL.
 
 ## [1.1.0-beta.14] - 2026-08-23
 

--- a/lib/src/environment/env_constants.dart
+++ b/lib/src/environment/env_constants.dart
@@ -156,6 +156,13 @@ const String otelExporterOtlpHeaders = 'OTEL_EXPORTER_OTLP_HEADERS';
 /// This option only applies to OTLP/gRPC when an endpoint is provided without
 /// the http or https scheme. OTLP/HTTP always uses the scheme from the endpoint.
 ///
+/// An `https` or `http` scheme on the endpoint takes precedence over this
+/// variable, so it only decides for a scheme-less endpoint such as
+/// `my-collector:4317`.
+///
+/// The `secure` parameter of `OTel.initialize` is the code equivalent of this
+/// variable (inverted) and takes precedence over it.
+///
 /// Type: Boolean
 /// Default: false
 const String otelExporterOtlpInsecure = 'OTEL_EXPORTER_OTLP_INSECURE';

--- a/lib/src/environment/env_constants.dart
+++ b/lib/src/environment/env_constants.dart
@@ -245,6 +245,10 @@ const String otelExporterOtlpTracesHeaders =
 ///
 /// Overrides OTEL_EXPORTER_OTLP_INSECURE for traces.
 ///
+/// Applies only to OTLP/gRPC, and only when the traces endpoint carries no
+/// `http://` or `https://` scheme — a scheme takes precedence over this
+/// variable, and OTLP/HTTP always takes its security from the endpoint.
+///
 /// Type: Boolean
 /// Default: none (uses OTEL_EXPORTER_OTLP_INSECURE)
 const String otelExporterOtlpTracesInsecure =
@@ -338,6 +342,10 @@ const String otelExporterOtlpMetricsHeaders =
 ///
 /// Overrides OTEL_EXPORTER_OTLP_INSECURE for metrics.
 ///
+/// Applies only to OTLP/gRPC, and only when the metrics endpoint carries no
+/// `http://` or `https://` scheme — a scheme takes precedence over this
+/// variable, and OTLP/HTTP always takes its security from the endpoint.
+///
 /// Type: Boolean
 /// Default: none (uses OTEL_EXPORTER_OTLP_INSECURE)
 const String otelExporterOtlpMetricsInsecure =
@@ -427,6 +435,10 @@ const String otelExporterOtlpLogsHeaders = 'OTEL_EXPORTER_OTLP_LOGS_HEADERS';
 /// Whether to use insecure connection for logs OTLP/gRPC.
 ///
 /// Overrides OTEL_EXPORTER_OTLP_INSECURE for logs.
+///
+/// Applies only to OTLP/gRPC, and only when the logs endpoint carries no
+/// `http://` or `https://` scheme — a scheme takes precedence over this
+/// variable, and OTLP/HTTP always takes its security from the endpoint.
 ///
 /// Type: Boolean
 /// Default: none (uses OTEL_EXPORTER_OTLP_INSECURE)

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -681,14 +681,19 @@ class OTelEnv {
   /// Resolves whether an OTLP connection should use TLS, per the OTLP
   /// exporter spec's precedence:
   ///
-  /// 1. an explicit programmatic choice ([explicitSecure]) wins;
-  /// 2. otherwise the endpoint **scheme** decides — the spec states the
-  ///    scheme indicates the connection security, and that
-  ///    `OTEL_EXPORTER_OTLP_INSECURE` "only applies to OTLP/gRPC when an
-  ///    endpoint is provided without the http or https scheme";
+  /// 1. the endpoint **scheme** decides when there is one: an `https` or
+  ///    `http` scheme "takes precedence over the `insecure` configuration
+  ///    setting";
+  /// 2. otherwise — a scheme-less endpoint such as `my-collector:4317`, the
+  ///    only case where the setting applies at all — an explicit
+  ///    programmatic choice ([explicitSecure]) wins, being the code
+  ///    equivalent of the environment variable;
   /// 3. otherwise `OTEL_EXPORTER_OTLP_INSECURE` (or its per-signal
   ///    variant, passed as [envInsecure]) applies;
   /// 4. otherwise [fallback] (secure by default).
+  ///
+  /// Note that the setting is meaningful only for OTLP/gRPC: OTLP/HTTP
+  /// always takes its security from the endpoint scheme.
   ///
   /// Bare `host:port` endpoints parse with a bogus scheme (`host`), so
   /// only exact `http`/`https` schemes participate in step 2.
@@ -698,9 +703,10 @@ class OTelEnv {
     String? endpoint,
     bool fallback = true,
   }) {
-    if (explicitSecure != null) {
-      return explicitSecure;
-    }
+    // The endpoint scheme outranks the insecure setting from either
+    // channel: "A scheme of https indicates a secure connection and takes
+    // precedence over the insecure configuration setting" (and likewise
+    // for http) - protocol/exporter.md, Endpoint (OTLP/gRPC).
     final scheme =
         endpoint == null ? null : Uri.tryParse(endpoint)?.scheme.toLowerCase();
     if (scheme == 'http') {
@@ -708,6 +714,13 @@ class OTelEnv {
     }
     if (scheme == 'https') {
       return true;
+    }
+    // Scheme-less endpoint: the insecure setting decides. The programmatic
+    // choice is the code equivalent of OTEL_EXPORTER_OTLP_INSECURE and wins
+    // over it, per "The environment-based configuration MUST have a direct
+    // code configuration equivalent" - configuration/sdk-environment-variables.md.
+    if (explicitSecure != null) {
+      return explicitSecure;
     }
     if (envInsecure != null) {
       return !envInsecure;

--- a/lib/src/environment/otel_env.dart
+++ b/lib/src/environment/otel_env.dart
@@ -681,13 +681,14 @@ class OTelEnv {
   /// Resolves whether an OTLP connection should use TLS, per the OTLP
   /// exporter spec's precedence:
   ///
-  /// 1. the endpoint **scheme** decides when there is one: an `https` or
-  ///    `http` scheme "takes precedence over the `insecure` configuration
-  ///    setting";
-  /// 2. otherwise — a scheme-less endpoint such as `my-collector:4317`, the
-  ///    only case where the setting applies at all — an explicit
-  ///    programmatic choice ([explicitSecure]) wins, being the code
-  ///    equivalent of the environment variable;
+  /// 1. if [endpoint] carries an `http://` or `https://` scheme, that scheme
+  ///    alone decides — the spec says a scheme "takes precedence over the
+  ///    `insecure` configuration setting", from either channel;
+  /// 2. otherwise the endpoint is scheme-less (gRPC's native
+  ///    `my-collector:4317` form), which is the only case where the insecure
+  ///    setting applies at all. There, an explicit programmatic choice
+  ///    ([explicitSecure]) wins, being the code equivalent of the
+  ///    environment variable;
   /// 3. otherwise `OTEL_EXPORTER_OTLP_INSECURE` (or its per-signal
   ///    variant, passed as [envInsecure]) applies;
   /// 4. otherwise [fallback] (secure by default).

--- a/lib/src/logs/export/logs_config.dart
+++ b/lib/src/logs/export/logs_config.dart
@@ -38,7 +38,7 @@ class LogsConfiguration {
   /// @return The configured LoggerProvider
   static LoggerProvider configureLoggerProvider({
     String? endpoint,
-    bool secure = false,
+    bool? secure,
     LogRecordExporter? logRecordExporter,
     LogRecordProcessor? logRecordProcessor,
     Resource? resource,
@@ -121,7 +121,7 @@ class LogsConfiguration {
   static LogRecordExporter? _createExporter(
     String exporterType,
     String? endpoint,
-    bool secure,
+    bool? secure,
   ) {
     // Get OTLP config for logs signal
     final otlpConfig = OTelEnv.getOtlpConfig(signal: 'logs');
@@ -137,7 +137,7 @@ class LogsConfiguration {
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: envInsecure,
       endpoint: effectiveEndpoint,
-      fallback: secure,
+      explicitSecure: secure,
     );
 
     if (exporterType == 'console') {

--- a/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
+++ b/lib/src/logs/export/otlp/otlp_grpc_log_record_exporter.dart
@@ -7,6 +7,7 @@ import 'dart:math';
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
     show OTelLog;
 import 'package:grpc/grpc.dart';
+import 'package:meta/meta.dart';
 
 import '../../../../proto/opentelemetry_proto_dart.dart' as proto;
 import '../../../export/otlp_user_agent.dart';
@@ -31,6 +32,11 @@ class OtlpGrpcLogRecordExporter implements LogRecordExporter {
   ];
 
   final OtlpGrpcLogRecordExporterConfig _config;
+
+  /// The configuration this exporter was created with. Exposed for
+  /// tests asserting the resolved connection security (#253).
+  @visibleForTesting
+  OtlpGrpcLogRecordExporterConfig get config => _config;
   ClientChannel? _channel;
   proto.LogsServiceClient? _logsService;
   bool _isShutdown = false;

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -35,7 +35,7 @@ class MetricsConfiguration {
   /// `OTel.defaultEndpoint` for the HTTP protocols.
   static MeterProvider configureMeterProvider({
     String? endpoint,
-    bool secure = false,
+    bool? secure,
     MetricExporter? metricExporter,
     MetricReader? metricReader,
     Resource? resource,
@@ -126,7 +126,7 @@ class MetricsConfiguration {
   static MetricExporter? _createExporter(
     String exporterType,
     String? endpoint,
-    bool secure,
+    bool? secure,
   ) {
     if (exporterType == 'console') {
       if (OTelLog.isDebug()) {
@@ -155,7 +155,7 @@ class MetricsConfiguration {
     final effectiveSecure = OTelEnv.resolveOtlpSecure(
       envInsecure: otlpConfig.insecure,
       endpoint: effectiveEndpoint,
-      fallback: secure,
+      explicitSecure: secure,
     );
     final headers = otlpConfig.headers ?? const {};
     final timeout = otlpConfig.timeout ?? const Duration(seconds: 10);

--- a/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
+++ b/lib/src/metrics/export/otlp/otlp_grpc_metric_exporter.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:grpc/grpc.dart';
+import 'package:meta/meta.dart';
 
 import '../../../../dartastic_opentelemetry.dart';
 import '../../../../proto/collector/metrics/v1/metrics_service.pbgrpc.dart';
@@ -14,14 +15,19 @@ import 'metric_transformer.dart';
 /// OtlpGrpcMetricExporter exports metrics to the OpenTelemetry collector via gRPC.
 class OtlpGrpcMetricExporter implements MetricExporter {
   final MetricsServiceClient _client;
+
+  /// The configuration this exporter was created with. Exposed for
+  /// tests asserting the resolved connection security (#253).
+  @visibleForTesting
+  final OtlpGrpcMetricExporterConfig config;
+
   bool _shutdown = false;
 
   // Static channel reference to allow shutdown
   static late ClientChannel _channel;
 
   /// Creates a new OtlpGrpcMetricExporter with the given configuration.
-  OtlpGrpcMetricExporter(OtlpGrpcMetricExporterConfig config)
-      : _client = _createClient(config);
+  OtlpGrpcMetricExporter(this.config) : _client = _createClient(config);
 
   /// Creates channel credentials based on configuration.
   ///

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -182,6 +182,11 @@ class OTel {
     final envInsecure = secure == null ? otlpConfig?.insecure : null;
 
     endpoint ??= envEndpoint;
+    // Keep the caller's explicit choice (null when not given): the
+    // metrics/logs configurations resolve security against their own
+    // per-signal endpoints and env vars, so they must receive the
+    // original parameter rather than the traces-resolved value (#253).
+    final explicitSecure = secure;
     secure = OTelEnv.resolveOtlpSecure(
       explicitSecure: secure,
       envInsecure: envInsecure,
@@ -480,14 +485,14 @@ class OTel {
       if (metricExporter == null && metricReader == null) {
         MetricsConfiguration.configureMeterProvider(
           endpoint: endpoint,
-          secure: secure,
+          secure: explicitSecure,
           resource: OTel.defaultResource,
         );
       } else {
         // Use the provided exporter and/or reader
         MetricsConfiguration.configureMeterProvider(
           endpoint: endpoint,
-          secure: secure,
+          secure: explicitSecure,
           metricExporter: metricExporter,
           metricReader: metricReader,
           resource: OTel.defaultResource,
@@ -499,7 +504,7 @@ class OTel {
     if (enableLogs && !sdkDisabled) {
       LogsConfiguration.configureLoggerProvider(
         endpoint: endpoint,
-        secure: secure,
+        secure: explicitSecure,
         logRecordExporter: logRecordExporter,
         logRecordProcessor: logRecordProcessor,
         resource: OTel.defaultResource,

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -100,7 +100,30 @@ class OTel {
   /// It sets up the global configuration and installs the SDK implementation.
   ///
   /// @param endpoint The endpoint URL for the OpenTelemetry collector (default: http://localhost:4318)
-  /// @param secure Whether to use TLS for the connection (default: true)
+  /// @param secure Transport security for OTLP/gRPC when the endpoint carries
+  ///   no scheme. This is the code equivalent of `OTEL_EXPORTER_OTLP_INSECURE`
+  ///   (inverted - `secure: true` means `insecure=false`) and takes precedence
+  ///   over it, per the spec rule that every environment variable has a direct
+  ///   code configuration equivalent.
+  ///
+  ///   The option is deliberately narrow, per the OTLP exporter specification
+  ///   (`protocol/exporter.md`, "Insecure"):
+  ///
+  ///   - **OTLP/HTTP ignores it entirely** - the endpoint's scheme always
+  ///     decides, so `https://host:4318` is TLS and `http://host:4318` is not.
+  ///   - **A scheme on the endpoint wins over this parameter.** The spec says
+  ///     an `https` or `http` scheme "takes precedence over the `insecure`
+  ///     configuration setting", so passing `secure: true` alongside
+  ///     `http://host:4317` does not produce TLS.
+  ///   - It therefore applies only to **OTLP/gRPC with a scheme-less
+  ///     endpoint**, such as `my-collector:4317` - the native gRPC form, and
+  ///     the one case where nothing else can express the choice.
+  ///
+  ///   Leave it null (the default) to let the endpoint scheme decide, then
+  ///   `OTEL_EXPORTER_OTLP_INSECURE`, then the spec default. That default is
+  ///   *secure*, but the default endpoint is `http://localhost:4317`, whose
+  ///   scheme wins - so an unconfigured SDK talks plaintext to a local
+  ///   collector, which is what you want for local development.
   /// @param serviceName Name that uniquely identifies the service (default: "@dart/dartastic_opentelemetry")
   /// @param serviceVersion Version of the service (defaults to the OTel spec version)
   /// @param tracerName Name of the default tracer (default: "dartastic")

--- a/test/unit/config_secure_param_test.dart
+++ b/test/unit/config_secure_param_test.dart
@@ -38,8 +38,10 @@ void main() {
         // Generic endpoint is plaintext, so the traces signal resolves
         // insecure...
         'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317',
-        // ...while the operator points logs at a TLS endpoint.
-        'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT': 'https://logs.example.com:4317',
+        // ...while logs point at a scheme-less host. No scheme means the
+        // insecure setting decides, and nothing set it - so logs must fall
+        // back to the spec default (secure), not inherit the traces answer.
+        'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT': 'logs.example.com:4317',
       };
 
       // No `secure:` argument, so nothing the caller said may override the
@@ -58,9 +60,10 @@ void main() {
       expect(
         exporter.config.insecure,
         isFalse,
-        reason: 'the logs endpoint is https, so the logs exporter must use '
-            'TLS; the traces signal resolving to insecure must not become '
-            "the logs signal's explicit choice",
+        reason: 'the logs endpoint carries no scheme and nothing chose '
+            'insecure for it, so it takes the secure default; the traces '
+            'signal resolving to insecure must not become the logs '
+            "signal's explicit choice",
       );
     });
   });
@@ -160,9 +163,7 @@ void main() {
         expect(exporter.config.insecure, isFalse);
       });
 
-      test(
-          'an explicit secure: true currently outranks an http scheme '
-          '(see #225)', () {
+      test('an http scheme outranks an explicit secure: true (#225)', () {
         EnvironmentService.testOverrides = {
           'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
         };
@@ -170,11 +171,11 @@ void main() {
           endpoint: 'http://localhost:4317',
           secure: true,
         );
-        expect(exporter.config.insecure, isFalse,
-            reason: 'resolveOtlpSecure returns the explicit parameter '
-                'before consulting the scheme. #225 tracks making the '
-                'endpoint scheme decisive at the gRPC exporter layer, '
-                'which will invert this expectation.');
+        expect(exporter.config.insecure, isTrue,
+            reason: 'protocol/exporter.md: an http scheme "takes precedence '
+                'over the insecure configuration setting", so a '
+                'scheme-carrying endpoint is not overridable by the '
+                'parameter');
       });
     });
 

--- a/test/unit/config_secure_param_test.dart
+++ b/test/unit/config_secure_param_test.dart
@@ -1,0 +1,225 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for #253: the programmatic `secure` parameter of
+// MetricsConfiguration.configureMeterProvider and
+// LogsConfiguration.configureLoggerProvider takes effect with the
+// same precedence as OTel.initialize's parameter: a non-null value is
+// the explicit choice and wins over OTEL_EXPORTER_OTLP_INSECURE; null
+// defers to the endpoint scheme, then the env var, then insecure.
+// The endpoint scheme still decides at the gRPC exporter for
+// scheme-carrying endpoints, per the OTLP endpoint rule (#225).
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // The regression that makes this fix load-bearing: OTel.initialize
+  // resolves `secure` for the traces signal and reassigns its own
+  // parameter to that boolean. If that resolved value is handed to the
+  // metrics/logs configurations as their *explicit* choice, it outranks
+  // their own per-signal endpoint scheme - silently turning TLS off for a
+  // signal the operator pointed at an https endpoint.
+  group('OTel.initialize does not leak the traces decision (#253)', () {
+    setUp(() async {
+      await OTel.reset();
+    });
+
+    tearDown(() async {
+      EnvironmentService.testOverrides = null;
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    test('an https logs endpoint keeps TLS when traces resolve insecure',
+        () async {
+      EnvironmentService.testOverrides = {
+        'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+        // Generic endpoint is plaintext, so the traces signal resolves
+        // insecure...
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317',
+        // ...while the operator points logs at a TLS endpoint.
+        'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT': 'https://logs.example.com:4317',
+      };
+
+      // No `secure:` argument, so nothing the caller said may override the
+      // per-signal scheme.
+      await OTel.initialize(
+        serviceName: 'secure-initialize-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+      );
+
+      final provider = OTel.loggerProvider();
+      final processor =
+          provider.logRecordProcessors.last as BatchLogRecordProcessor;
+      final exporter = processor.exporter as OtlpGrpcLogRecordExporter;
+
+      expect(
+        exporter.config.insecure,
+        isFalse,
+        reason: 'the logs endpoint is https, so the logs exporter must use '
+            'TLS; the traces signal resolving to insecure must not become '
+            "the logs signal's explicit choice",
+      );
+    });
+  });
+  group('programmatic secure parameter precedence (#253)', () {
+    setUp(() async {
+      await OTel.reset();
+      await OTel.initialize(
+        serviceName: 'secure-param-test',
+        detectPlatformResources: false,
+        enableMetrics: false,
+        enableLogs: false,
+      );
+    });
+
+    tearDown(() async {
+      EnvironmentService.testOverrides = null;
+      await OTel.shutdown();
+      await OTel.reset();
+    });
+
+    OtlpGrpcMetricExporter metricsExporter({
+      required String endpoint,
+      bool? secure,
+    }) {
+      final provider = MetricsConfiguration.configureMeterProvider(
+        endpoint: endpoint,
+        secure: secure,
+      );
+      final reader =
+          provider.metricReaders.last as PeriodicExportingMetricReader;
+      return reader.exporter as OtlpGrpcMetricExporter;
+    }
+
+    OtlpGrpcLogRecordExporter logsExporter({
+      required String endpoint,
+      bool? secure,
+    }) {
+      final provider = LogsConfiguration.configureLoggerProvider(
+        endpoint: endpoint,
+        secure: secure,
+      );
+      final processor =
+          provider.logRecordProcessors.last as BatchLogRecordProcessor;
+      return processor.exporter as OtlpGrpcLogRecordExporter;
+    }
+
+    group('metrics', () {
+      test(
+          'secure: true beats OTEL_EXPORTER_OTLP_INSECURE on a '
+          'scheme-less endpoint', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_INSECURE': 'true',
+        };
+        final exporter =
+            metricsExporter(endpoint: 'localhost:4317', secure: true);
+        expect(exporter.config.insecure, isFalse,
+            reason: 'the explicit programmatic choice must win over env');
+      });
+
+      test(
+          'secure: false beats an env demand for TLS on a scheme-less '
+          'endpoint', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_INSECURE': 'false',
+        };
+        final exporter =
+            metricsExporter(endpoint: 'localhost:4317', secure: false);
+        expect(exporter.config.insecure, isTrue);
+      });
+
+      test('null defers to OTEL_EXPORTER_OTLP_INSECURE', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_INSECURE': 'false',
+        };
+        final exporter = metricsExporter(endpoint: 'localhost:4317');
+        expect(exporter.config.insecure, isFalse);
+      });
+
+      test('null with no scheme and no env falls back to TLS', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+        };
+        final exporter = metricsExporter(endpoint: 'localhost:4317');
+        expect(exporter.config.insecure, isFalse,
+            reason: 'resolveOtlpSecure falls back to secure when neither a '
+                'scheme, an env var, nor the parameter decides');
+      });
+
+      test('an https scheme yields TLS without any parameter', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+        };
+        final exporter = metricsExporter(endpoint: 'https://collector:4317');
+        expect(exporter.config.insecure, isFalse);
+      });
+
+      test(
+          'an explicit secure: true currently outranks an http scheme '
+          '(see #225)', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+        };
+        final exporter = metricsExporter(
+          endpoint: 'http://localhost:4317',
+          secure: true,
+        );
+        expect(exporter.config.insecure, isFalse,
+            reason: 'resolveOtlpSecure returns the explicit parameter '
+                'before consulting the scheme. #225 tracks making the '
+                'endpoint scheme decisive at the gRPC exporter layer, '
+                'which will invert this expectation.');
+      });
+    });
+
+    group('logs', () {
+      test(
+          'secure: true beats OTEL_EXPORTER_OTLP_INSECURE on a '
+          'scheme-less endpoint', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_INSECURE': 'true',
+        };
+        final exporter = logsExporter(endpoint: 'localhost:4317', secure: true);
+        expect(exporter.config.insecure, isFalse);
+      });
+
+      test(
+          'secure: false beats an env demand for TLS on a scheme-less '
+          'endpoint', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_INSECURE': 'false',
+        };
+        final exporter =
+            logsExporter(endpoint: 'localhost:4317', secure: false);
+        expect(exporter.config.insecure, isTrue);
+      });
+
+      test('null defers to OTEL_EXPORTER_OTLP_INSECURE', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+          'OTEL_EXPORTER_OTLP_INSECURE': 'false',
+        };
+        final exporter = logsExporter(endpoint: 'localhost:4317');
+        expect(exporter.config.insecure, isFalse);
+      });
+
+      test('null with no scheme and no env falls back to TLS', () {
+        EnvironmentService.testOverrides = {
+          'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+        };
+        final exporter = logsExporter(endpoint: 'localhost:4317');
+        expect(exporter.config.insecure, isFalse,
+            reason: 'resolveOtlpSecure falls back to secure when neither a '
+                'scheme, an env var, nor the parameter decides');
+      });
+    });
+  });
+}

--- a/test/unit/environment/resolve_otlp_secure_test.dart
+++ b/test/unit/environment/resolve_otlp_secure_test.dart
@@ -11,21 +11,54 @@ import 'package:test/test.dart';
 
 void main() {
   group('OTelEnv.resolveOtlpSecure', () {
-    test('explicit choice wins over everything', () {
+    test('a scheme outranks an explicit choice (#225)', () {
+      // protocol/exporter.md, Endpoint (OTLP/gRPC): an https scheme
+      // "indicates a secure connection and takes precedence over the
+      // insecure configuration setting", and likewise http for insecure.
+      // The setting - from either the parameter or the environment - only
+      // applies to a scheme-less endpoint.
+      //
+      // This inverts the expectation originally pinned in #89, which had
+      // the explicit parameter winning over the scheme.
       expect(
         OTelEnv.resolveOtlpSecure(
           explicitSecure: true,
           envInsecure: true,
           endpoint: 'http://collector:4317',
         ),
-        isTrue,
+        isFalse,
+        reason: 'an http scheme means plaintext even when asked for TLS',
       );
       expect(
         OTelEnv.resolveOtlpSecure(
           explicitSecure: false,
           endpoint: 'https://collector:4317',
         ),
+        isTrue,
+        reason: 'an https scheme means TLS even when asked for plaintext',
+      );
+    });
+
+    test('the explicit choice decides for a scheme-less endpoint', () {
+      // The window where the setting actually applies: gRPC's native
+      // host:port form. Here the parameter beats the environment, being
+      // the code equivalent of OTEL_EXPORTER_OTLP_INSECURE.
+      expect(
+        OTelEnv.resolveOtlpSecure(
+          explicitSecure: false,
+          envInsecure: false,
+          endpoint: 'collector:4317',
+        ),
         isFalse,
+        reason: 'code beats env',
+      );
+      expect(
+        OTelEnv.resolveOtlpSecure(
+          explicitSecure: true,
+          envInsecure: true,
+          endpoint: 'collector:4317',
+        ),
+        isTrue,
       );
     });
 


### PR DESCRIPTION
## Summary

Fixes #253. Supersedes #265, which diagnosed the bug correctly and had the right shape for the config layer, but landing only that half turns the fix into a TLS-disabling regression — see below.

`LogsConfiguration.configureLoggerProvider` and `MetricsConfiguration.configureMeterProvider` declared `bool secure = false` and passed it to `resolveOtlpSecure` as `fallback:` — the *lowest* precedence input. Since both default endpoints carry a scheme, the scheme always decided and the parameter was a silent no-op.

They now take `bool? secure`, passed as `explicitSecure:`: a non-null value is the caller's explicit choice and outranks `OTEL_EXPORTER_OTLP_INSECURE`; `null` (the default) defers to the endpoint scheme, then the environment, then the built-in default.

## The half that makes it safe

`OTel.initialize` resolves `secure` for the traces signal and **reassigns its own parameter** to that boolean before passing it down to the metrics and logs configurations. Promoting the configs' argument from `fallback` to `explicitSecure` without also forwarding the caller's *original* value hands a traces-derived decision to the other signals as though the user had demanded it — and `explicitSecure` outranks the endpoint scheme.

Concretely, with:

```
OTEL_EXPORTER_OTLP_PROTOCOL=grpc
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs.example.com:4317
```

traces resolve insecure from the plaintext generic endpoint, that `false` arrives at the logs configuration as an explicit choice, and the logs exporter is built with `insecure: true` — **plaintext gRPC to an `https://` endpoint**, with no warning. `initialize` now forwards the caller's original (possibly null) value; the traces path resolves exactly as before.

## Testing

`test/unit/config_secure_param_test.dart` covers the precedence matrix per signal (explicit true/false vs env vs scheme vs default) plus that regression through the public `initialize` path. The two gRPC exporters expose their config behind `@visibleForTesting` so the assertions can read the resolved connection security.

Verified by mutation rather than by green alone: reverting just the `initialize` half fails the regression test with `insecure: true` against the https endpoint, and the rest of the suite stays green — which is precisely the state #265 would have merged in.

Full `test/unit` suite passes (2123); `dart analyze` and `dart format` clean.

## Notes for review

- One test documents that an explicit `secure: true` currently outranks an `http://` scheme. #225 tracks making the endpoint scheme decisive at the gRPC exporter layer, which will invert that expectation — the test says so, so whoever lands #225 finds it.
- Credit to @abidiahmedcom for the diagnosis in #265: the root-cause write-up there is accurate, and the `bool? secure` + `explicitSecure` shape is what this uses.

Assisted-by: Claude Fable 5


## On reversing #89

This inverts an expectation deliberately pinned in [#89](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/pull/89) — a test named *"explicit choice wins over everything"*, asserting that a programmatic `secure` outranks the endpoint scheme. `protocol/exporter.md` says the opposite:

> A scheme of `https` indicates a secure connection and **takes precedence over the `insecure` configuration setting**. A scheme of `http` indicates an insecure connection and takes precedence over the `insecure` configuration setting.

and scopes the setting to "OTLP/gRPC when an endpoint is provided without the `http` or `https` scheme". #89 made the scheme beat the *environment variable* but left the programmatic parameter above it; this completes that change. The old test now asserts the spec rule, with a companion pinning that the parameter still beats the environment for scheme-less endpoints — the window where it applies at all.

Reviewed and confirmed by the maintainer before merging.
