### PR TITLE
fix(propagation): correct W3C traceparent parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0-beta.15-wip]
 
+### Fixed
+
+- **`traceparent` parsing now follows W3C Trace Context Level 2** (#192, #193,
+  #194). Higher versions from `01` through `fe` are parsed using the version
+  `00` field layout and may carry trailing fields, while version `00` retains
+  its strict grammar. Version, trace ID, parent ID, and trace flags now require
+  fixed-width lowercase hexadecimal syntax, preventing malformed identifiers
+  from being accepted and invalid flags from being coerced to unsampled.
+
 ## [1.1.0-beta.14] - 2026-08-23
 
 ### Changed

--- a/lib/src/trace/w3c_trace_context_propagator.dart
+++ b/lib/src/trace/w3c_trace_context_propagator.dart
@@ -29,11 +29,34 @@ class W3CTraceContextPropagator
   /// The standard header name for W3C trace state
   static const _tracestateHeader = 'tracestate';
 
-  /// The current version of the W3C Trace Context specification
+  /// The highest traceparent version this propagator understands, and the
+  /// version it emits. Per the spec's versioning rules, higher versions are
+  /// parsed using this version's field layout.
   static const _version = '00';
 
-  /// The length of a valid traceparent header value
+  /// The version reserved as invalid by the specification.
+  static const _forbiddenVersion = 'ff';
+
+  static const _versionLength = 2;
+  static const _traceIdLength = 32;
+  static const _spanIdLength = 16;
+  static const _traceFlagsLength = 2;
+
+  /// Field offsets, applied to every version. The spec assumes future versions
+  /// will be additive to version 00, and on that basis defines the parse of a
+  /// higher version as reading these same positions.
+  static const _traceIdOffset = _versionLength + 1;
+  static const _spanIdOffset = _traceIdOffset + _traceIdLength + 1;
+  static const _traceFlagsOffset = _spanIdOffset + _spanIdLength + 1;
+
+  /// The exact length of a version 00 traceparent, and the minimum length of
+  /// any traceparent.
   static const _traceparentLength = 55; // 00-{32}-{16}-{2}
+
+  /// The specification's grammar allows lowercase hex only.
+  static final _hexPairPattern = RegExp(r'^[0-9a-f]{2}$');
+  static final _traceIdPattern = RegExp('^[0-9a-f]{$_traceIdLength}\$');
+  static final _spanIdPattern = RegExp('^[0-9a-f]{$_spanIdLength}\$');
 
   @override
   Context extract(
@@ -131,68 +154,108 @@ class W3CTraceContextPropagator
   /// The traceparent format is: version-traceId-spanId-traceFlags
   /// Example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
   ///
+  /// A version above [_version] may append further dash-delimited fields, which
+  /// are ignored. Version [_version] itself must carry no trailing data. Every
+  /// field must be lowercase hex, and version `ff` is always invalid.
+  ///
   /// Returns null if the format is invalid.
   SpanContext? _parseTraceparent(String traceparent) {
-    // Basic validation
-    if (traceparent.length != _traceparentLength) {
+    if (traceparent.length < _traceparentLength) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-          'Invalid traceparent length: ${traceparent.length}, expected $_traceparentLength',
+          'Invalid traceparent length: ${traceparent.length}, expected at least $_traceparentLength',
         );
       }
       return null;
     }
 
-    final parts = traceparent.split('-');
-    if (parts.length != 4) {
+    if (traceparent[_traceIdOffset - 1] != '-' ||
+        traceparent[_spanIdOffset - 1] != '-' ||
+        traceparent[_traceFlagsOffset - 1] != '-') {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug('Invalid traceparent format: misplaced delimiters');
+      }
+      return null;
+    }
+
+    final version = traceparent.substring(0, _versionLength);
+    if (!_hexPairPattern.hasMatch(version)) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-          'Invalid traceparent format: expected 4 parts, got ${parts.length}',
+          'Invalid traceparent version, expected only 0-9 and a-f: $version',
         );
       }
       return null;
     }
 
