### PR TITLE
fix: service.name defaults to unknown_service per OTel spec (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `false`**, and a malformed value is dropped with a warning instead of
   failing `OTel.initialize`.
 
+- **`service.name` defaults to spec-compliant `unknown_service`** (#204):
+  Previously defaulted to `@dart/dartastic_opentelemetry`. Now defaults to
+  `unknown_service:<process.executable.name>` on native platforms and
+  `unknown_service` on web, as required by the OTel specification.
+  `service.version` is no longer invented when not provided.
+
 ## [1.1.0-beta.14] - 2026-08-23
 
 ### Changed

--- a/lib/src/environment/executable_name.dart
+++ b/lib/src/environment/executable_name.dart
@@ -1,0 +1,5 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+export 'executable_name_io.dart'
+    if (dart.library.js_interop) 'executable_name_web.dart';

--- a/lib/src/environment/executable_name_io.dart
+++ b/lib/src/environment/executable_name_io.dart
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:io' as io;
+
+/// Returns the base name of the current process executable.
+String get processExecutableName {
+  final path = io.Platform.executable;
+  // Extract just the file name from the full path.
+  final lastSlash = path.lastIndexOf(io.Platform.pathSeparator);
+  return lastSlash == -1 ? path : path.substring(lastSlash + 1);
+}

--- a/lib/src/environment/executable_name_web.dart
+++ b/lib/src/environment/executable_name_web.dart
@@ -1,0 +1,5 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Returns an empty string on web where dart:io is not available.
+String get processExecutableName => '';

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../dartastic_opentelemetry.dart';
+import 'environment/executable_name.dart';
 
 /// Main entry point for the OpenTelemetry SDK.
 ///
@@ -67,7 +68,16 @@ class OTel {
   static Resource? defaultResource;
 
   /// Default service name used if none is provided.
-  static const defaultServiceName = '@dart/dartastic_opentelemetry';
+  ///
+  /// Per the OTel specification, the SDK-provided default is
+  /// `unknown_service:<process.executable.name>`. When the executable
+  /// name is unavailable (e.g. web), the default is `unknown_service`.
+  static String get defaultServiceName {
+    final executable = processExecutableName;
+    return executable.isEmpty
+        ? 'unknown_service'
+        : 'unknown_service:$executable';
+  }
 
   /// Default OTEL endpoint.
   ///
@@ -265,7 +275,10 @@ class OTel {
 
     // Apply defaults if still null.
     serviceName ??= defaultServiceName;
-    serviceVersion ??= '1.0.0';
+    // serviceVersion is intentionally left nullable: the OTel spec does not
+    // mandate a default service.version, so we only set it when the caller
+    // (or OTEL_SERVICE_VERSION / OTEL_RESOURCE_ATTRIBUTES) provides one.
+    // secure is guaranteed non-null from above
 
     // Log environment variable usage
     if (OTelLog.isDebug()) {
@@ -309,7 +322,7 @@ class OTel {
     if (serviceName.isEmpty) {
       throw ArgumentError('serviceName must not be the empty string.');
     }
-    if (serviceVersion.isEmpty) {
+    if (serviceVersion != null && serviceVersion.isEmpty) {
       throw ArgumentError('serviceVersion must not be the empty string.');
     }
     final factoryFactory =
@@ -323,7 +336,7 @@ class OTel {
     final createdFactory = factoryFactory(
       apiEndpoint: endpoint ?? defaultEndpoint,
       apiServiceName: serviceName,
-      apiServiceVersion: serviceVersion,
+      apiServiceVersion: serviceVersion ?? OTelAPI.defaultServiceVersion,
     );
     OTelFactory.otelFactory = createdFactory;
     if (createdFactory is OTelSDKFactory) {
@@ -356,9 +369,9 @@ class OTel {
     mergedResource = mergedResource.merge(envVarResource);
 
     // Apply OTEL_SERVICE_NAME (and VERSION) via service name variables
-    final serviceResourceAttributes = {
+    final serviceResourceAttributes = <String, Object>{
       Service.serviceName.key: serviceName,
-      Service.serviceVersion.key: serviceVersion,
+      if (serviceVersion != null) Service.serviceVersion.key: serviceVersion,
     };
     mergedResource = mergedResource.merge(
         OTel.resource(OTel.attributesFromMap(serviceResourceAttributes)));

--- a/test/unit/otel_service_precedence_test.dart
+++ b/test/unit/otel_service_precedence_test.dart
@@ -162,7 +162,8 @@ void main() {
       final resource = await initWith({});
       expect(attributeOf(resource, 'service.name'), isNotNull);
       expect(attributeOf(resource, 'service.name'), isNotEmpty);
-      expect(attributeOf(resource, 'service.version'), equals('1.0.0'));
+      // service.version is not set when not provided (issue #204)
+      expect(attributeOf(resource, 'service.version'), isNull);
     });
   });
 }


### PR DESCRIPTION
Closes #204

The OTel specification requires the default `service.name` to be
`unknown_service:<process.executable.name>`. The SDK was using a
vendor-specific name (`@dart/dartastic_opentelemetry`) and inventing
a `service.version` of `1.0.0` when none was provided.

This fix:

1. Changes `defaultServiceName` from a const to a computed getter that
   returns `unknown_service:<executable>` on native platforms and
   `unknown_service` on web (where `dart:io` is unavailable).

2. Removes the `serviceVersion ??= '1.0.0'` default. The version is now
   only set when the caller explicitly provides one (via argument,
   `OTEL_SERVICE_VERSION`, or `OTEL_RESOURCE_ATTRIBUTES`).

3. Uses conditional imports for `Platform.executable` access:
   - `executable_name.dart` (barrel with platform conditional export)
   - `executable_name_io.dart` (native: reads `Platform.executable`)
   - `executable_name_web.dart` (web: returns empty string)

Changes:
- `otel.dart`: `defaultServiceName` is now a computed getter, `serviceVersion`
  stays nullable, resource attributes conditionally include `service.version`
- `environment/executable_name*.dart`: new platform-conditional files
- `otel_service_precedence_test.dart`: updated to expect null `service.version`
  when not provided
- `CHANGELOG.md`: entry under Fixed

Local verification:
- `dart analyze`: 0 issues
- `dart format`: no changes
- 1000+ tests pass (2 pre-existing metric failures unrelated to this change)
