### PR TITLE
fix: getLogger returns no-op logger after shutdown instead of throwing (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`http:`, `https:`) takes precedence and `secure` applies only to
   scheme-less endpoints.
 
+- **`getLogger` no longer throws after shutdown** (#177):
+  Previously `LoggerProvider.getLogger()` threw `StateError` after shutdown.
+  It now returns a no-op logger that silently drops all calls, as required
+  by the OTel specification.
+
 ## [1.1.0-beta.14] - 2026-08-23
 
 ### Changed

--- a/lib/src/logs/logger_provider.dart
+++ b/lib/src/logs/logger_provider.dart
@@ -134,6 +134,16 @@ class LoggerProvider implements APILoggerProvider {
           'LoggerProvider: Attempting to get logger "$name" after shutdown. Returning a no-op logger.',
         );
       }
+      final delegate = _delegate.getLogger(
+        name,
+        version: version,
+        schemaUrl: schemaUrl,
+        attributes: attributes,
+      );
+      return SDKLoggerCreate.create(
+        delegate: delegate,
+        provider: this,
+      );
     }
 
     // Ensure resource is set before creating logger

--- a/lib/src/logs/logger_provider.dart
+++ b/lib/src/logs/logger_provider.dart
@@ -126,7 +126,14 @@ class LoggerProvider implements APILoggerProvider {
           'LoggerProvider: Getting logger with name: $name, version: $version, schemaUrl: $schemaUrl');
     }
     if (isShutdown) {
-      throw StateError('LoggerProvider has been shut down');
+      // Return a no-op logger instead of throwing, per the OTel spec:
+      // "The SDK MUST NOT throw unhandled exceptions for errors in their
+      // own operations."
+      if (OTelLog.isDebug()) {
+        OTelLog.debug(
+          'LoggerProvider: Attempting to get logger "$name" after shutdown. Returning a no-op logger.',
+        );
+      }
     }
 
     // Ensure resource is set before creating logger

--- a/test/unit/logs/logger_provider_test.dart
+++ b/test/unit/logs/logger_provider_test.dart
@@ -100,14 +100,13 @@ void main() {
       expect(loggerProvider.logRecordProcessors.length, equals(2));
     });
 
-    test('LoggerProvider throws when getting logger after shutdown', () async {
+    test('LoggerProvider returns no-op logger after shutdown', () async {
       final loggerProvider = OTel.loggerProvider();
       await loggerProvider.shutdown();
 
-      expect(
-        () => loggerProvider.getLogger('test-logger'),
-        throwsA(isA<StateError>()),
-      );
+      final logger = loggerProvider.getLogger('test-logger');
+      expect(logger, isNotNull);
+      expect(logger.enabled, isFalse);
     });
 
     test('LoggerProvider throws when adding processor after shutdown',

--- a/test/unit/logs/logs_coverage_test.dart
+++ b/test/unit/logs/logs_coverage_test.dart
@@ -275,7 +275,7 @@ void main() {
       );
     });
 
-    test('getLogger after shutdown throws StateError', () async {
+    test('getLogger after shutdown returns no-op logger', () async {
       await OTel.initialize(
         serviceName: 'lp-getlogger-shutdown-test',
         detectPlatformResources: false,
@@ -285,10 +285,9 @@ void main() {
       final provider = OTel.loggerProvider();
       await provider.shutdown();
 
-      expect(
-        () => provider.getLogger('test-after-shutdown'),
-        throwsA(isA<StateError>()),
-      );
+      final logger = provider.getLogger('test-after-shutdown');
+      expect(logger, isNotNull);
+      expect(logger.enabled, isFalse);
     });
 
     test('addLogRecordProcessor after shutdown throws StateError', () async {


### PR DESCRIPTION
Closes #177

`LoggerProvider.getLogger()` previously threw `StateError` after shutdown,
which violates the OTel specification requirement that "The SDK MUST NOT
throw unhandled exceptions for errors in their own operations."

After shutdown, `getLogger()` now returns the logger normally. The
`OTelLogger.enabled` getter already returns `false` when the provider
is shut down, and `emit()` returns early when `!enabled`, so the returned
logger is effectively a no-op.

Changes:
- `logger_provider.dart`: replaced `throw StateError` with a debug log
- `logger_provider_test.dart`: updated test to verify no-op logger is returned
- `logs_coverage_test.dart`: updated test to verify no-op logger is returned
- `CHANGELOG.md`: entry under Fixed

Local verification:
- `dart analyze`: 0 issues
- `dart format`: no changes
- `dart test test/unit/logs/`: 92/92 pass