-    final version = parts[0];
-    final traceIdHex = parts[1];
-    final spanIdHex = parts[2];
-    final traceFlagsHex = parts[3];
-
-    // Validate version (currently only 00 is supported)
-    if (version != _version) {
-      if (OTelLog.isDebug()) {
-        OTelLog.debug('Unsupported traceparent version: $version');
-      }
-      // Per spec, we should still try to parse if version is unknown
-      // but for now we'll reject it
-      return null;
-    }
-
-    // Validate trace ID length (32 hex chars = 16 bytes)
-    if (traceIdHex.length != 32) {
+    if (version == _forbiddenVersion) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-          'Invalid trace ID length: ${traceIdHex.length}, expected 32',
+          'Invalid traceparent version: $_forbiddenVersion is reserved as invalid',
         );
       }
       return null;
     }
 
-    // Validate span ID length (16 hex chars = 8 bytes)
-    if (spanIdHex.length != 16) {
+    // Version 00 has a closed grammar, so trailing data makes it malformed. A
+    // higher version may append dash-delimited fields, which this propagator
+    // must tolerate and ignore.
+    if (version == _version) {
+      if (traceparent.length != _traceparentLength) {
+        if (OTelLog.isDebug()) {
+          OTelLog.debug(
+            'Version $_version traceparent must be exactly $_traceparentLength characters, got ${traceparent.length}',
+          );
+        }
+        return null;
+      }
+    } else if (traceparent.length > _traceparentLength &&
+        traceparent[_traceparentLength] != '-') {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-          'Invalid span ID length: ${spanIdHex.length}, expected 16',
+          'Invalid traceparent: trace flags must end the header or be followed by a dash',
         );
       }
       return null;
     }
 
-    // Validate trace flags length (2 hex chars = 1 byte)
-    if (traceFlagsHex.length != 2) {
+    final traceIdHex = traceparent.substring(
+      _traceIdOffset,
+      _traceIdOffset + _traceIdLength,
+    );
+    final spanIdHex = traceparent.substring(
+      _spanIdOffset,
+      _spanIdOffset + _spanIdLength,
+    );
+    final traceFlagsHex = traceparent.substring(
+      _traceFlagsOffset,
+      _traceFlagsOffset + _traceFlagsLength,
+    );
+
+    // Not left to the ID and flag factories: they use int.tryParse, which
+    // accepts uppercase, signs and leading whitespace ('-1' wraps to 255).
+    if (!_traceIdPattern.hasMatch(traceIdHex)) {
       if (OTelLog.isDebug()) {
         OTelLog.debug(
-          'Invalid trace flags length: ${traceFlagsHex.length}, expected 2',
+          'Invalid trace ID, expected only 0-9 and a-f: $traceIdHex',
+        );
+      }
+      return null;
+    }
+
+    if (!_spanIdPattern.hasMatch(spanIdHex)) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+          'Invalid span ID, expected only 0-9 and a-f: $spanIdHex',
+        );
+      }
+      return null;
+    }
+
+    if (!_hexPairPattern.hasMatch(traceFlagsHex)) {
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+          'Invalid trace flags, expected only 0-9 and a-f: $traceFlagsHex',
         );
       }
       return null;

--- a/test/unit/infrastructure_coverage_test.dart
+++ b/test/unit/infrastructure_coverage_test.dart
@@ -125,11 +125,12 @@ void main() {
       );
     });
 
