### PR TITLE
test: add regression test for OTEL_EXPORTER_OTLP_METRICS_ENDPOINT (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously `secure` overrode the gRPC endpoint scheme; now the scheme
   (`http:`, `https:`) takes precedence and `secure` applies only to
   scheme-less endpoints.
+- Regression test verifying `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is applied
+  to both HTTP and gRPC metric exporters. ([#229](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/issues/229))
 
 ## [1.1.0-beta.14] - 2026-08-23
 

--- a/test/unit/environment/exporter_selection_inprocess_test.dart
+++ b/test/unit/environment/exporter_selection_inprocess_test.dart
@@ -45,6 +45,33 @@ void main() {
     EnvironmentService.testOverrides = null;
   });
 
+  group('OTEL_EXPORTER_OTLP_METRICS_ENDPOINT', () {
+    test('signal-specific metrics endpoint flows to the http exporter',
+        () async {
+      OTelLog.currentLevel = LogLevel.debug;
+      await initWith({
+        'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT': 'http://custom-metrics:9999',
+      }, metrics: true);
+      final reader = OTel.meterProvider().metricReaders.single
+          as PeriodicExportingMetricReader;
+      expect(reader.exporter, isA<OtlpHttpMetricExporter>());
+      expect(warnings.join('\n'), contains('http://custom-metrics:9999'));
+    });
+
+    test('signal-specific metrics endpoint flows to the grpc exporter',
+        () async {
+      OTelLog.currentLevel = LogLevel.debug;
+      await initWith({
+        'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT': 'http://custom-metrics:4317',
+        'OTEL_EXPORTER_OTLP_PROTOCOL': 'grpc',
+      }, metrics: true);
+      final reader = OTel.meterProvider().metricReaders.single
+          as PeriodicExportingMetricReader;
+      expect(reader.exporter, isA<OtlpGrpcMetricExporter>());
+      expect(warnings.join('\n'), contains('http://custom-metrics:4317'));
+    });
+  });
+
   group('OTEL_METRICS_EXPORTER selection', () {
     test('none installs no reader', () async {
       await initWith({'OTEL_METRICS_EXPORTER': 'none'}, metrics: true);


### PR DESCRIPTION
Closes #229

The fix for this issue is already in `metric_config.dart:149`:

```dart
final effectiveEndpoint = otlpConfig.endpoint ?? endpoint ?? ...
```

`otlpConfig.endpoint` reads from `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` via
`OTelEnv.getOtlpConfig(signal: 'metrics')`. The env var is applied correctly
for both HTTP and gRPC metric exporters.

This PR adds two regression tests to lock in that behavior and prevent
future regressions:

- `exporter_selection_inprocess_test.dart`: 2 new tests in a new
  `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` group
- `CHANGELOG.md`: regression test entry for #229

Local verification:
- `dart analyze`: 0 issues
- `dart format`: no changes
- `dart test exporter_selection_inprocess_test.dart`: 18/18 pass