-    test('extract with invalid traceparent format logs debug', () {
-      // Correct total length (55) but wrong version to trigger version mismatch log.
+    test('extract with forbidden version logs debug', () {
+      // Correct total length (55) but version ff, which the spec forbids.
+      // A higher version such as 01 is parsed, not rejected.
       final carrier = {
         'traceparent':
-            '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+            'ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
       };
       logOutput.clear();
       final extracted = propagator.extract(
@@ -140,9 +141,39 @@ void main() {
 
       expect(extracted.spanContext, isNull);
       expect(
-        logOutput.any((m) => m.contains('Unsupported traceparent version')),
+        logOutput.any(
+          (m) =>
+              m.contains('Invalid traceparent version') &&
+              m.contains('reserved'),
+        ),
         isTrue,
-        reason: 'Expected debug log about unsupported version',
+        reason: 'ff is valid hex, so the log must cite the reserved version '
+            'rather than the character set',
+      );
+    });
+
+    test('extract with a non-hex version logs debug', () {
+      final carrier = {
+        'traceparent':
+            'zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      };
+      logOutput.clear();
+      final extracted = propagator.extract(
+        OTel.context(),
+        carrier,
+        _MapGetter(carrier),
+      );
+
+      expect(extracted.spanContext, isNull);
+      expect(
+        logOutput.any(
+          (m) =>
+              m.contains('Invalid traceparent version') &&
+              m.contains('0-9 and a-f'),
+        ),
+        isTrue,
+        reason: 'A non-hex version must cite the character set rather than '
+            'the reserved version',
       );
     });
 
@@ -335,8 +366,7 @@ void main() {
 
     test('extract with invalid traceparent logs "Invalid traceparent format"',
         () {
-      // Force a traceparent that is exactly 55 chars but has no '-' separators,
-      // so split('-') yields only 1 part instead of 4.
+      // Correct total length, but no delimiters at the required offsets.
       final bogus = 'X' * 55;
       final carrier = {'traceparent': bogus};
       logOutput.clear();
@@ -344,15 +374,12 @@ void main() {
 
       expect(
         logOutput.any(
-          (m) =>
-              m.contains('Invalid traceparent format') ||
-              m.contains('Invalid trace ID length') ||
-              m.contains('Invalid span ID length') ||
-              m.contains('Invalid trace flags length'),
+          (m) => m.contains(
+            'Invalid traceparent format: misplaced delimiters',
+          ),
         ),
         isTrue,
-        reason:
-            'Expected some validation debug log for the malformed traceparent',
+        reason: 'Expected the misplaced-delimiter validation log',
       );
     });
   });

--- a/test/unit/trace/w3c_trace_context_propagator_contract_test.dart
+++ b/test/unit/trace/w3c_trace_context_propagator_contract_test.dart
@@ -1,0 +1,317 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+/// W3C Trace Context Level 2 conformance tests for traceparent parsing.
+///
+/// Covers three spec deviations:
+/// - #192 a higher traceparent version must be parsed, not rejected (§3.2.4)
+/// - #193 trace-id and span-id are lowercase hex only (§3.2.2.3, §3.2.2.4)
+/// - #194 malformed trace-flags invalidate the header (§3.2.2.5)
+void main() {
+  const traceIdHex = '4bf92f3577b34da6a3ce929d0e0e4736';
+  const spanIdHex = '00f067aa0ba902b7';
+
+  late W3CTraceContextPropagator propagator;
+
+  setUpAll(() async {
+    await OTel.initialize(
+      serviceName: 'test-service',
+      endpoint: 'http://localhost:4317',
+      detectPlatformResources: false,
+    );
+  });
+
+  setUp(() {
+    propagator = W3CTraceContextPropagator();
+  });
+
+  tearDownAll(() async {
+    await OTel.reset();
+  });
+
+  /// Extracts [traceparent] and returns the resulting SpanContext, or null when
+  /// the header was rejected and the incoming Context was returned untouched.
+  SpanContext? extract(String traceparent) {
+    final carrier = {'traceparent': traceparent};
+    return propagator
+        .extract(OTel.context(), carrier, _MapGetter(carrier))
+        .spanContext;
+  }
+
+  group('W3CTraceContextPropagator contract', () {
+    group('traceparent version handling', () {
+      test('accepts a higher version with the version 00 field layout', () {
+        final spanContext = extract('01-$traceIdHex-$spanIdHex-01');
+
+        expect(spanContext, isNotNull);
+        expect(spanContext!.traceId.hexString, equals(traceIdHex));
+        expect(spanContext.spanId.hexString, equals(spanIdHex));
+        expect(spanContext.traceFlags.isSampled, isTrue);
+        expect(spanContext.isRemote, isTrue);
+      });
+
+      test('injects an extracted higher version as version 00', () {
+        final incoming = {
+          'traceparent': '01-$traceIdHex-$spanIdHex-01-extradata',
+        };
+        final context = propagator.extract(
+          OTel.context(),
+          incoming,
+          _MapGetter(incoming),
+        );
+        final outgoing = <String, String>{};
+
+        propagator.inject(context, outgoing, _MapSetter(outgoing));
+
+        expect(
+          outgoing['traceparent'],
+          equals('00-$traceIdHex-$spanIdHex-01'),
+        );
+      });
+
+      test('accepts the version cc example from the issue report', () {
+        expect(
+          extract('cc-$traceIdHex-$spanIdHex-01')?.traceId.hexString,
+          equals(traceIdHex),
+        );
+      });
+
+      test('accepts fe, the highest legal version', () {
+        expect(extract('fe-$traceIdHex-$spanIdHex-01'), isNotNull);
+      });
+
+      test('accepts a higher version carrying one additive field', () {
+        final spanContext = extract('01-$traceIdHex-$spanIdHex-01-extradata');
+
+        expect(spanContext, isNotNull);
+        expect(spanContext!.traceId.hexString, equals(traceIdHex));
+        expect(spanContext.spanId.hexString, equals(spanIdHex));
+        expect(spanContext.traceFlags.isSampled, isTrue);
+      });
+
+      test('accepts a higher version carrying several additive fields', () {
+        expect(
+          extract('01-$traceIdHex-$spanIdHex-01-aa-bb-cc')?.traceId.hexString,
+          equals(traceIdHex),
+        );
+      });
+
+      test('accepts a higher version whose additive field is empty', () {
+        // §3.2.4 requires the flags to be at the end of the string or followed by
+        // a dash. Java, Go and JS all accept a bare trailing dash.
+        expect(extract('01-$traceIdHex-$spanIdHex-01-'), isNotNull);
+      });
+
+      test('parses tracestate alongside a higher-version traceparent', () {
+        // §3.3.5: tracestate must still be attempted for a higher version.
+        final carrier = {
+          'traceparent': '01-$traceIdHex-$spanIdHex-01-extradata',
+          'tracestate': 'rojo=00f067aa0ba902b7',
+        };
+
+        final spanContext = propagator
+            .extract(OTel.context(), carrier, _MapGetter(carrier))
+            .spanContext;
+
+        expect(spanContext, isNotNull);
+        expect(
+          spanContext!.traceState?.entries['rojo'],
+          equals('00f067aa0ba902b7'),
+        );
+      });
+
+      test('rejects version ff', () {
+        expect(extract('ff-$traceIdHex-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects a version 00 header carrying additive fields', () {
+        // §3.2.2.2 closes the version 00 grammar, so trailing data is malformed.
+        expect(extract('00-$traceIdHex-$spanIdHex-01-extradata'), isNull);
+      });
+
+      test('rejects a higher version whose flags are not followed by a dash',
+          () {
+        expect(extract('01-$traceIdHex-$spanIdHex-01x'), isNull);
+      });
+
+      test('rejects a higher version shorter than 55 characters', () {
+        expect(extract('01-$traceIdHex-$spanIdHex-0'), isNull);
+      });
+
+      test('rejects a non-hex version', () {
+        expect(extract('zz-$traceIdHex-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects an uppercase version', () {
+        expect(extract('0A-$traceIdHex-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects a single-character version', () {
+        expect(extract('0-$traceIdHex-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects a header whose delimiters are misplaced', () {
+        expect(extract('01_$traceIdHex-$spanIdHex-01'), isNull);
+      });
+    });
+
+    group('trace-id and span-id syntax', () {
+      test('rejects an uppercase trace-id', () {
+        expect(extract('00-${traceIdHex.toUpperCase()}-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects an uppercase span-id', () {
+        expect(extract('00-$traceIdHex-${spanIdHex.toUpperCase()}-01'), isNull);
+      });
+
+      test('rejects a signed trace-id', () {
+        // int.tryParse('+b', radix: 16) returns 11, which silently rewrote the
+        // first byte to 0x0b instead of rejecting the header.
+        expect(
+          extract('00-+bf92f3577b34da6a3ce929d0e0e4736-$spanIdHex-01'),
+          isNull,
+        );
+      });
+
+      test('rejects a negative-signed trace-id', () {
+        // A '-' keeps the delimiters at their expected offsets, so this reaches
+        // the field check. int.tryParse('-b', radix: 16) returns -11, which wraps
+        // to 245 in a Uint8List and corrupted the trace ID rather than failing.
+        final signed = traceIdHex.replaceRange(0, 1, '-');
+
+        expect(signed.length, equals(32));
+        expect(extract('00-$signed-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects a signed span-id', () {
+        expect(extract('00-$traceIdHex-+0f067aa0ba902b7-01'), isNull);
+      });
+
+      test('rejects a non-hex trace-id', () {
+        expect(extract('00-${'z' * 32}-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects a non-hex span-id', () {
+        expect(extract('00-$traceIdHex-${'z' * 16}-01'), isNull);
+      });
+
+      test('rejects a space inside the trace-id', () {
+        final spaced = traceIdHex.replaceRange(30, 31, ' ');
+
+        expect(spaced.length, equals(32));
+        expect(extract('00-$spaced-$spanIdHex-01'), isNull);
+      });
+
+      test('applies lowercase hex validation above version 00 too', () {
+        expect(extract('01-${traceIdHex.toUpperCase()}-$spanIdHex-01'), isNull);
+      });
+    });
+
+    group('trace-flags syntax', () {
+      test('rejects non-hex trace-flags instead of coercing them to 00', () {
+        expect(extract('00-$traceIdHex-$spanIdHex-zz'), isNull);
+      });
+
+      test('rejects partially non-hex trace-flags', () {
+        expect(extract('00-$traceIdHex-$spanIdHex-0z'), isNull);
+      });
+
+      test('rejects signed trace-flags', () {
+        expect(extract('00-$traceIdHex-$spanIdHex-+1'), isNull);
+      });
+
+      test('rejects uppercase trace-flags', () {
+        expect(extract('00-$traceIdHex-$spanIdHex-0A'), isNull);
+      });
+
+      test('preserves every bit of a well-formed trace-flags byte', () {
+        // Pass-through, matching opentelemetry-java and opentelemetry-js. Masking
+        // to the flags this SDK models would drop the random-trace-id bit, which
+        // §3.2.2.5.2 requires to survive; TraceFlags gains that bit in #132.
+        final spanContext = extract('00-$traceIdHex-$spanIdHex-ff');
+
+        expect(spanContext, isNotNull);
+        expect(spanContext!.traceFlags.asByte, equals(0xff));
+        expect(spanContext.traceFlags.isSampled, isTrue);
+      });
+
+      test('preserves the random-trace-id bit without the sampled bit', () {
+        final spanContext = extract('00-$traceIdHex-$spanIdHex-02');
+
+        expect(spanContext, isNotNull);
+        expect(spanContext!.traceFlags.asByte, equals(0x02));
+        expect(spanContext.traceFlags.isSampled, isFalse);
+      });
+    });
+
+    group('baseline traceparent behavior', () {
+      test('accepts the canonical version 00 header', () {
+        final spanContext = extract('00-$traceIdHex-$spanIdHex-01');
+
+        expect(spanContext, isNotNull);
+        expect(spanContext!.traceId.hexString, equals(traceIdHex));
+        expect(spanContext.spanId.hexString, equals(spanIdHex));
+        expect(spanContext.traceFlags.isSampled, isTrue);
+      });
+
+      test('accepts an unsampled version 00 header', () {
+        expect(extract('00-$traceIdHex-$spanIdHex-00')?.traceFlags.isSampled,
+            isFalse);
+      });
+
+      test('rejects an all-zero trace-id', () {
+        expect(extract('00-${'0' * 32}-$spanIdHex-01'), isNull);
+      });
+
+      test('rejects an all-zero span-id', () {
+        expect(extract('00-$traceIdHex-${'0' * 16}-01'), isNull);
+      });
+
+      test('rejects a header truncated before the flags', () {
+        expect(extract('00-$traceIdHex-$spanIdHex'), isNull);
+      });
+
+      test('rejects an empty header', () {
+        expect(extract(''), isNull);
+      });
+
+      test('returns the incoming Context untouched when the header is rejected',
+          () {
+        final carrier = {'traceparent': 'ff-$traceIdHex-$spanIdHex-01'};
+        final context = OTel.context();
+
+        final extracted = propagator.extract(
+          context,
+          carrier,
+          _MapGetter(carrier),
+        );
+
+        expect(extracted, equals(context));
+      });
+    });
+  });
+}
+
+class _MapGetter implements TextMapGetter<String> {
+  final Map<String, String> _map;
+
+  _MapGetter(this._map);
+
+  @override
+  String? get(String key) => _map[key];
+
+  @override
+  Iterable<String> keys() => _map.keys;
+}
+
+class _MapSetter implements TextMapSetter<String> {
+  final Map<String, String> _map;
+
+  _MapSetter(this._map);
+
+  @override
+  void set(String key, String value) => _map[key] = value;
+}

--- a/test/unit/trace/w3c_trace_context_propagator_test.dart
+++ b/test/unit/trace/w3c_trace_context_propagator_test.dart
@@ -157,11 +157,33 @@ void main() {
         expect(extracted, equals(context));
       });
 
-      test('rejects unsupported version', () {
+      test('parses a higher version with the version 00 layout', () {
         // Arrange
         final carrier = {
           'traceparent':
               '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        };
+        final getter = MapTextMapGetter(carrier);
+        final context = OTel.context();
+
+        // Act
+        final extracted = propagator.extract(context, carrier, getter);
+
+        // Assert
+        final spanContext = extracted.spanContext;
+        expect(spanContext, isNotNull);
+        expect(
+          spanContext!.traceId.hexString,
+          equals('4bf92f3577b34da6a3ce929d0e0e4736'),
+        );
+        expect(spanContext.traceFlags.isSampled, isTrue);
+      });
+
+      test('rejects the forbidden version ff', () {
+        // Arrange
+        final carrier = {
+          'traceparent':
+              'ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
         };
         final getter = MapTextMapGetter(carrier);
         final context = OTel.context();


### PR DESCRIPTION
## Summary

Fixes three W3C Trace Context Level 2 compliance issues:

- **#192:** Parse higher `traceparent` versions using the version `00` field
  layout, while retaining version `00`'s strict grammar.
- **#193:** Reject version, trace ID, and parent ID fields that are not
  fixed-width lowercase hexadecimal.
- **#194:** Reject malformed trace flags instead of coercing them to unsampled.

## Changes

- Reworked `traceparent` parsing around fixed field offsets.
- Added focused W3C Level 2 contract coverage, including higher-version
  downgrade behavior.
- Updated existing propagator and debug-log tests.
- Added the fixes to the current changelog section.

## Verification

- `dart format` clean
- `dart analyze` clean
- Relevant contract and infrastructure tests: 84 passed
- Full test and coverage suite passed via the pre-push checks
- Line coverage: 93.5914% (required: 93.4%)
- Bugbot: no bugs

Closes #192
Closes #193
Closes #194

Made with [Cursor](https://cursor.com)