### PR TITLE
feat: Implement Metrics Exemplar support per OTel v1.60.0 (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fallback. Enforcing the limits is follow-up work, so setting them has no
   effect on emitted telemetry yet.
 
+- **Metrics SDK Exemplars implementation** (#154):
+  Implemented `ExemplarFilter` and `ExemplarReservoir` as required by the OpenTelemetry Specification.
+  The metrics SDK now collects exemplars for sum, gauge, and histogram instruments according to the configured exemplar filter.
+
 ### Fixed
 
 - **The `secure` parameter now works for logs and metrics** (#253, #225).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changed the type of those attributes on the wire.
 - **`OTEL_RESOURCE_ATTRIBUTES` values are percent-decoded**, so `k=a%2Cb`
   now yields `a,b`.
+- **`Exemplar.fromMeasurement` signature reverted to take a `Measurement` object** instead of spreading its fields. This restores the previous API shape and adheres to the DRY principle.
 
 ### Added
 

--- a/lib/src/metrics/data/exemplar.dart
+++ b/lib/src/metrics/data/exemplar.dart
@@ -43,7 +43,8 @@ class Exemplar {
 
   /// Creates an exemplar from a measurement.
   factory Exemplar.fromMeasurement({
-    required Measurement measurement,
+    required num value,
+    required Attributes measurementAttributes,
     required DateTime timestamp,
     required Attributes aggregationAttributes,
     SpanId? spanId,
@@ -51,7 +52,7 @@ class Exemplar {
   }) {
     // Determine which attributes are filtered out
     final filteredAttrs = _filterAttributes(
-      measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
+      measurementAttributes,
       aggregationAttributes,
     );
 
@@ -59,7 +60,7 @@ class Exemplar {
       attributes: aggregationAttributes,
       filteredAttributes: filteredAttrs,
       timestamp: timestamp,
-      value: measurement.value,
+      value: value,
       traceId: traceId,
       spanId: spanId,
     );

--- a/lib/src/metrics/data/exemplar.dart
+++ b/lib/src/metrics/data/exemplar.dart
@@ -43,8 +43,7 @@ class Exemplar {
 
   /// Creates an exemplar from a measurement.
   factory Exemplar.fromMeasurement({
-    required num value,
-    required Attributes measurementAttributes,
+    required Measurement measurement,
     required DateTime timestamp,
     required Attributes aggregationAttributes,
     SpanId? spanId,
@@ -52,7 +51,7 @@ class Exemplar {
   }) {
     // Determine which attributes are filtered out
     final filteredAttrs = _filterAttributes(
-      measurementAttributes,
+      measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
       aggregationAttributes,
     );
 
@@ -60,7 +59,7 @@ class Exemplar {
       attributes: aggregationAttributes,
       filteredAttributes: filteredAttrs,
       timestamp: timestamp,
-      value: value,
+      value: measurement.value,
       traceId: traceId,
       spanId: spanId,
     );

--- a/lib/src/metrics/exemplar_filter.dart
+++ b/lib/src/metrics/exemplar_filter.dart
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+/// An ExemplarFilter evaluates a measurement to determine if an Exemplar should
+/// be sampled.
+abstract class ExemplarFilter {
+  /// Evaluates whether an exemplar should be sampled for the given measurement.
+  ///
+  /// @param value The value of the measurement.
+  /// @param attributes The attributes associated with the measurement.
+  /// @param context The Context associated with the measurement.
+  /// @return true if the measurement should be sampled as an exemplar, false otherwise.
+  bool shouldSample(num value, Attributes attributes, Context context);
+}
+
+/// An ExemplarFilter which samples all measurements.
+class AlwaysOnExemplarFilter implements ExemplarFilter {
+  const AlwaysOnExemplarFilter();
+
+  @override
+  bool shouldSample(num value, Attributes attributes, Context context) {
+    return true;
+  }
+}
+
+/// An ExemplarFilter which samples no measurements.
+class AlwaysOffExemplarFilter implements ExemplarFilter {
+  const AlwaysOffExemplarFilter();
+
+  @override
+  bool shouldSample(num value, Attributes attributes, Context context) {
+    return false;
+  }
+}
+
+/// An ExemplarFilter which makes its sampling decisions based on the trace context.
+///
+/// It only samples measurements if the context contains a sampled trace.
+class TraceBasedExemplarFilter implements ExemplarFilter {
+  const TraceBasedExemplarFilter();
+
+  @override
+  bool shouldSample(num value, Attributes attributes, Context context) {
+    final spanContext = context.spanContext;
+    return spanContext != null &&
+        spanContext.isValid &&
+        spanContext.traceFlags.isSampled;
+  }
+}

--- a/lib/src/metrics/exemplar_reservoir.dart
+++ b/lib/src/metrics/exemplar_reservoir.dart
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:math';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+import 'data/exemplar.dart';
+
+/// An ExemplarReservoir receives measurements from instruments and samples them
+/// to provide Exemplars.
+abstract class ExemplarReservoir {
+  /// Offers a measurement to the reservoir.
+  ///
+  /// The reservoir decides whether to retain the measurement as an exemplar.
+  ///
+  /// @param value The value of the measurement.
+  /// @param attributes The attributes associated with the measurement.
+  /// @param context The Context associated with the measurement.
+  /// @param timestamp The time the measurement was recorded.
+  void offerMeasurement(
+      num value, Attributes attributes, Context context, DateTime timestamp);
+
+  /// Returns the currently sampled exemplars and clears the reservoir.
+  ///
+  /// @param pointAttributes The attributes associated with the metric point.
+  /// @return A list of the sampled exemplars.
+  List<Exemplar> collectAndReset(Attributes pointAttributes);
+}
+
+/// A reservoir that retains a fixed number of exemplars.
+///
+/// If more measurements are offered than the fixed size, this implementation
+/// uses a simple random sampling algorithm to decide which exemplars to replace.
+class SimpleFixedSizeExemplarReservoir implements ExemplarReservoir {
+  final int _size;
+  final Random _random = Random();
+  int _measurementsSeen = 0;
+  final List<_MeasurementData?> _storage;
+
+  SimpleFixedSizeExemplarReservoir(this._size)
+      : _storage = List.filled(_size, null);
+
+  @override
+  void offerMeasurement(
+      num value, Attributes attributes, Context context, DateTime timestamp) {
+    int bucket;
+    if (_measurementsSeen < _size) {
+      bucket = _measurementsSeen;
+    } else {
+      bucket = _random.nextInt(_measurementsSeen + 1);
+    }
+
+    if (bucket < _size) {
+      _storage[bucket] = _MeasurementData(
+        value: value,
+        attributes: attributes,
+        context: context,
+        timestamp: timestamp,
+      );
+    }
+    _measurementsSeen++;
+  }
+
+  @override
+  List<Exemplar> collectAndReset(Attributes pointAttributes) {
+    final exemplars = <Exemplar>[];
+    for (var i = 0; i < _storage.length; i++) {
+      final data = _storage[i];
+      if (data != null) {
+        exemplars.add(
+          Exemplar.fromMeasurement(
+            value: data.value,
+            measurementAttributes: data.attributes,
+            timestamp: data.timestamp,
+            aggregationAttributes: pointAttributes,
+            spanId: data.context.spanContext?.spanId,
+            traceId: data.context.spanContext?.traceId,
+          ),
+        );
+        _storage[i] = null;
+      }
+    }
+    _measurementsSeen = 0;
+    return exemplars;
+  }
+}
+
+/// A reservoir that is aligned to histogram buckets.
+///
+/// It keeps the last seen measurement per histogram bucket.
+class AlignedHistogramBucketExemplarReservoir implements ExemplarReservoir {
+  final List<double> _boundaries;
+  final List<_MeasurementData?> _storage;
+
+  AlignedHistogramBucketExemplarReservoir(this._boundaries)
+      : _storage = List.filled(_boundaries.length + 1, null);
+
+  @override
+  void offerMeasurement(
+      num value, Attributes attributes, Context context, DateTime timestamp) {
+    var bucketIndex = _boundaries.length;
+    for (var i = 0; i < _boundaries.length; i++) {
+      if (value <= _boundaries[i]) {
+        bucketIndex = i;
+        break;
+      }
+    }
+    _storage[bucketIndex] = _MeasurementData(
+      value: value,
+      attributes: attributes,
+      context: context,
+      timestamp: timestamp,
+    );
+  }
+
+  @override
+  List<Exemplar> collectAndReset(Attributes pointAttributes) {
+    final exemplars = <Exemplar>[];
+    for (var i = 0; i < _storage.length; i++) {
+      final data = _storage[i];
+      if (data != null) {
+        exemplars.add(
+          Exemplar.fromMeasurement(
+            value: data.value,
+            measurementAttributes: data.attributes,
+            timestamp: data.timestamp,
+            aggregationAttributes: pointAttributes,
+            spanId: data.context.spanContext?.spanId,
+            traceId: data.context.spanContext?.traceId,
+          ),
+        );
+        _storage[i] = null;
+      }
+    }
+    return exemplars;
+  }
+}
+
+class _MeasurementData {
+  final num value;
+  final Attributes attributes;
+  final Context context;
+  final DateTime timestamp;
+
+  _MeasurementData({
+    required this.value,
+    required this.attributes,
+    required this.context,
+    required this.timestamp,
+  });
+}

--- a/lib/src/metrics/exemplar_reservoir.dart
+++ b/lib/src/metrics/exemplar_reservoir.dart
@@ -9,6 +9,10 @@ import 'data/exemplar.dart';
 
 /// An ExemplarReservoir receives measurements from instruments and samples them
 /// to provide Exemplars.
+///
+/// Note for future extension (Issues #151, #153): The reservoir choice should be
+/// user-configurable via a View. Currently, storage constructors hardcode the reservoir
+/// types. Once View parameters are fully wired up, this should be driven by the resolved View.
 abstract class ExemplarReservoir {
   /// Offers a measurement to the reservoir.
   ///
@@ -18,8 +22,10 @@ abstract class ExemplarReservoir {
   /// @param attributes The attributes associated with the measurement.
   /// @param context The Context associated with the measurement.
   /// @param timestamp The time the measurement was recorded.
+  /// @param bucketIndex Optional pre-computed histogram bucket index.
   void offerMeasurement(
-      num value, Attributes attributes, Context context, DateTime timestamp);
+      num value, Attributes attributes, Context context, DateTime timestamp,
+      [int? bucketIndex]);
 
   /// Returns the currently sampled exemplars and clears the reservoir.
   ///
@@ -34,16 +40,18 @@ abstract class ExemplarReservoir {
 /// uses a simple random sampling algorithm to decide which exemplars to replace.
 class SimpleFixedSizeExemplarReservoir implements ExemplarReservoir {
   final int _size;
-  final Random _random = Random();
+  final Random _random;
   int _measurementsSeen = 0;
   final List<_MeasurementData?> _storage;
 
-  SimpleFixedSizeExemplarReservoir(this._size)
-      : _storage = List.filled(_size, null);
+  SimpleFixedSizeExemplarReservoir(this._size, {Random? random})
+      : _random = random ?? Random(),
+        _storage = List.filled(_size, null);
 
   @override
   void offerMeasurement(
-      num value, Attributes attributes, Context context, DateTime timestamp) {
+      num value, Attributes attributes, Context context, DateTime timestamp,
+      [int? bucketIndex]) {
     int bucket;
     if (_measurementsSeen < _size) {
       bucket = _measurementsSeen;
@@ -55,7 +63,8 @@ class SimpleFixedSizeExemplarReservoir implements ExemplarReservoir {
       _storage[bucket] = _MeasurementData(
         value: value,
         attributes: attributes,
-        context: context,
+        traceId: context.spanContext?.traceId,
+        spanId: context.spanContext?.spanId,
         timestamp: timestamp,
       );
     }
@@ -70,12 +79,11 @@ class SimpleFixedSizeExemplarReservoir implements ExemplarReservoir {
       if (data != null) {
         exemplars.add(
           Exemplar.fromMeasurement(
-            value: data.value,
-            measurementAttributes: data.attributes,
+            measurement: OTelAPI.createMeasurement(data.value, data.attributes),
             timestamp: data.timestamp,
             aggregationAttributes: pointAttributes,
-            spanId: data.context.spanContext?.spanId,
-            traceId: data.context.spanContext?.traceId,
+            spanId: data.spanId,
+            traceId: data.traceId,
           ),
         );
         _storage[i] = null;
@@ -88,30 +96,49 @@ class SimpleFixedSizeExemplarReservoir implements ExemplarReservoir {
 
 /// A reservoir that is aligned to histogram buckets.
 ///
-/// It keeps the last seen measurement per histogram bucket.
+/// It MUST store at most one measurement that falls within a histogram bucket,
+/// and SHOULD use a uniformly-weighted sampling algorithm based on the number
+/// of measurements the bucket has seen so far.
 class AlignedHistogramBucketExemplarReservoir implements ExemplarReservoir {
   final List<double> _boundaries;
   final List<_MeasurementData?> _storage;
+  final List<int> _counts;
+  final Random _random;
 
-  AlignedHistogramBucketExemplarReservoir(this._boundaries)
-      : _storage = List.filled(_boundaries.length + 1, null);
+  AlignedHistogramBucketExemplarReservoir(this._boundaries, {Random? random})
+      : _storage = List.filled(_boundaries.length + 1, null),
+        _counts = List.filled(_boundaries.length + 1, 0),
+        _random = random ?? Random();
 
   @override
   void offerMeasurement(
-      num value, Attributes attributes, Context context, DateTime timestamp) {
-    var bucketIndex = _boundaries.length;
-    for (var i = 0; i < _boundaries.length; i++) {
-      if (value <= _boundaries[i]) {
-        bucketIndex = i;
-        break;
+      num value, Attributes attributes, Context context, DateTime timestamp,
+      [int? bucketIndex]) {
+    int index;
+    if (bucketIndex != null) {
+      index = bucketIndex;
+    } else {
+      index = _boundaries.length;
+      for (var i = 0; i < _boundaries.length; i++) {
+        if (value <= _boundaries[i]) {
+          index = i;
+          break;
+        }
       }
     }
-    _storage[bucketIndex] = _MeasurementData(
-      value: value,
-      attributes: attributes,
-      context: context,
-      timestamp: timestamp,
-    );
+
+    final measurementsSeenBucket = _counts[index];
+    if (measurementsSeenBucket == 0 ||
+        _random.nextInt(measurementsSeenBucket + 1) == 0) {
+      _storage[index] = _MeasurementData(
+        value: value,
+        attributes: attributes,
+        traceId: context.spanContext?.traceId,
+        spanId: context.spanContext?.spanId,
+        timestamp: timestamp,
+      );
+    }
+    _counts[index]++;
   }
 
   @override
@@ -122,16 +149,16 @@ class AlignedHistogramBucketExemplarReservoir implements ExemplarReservoir {
       if (data != null) {
         exemplars.add(
           Exemplar.fromMeasurement(
-            value: data.value,
-            measurementAttributes: data.attributes,
+            measurement: OTelAPI.createMeasurement(data.value, data.attributes),
             timestamp: data.timestamp,
             aggregationAttributes: pointAttributes,
-            spanId: data.context.spanContext?.spanId,
-            traceId: data.context.spanContext?.traceId,
+            spanId: data.spanId,
+            traceId: data.traceId,
           ),
         );
         _storage[i] = null;
       }
+      _counts[i] = 0;
     }
     return exemplars;
   }
@@ -140,13 +167,15 @@ class AlignedHistogramBucketExemplarReservoir implements ExemplarReservoir {
 class _MeasurementData {
   final num value;
   final Attributes attributes;
-  final Context context;
+  final TraceId? traceId;
+  final SpanId? spanId;
   final DateTime timestamp;
 
   _MeasurementData({
     required this.value,
     required this.attributes,
-    required this.context,
+    this.traceId,
+    this.spanId,
     required this.timestamp,
   });
 }

--- a/lib/src/metrics/export/metric_config.dart
+++ b/lib/src/metrics/export/metric_config.dart
@@ -6,6 +6,7 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
 import '../../environment/otel_env.dart';
 import '../../otel.dart';
 import '../../resource/resource.dart';
+import '../exemplar_filter.dart';
 import '../meter_provider.dart';
 import '../metric_exporter.dart';
 import '../metric_reader.dart';
@@ -13,7 +14,6 @@ import 'composite_metric_exporter.dart';
 import 'metrics_sdk_config.dart';
 import 'otlp/http/otlp_http_metric_exporter.dart';
 import 'otlp/http/otlp_http_metric_exporter_config.dart';
-
 import 'otlp/otlp_grpc_metric_exporter.dart';
 import 'otlp/otlp_grpc_metric_exporter_config.dart';
 
@@ -40,6 +40,7 @@ class MetricsConfiguration {
     MetricExporter? metricExporter,
     MetricReader? metricReader,
     Resource? resource,
+    ExemplarFilter? exemplarFilter,
   }) {
     final meterProvider = OTel.meterProvider();
     if (resource != null) {
@@ -47,6 +48,17 @@ class MetricsConfiguration {
     }
 
     final metricsSdkConfig = MetricsSdkConfig.fromEnvironment();
+
+    ExemplarFilter filter;
+    switch (metricsSdkConfig.exemplarFilter) {
+      case MetricsExemplarFilter.alwaysOn:
+        filter = const AlwaysOnExemplarFilter();
+      case MetricsExemplarFilter.alwaysOff:
+        filter = const AlwaysOffExemplarFilter();
+      case MetricsExemplarFilter.traceBased:
+        filter = const TraceBasedExemplarFilter();
+    }
+    meterProvider.exemplarFilter = exemplarFilter ?? filter;
 
     // Honor OTEL_METRICS_EXPORTER, but only when the caller did not pass an
     // explicit exporter/reader — explicit args are an unambiguous opt-in and

--- a/lib/src/metrics/instruments/counter.dart
+++ b/lib/src/metrics/instruments/counter.dart
@@ -32,7 +32,7 @@ class Counter<T extends num> implements APICounter<T>, SDKInstrument {
   final Meter _meter;
 
   /// Storage for accumulating counter measurements.
-  final SumStorage<T> _storage = SumStorage<T>(isMonotonic: true);
+  final SumStorage<T> _storage;
 
   /// Creates a new Counter instance.
   ///
@@ -40,7 +40,11 @@ class Counter<T extends num> implements APICounter<T>, SDKInstrument {
   /// @param meter The Meter that created this Counter
   Counter({required APICounter<T> apiCounter, required Meter meter})
       : _apiCounter = apiCounter,
-        _meter = meter {
+        _meter = meter,
+        _storage = SumStorage<T>(
+          isMonotonic: true,
+          exemplarFilter: meter.provider.exemplarFilter,
+        ) {
     _meter.provider.registerInstrument(_meter.name, this);
   }
 
@@ -104,7 +108,7 @@ class Counter<T extends num> implements APICounter<T>, SDKInstrument {
     if (!enabled) return;
 
     // Record the measurement in our storage
-    _storage.record(value, attributes);
+    _storage.record(value, attributes, Context.current);
   }
 
   /// Records a measurement with attributes specified as a map.

--- a/lib/src/metrics/instruments/gauge.dart
+++ b/lib/src/metrics/instruments/gauge.dart
@@ -21,12 +21,15 @@ class Gauge<T extends num> implements APIGauge<T>, SDKInstrument {
   final Meter _meter;
 
   /// Storage for gauge measurements.
-  final GaugeStorage<T> _storage = GaugeStorage<T>();
+  final GaugeStorage<T> _storage;
 
   /// Creates a new Gauge instance.
   Gauge({required APIGauge<T> apiGauge, required Meter meter})
       : _apiGauge = apiGauge,
-        _meter = meter {
+        _meter = meter,
+        _storage = GaugeStorage<T>(
+          exemplarFilter: meter.provider.exemplarFilter,
+        ) {
     // Register this instrument with the meter provider
     _meter.provider.registerInstrument(_meter.name, this);
   }
@@ -67,7 +70,7 @@ class Gauge<T extends num> implements APIGauge<T>, SDKInstrument {
     if (!enabled) return;
 
     // Record the measurement in our storage
-    _storage.record(value, attributes);
+    _storage.record(value, attributes, Context.current);
   }
 
   @override

--- a/lib/src/metrics/instruments/histogram.dart
+++ b/lib/src/metrics/instruments/histogram.dart
@@ -33,6 +33,7 @@ class Histogram<T extends num> implements APIHistogram<T>, SDKInstrument {
         _storage = HistogramStorage(
           boundaries: boundaries ?? _defaultBoundaries,
           recordMinMax: true,
+          exemplarFilter: meter.provider.exemplarFilter,
         ) {
     // Register this instrument with the meter provider
     _meter.provider.registerInstrument(_meter.name, this);
@@ -96,7 +97,7 @@ class Histogram<T extends num> implements APIHistogram<T>, SDKInstrument {
     if (!enabled) return;
 
     // Record the measurement in our storage
-    _storage.record(value, attributes);
+    _storage.record(value, attributes, Context.current);
   }
 
   @override

--- a/lib/src/metrics/instruments/observable_counter.dart
+++ b/lib/src/metrics/instruments/observable_counter.dart
@@ -18,7 +18,7 @@ class ObservableCounter<T extends num>
   final Meter _meter;
 
   /// Storage for accumulating counter measurements.
-  final SumStorage<T> _storage = SumStorage<T>(isMonotonic: true);
+  final SumStorage<T> _storage;
 
   /// The last observed values, for tracking and detecting resets.
   final Map<Attributes, T> _lastValues = {};
@@ -28,7 +28,11 @@ class ObservableCounter<T extends num>
     required APIObservableCounter<T> apiCounter,
     required Meter meter,
   })  : _apiCounter = apiCounter,
-        _meter = meter;
+        _meter = meter,
+        _storage = SumStorage<T>(
+          isMonotonic: true,
+          exemplarFilter: meter.provider.exemplarFilter,
+        );
 
   @override
   String get name => _apiCounter.name;
@@ -146,22 +150,24 @@ class ObservableCounter<T extends num>
             // Per spec, for a reset we just record the current value
             // For SDK storage, convert the num to the appropriate T type
             if (T == int) {
-              _storage.record(value.toInt() as T, attributes);
+              _storage.record(value.toInt() as T, attributes, Context.current);
             } else if (T == double) {
-              _storage.record(value.toDouble() as T, attributes);
+              _storage.record(
+                  value.toDouble() as T, attributes, Context.current);
             } else {
-              _storage.record(value as T, attributes);
+              _storage.record(value as T, attributes, Context.current);
             }
             result.add(measurement);
           } else if (value > lastValue) {
             // Only add measurements with positive deltas
             // For SDK storage, convert the num to the appropriate T type
             if (T == int) {
-              _storage.record(value.toInt() as T, attributes);
+              _storage.record(value.toInt() as T, attributes, Context.current);
             } else if (T == double) {
-              _storage.record(value.toDouble() as T, attributes);
+              _storage.record(
+                  value.toDouble() as T, attributes, Context.current);
             } else {
-              _storage.record(value as T, attributes);
+              _storage.record(value as T, attributes, Context.current);
             }
             result.add(measurement);
           } else {
@@ -169,11 +175,12 @@ class ObservableCounter<T extends num>
             // but don't include it in the returned measurements
             // For SDK storage, convert the num to the appropriate T type
             if (T == int) {
-              _storage.record(value.toInt() as T, attributes);
+              _storage.record(value.toInt() as T, attributes, Context.current);
             } else if (T == double) {
-              _storage.record(value.toDouble() as T, attributes);
+              _storage.record(
+                  value.toDouble() as T, attributes, Context.current);
             } else {
-              _storage.record(value as T, attributes);
+              _storage.record(value as T, attributes, Context.current);
             }
             // Note: The measurement is deliberately not added to the result list
           }

--- a/lib/src/metrics/instruments/observable_gauge.dart
+++ b/lib/src/metrics/instruments/observable_gauge.dart
@@ -17,14 +17,17 @@ class ObservableGauge<T extends num>
   final Meter _meter;
 
   /// Storage for gauge measurements.
-  final GaugeStorage<T> _storage = GaugeStorage<T>();
+  final GaugeStorage<T> _storage;
 
   /// Creates a new ObservableGauge instance.
   ObservableGauge({
     required APIObservableGauge<T> apiGauge,
     required Meter meter,
   })  : _apiGaugeDelegate = apiGauge,
-        _meter = meter;
+        _meter = meter,
+        _storage = GaugeStorage<T>(
+          exemplarFilter: meter.provider.exemplarFilter,
+        );
 
   @override
   String get name => _apiGaugeDelegate.name;
@@ -130,11 +133,12 @@ class ObservableGauge<T extends num>
           final attributes =
               measurement.attributes ?? OTelFactory.otelFactory!.attributes();
           if (T == int) {
-            _storage.record(numValue.toInt() as T, attributes);
+            _storage.record(numValue.toInt() as T, attributes, Context.current);
           } else if (T == double) {
-            _storage.record(numValue.toDouble() as T, attributes);
+            _storage.record(
+                numValue.toDouble() as T, attributes, Context.current);
           } else {
-            _storage.record(numValue as T, attributes);
+            _storage.record(numValue as T, attributes, Context.current);
           }
 
           result.add(measurement);

--- a/lib/src/metrics/instruments/observable_up_down_counter.dart
+++ b/lib/src/metrics/instruments/observable_up_down_counter.dart
@@ -18,7 +18,7 @@ class ObservableUpDownCounter<T extends num>
   final Meter _meter;
 
   /// Storage for accumulating counter measurements.
-  final SumStorage<T> _storage = SumStorage<T>(isMonotonic: false);
+  final SumStorage<T> _storage;
 
   /// The last observed values, for tracking changes.
   final Map<Attributes, T> _lastValues = {};
@@ -28,7 +28,11 @@ class ObservableUpDownCounter<T extends num>
     required APIObservableUpDownCounter<T> apiCounter,
     required Meter meter,
   })  : _apiCounter = apiCounter,
-        _meter = meter;
+        _meter = meter,
+        _storage = SumStorage<T>(
+          isMonotonic: false,
+          exemplarFilter: meter.provider.exemplarFilter,
+        );
 
   @override
   String get name => _apiCounter.name;
@@ -139,11 +143,11 @@ class ObservableUpDownCounter<T extends num>
           // directly - not the delta
           // For SDK storage, convert the num to the appropriate T type
           if (T == int) {
-            _storage.record(value.toInt() as T, attributes);
+            _storage.record(value.toInt() as T, attributes, Context.current);
           } else if (T == double) {
-            _storage.record(value.toDouble() as T, attributes);
+            _storage.record(value.toDouble() as T, attributes, Context.current);
           } else {
-            _storage.record(value as T, attributes);
+            _storage.record(value as T, attributes, Context.current);
           }
 
           // Add measurement with the absolute value to the result

--- a/lib/src/metrics/instruments/up_down_counter.dart
+++ b/lib/src/metrics/instruments/up_down_counter.dart
@@ -22,12 +22,16 @@ class UpDownCounter<T extends num>
   final Meter _meter;
 
   /// Storage for accumulating up-down counter measurements.
-  final SumStorage<T> _storage = SumStorage<T>(isMonotonic: false);
+  final SumStorage<T> _storage;
 
   /// Creates a new UpDownCounter instance.
   UpDownCounter({required APIUpDownCounter<T> apiCounter, required Meter meter})
       : _apiCounter = apiCounter,
-        _meter = meter {
+        _meter = meter,
+        _storage = SumStorage<T>(
+          isMonotonic: false,
+          exemplarFilter: meter.provider.exemplarFilter,
+        ) {
     // Register this instrument with the meter provider
     _meter.provider.registerInstrument(_meter.name, this);
   }
@@ -68,7 +72,7 @@ class UpDownCounter<T extends num>
     if (!_meter.enabled) return;
 
     // Record the measurement in our storage
-    _storage.record(value, attributes);
+    _storage.record(value, attributes, Context.current);
   }
 
   @override

--- a/lib/src/metrics/meter_provider.dart
+++ b/lib/src/metrics/meter_provider.dart
@@ -36,7 +36,7 @@ class MeterProvider implements APIMeterProvider {
   final List<View> _views = [];
 
   /// The ExemplarFilter used by this provider's meters.
-  ExemplarFilter? exemplarFilter;
+  ExemplarFilter exemplarFilter = const TraceBasedExemplarFilter();
 
   /// Private constructor for creating MeterProvider instances.
   ///

--- a/lib/src/metrics/meter_provider.dart
+++ b/lib/src/metrics/meter_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../dartastic_opentelemetry.dart';
+import 'exemplar_filter.dart';
 import 'meter.dart';
 
 part 'meter_provider_create.dart';
@@ -33,6 +34,9 @@ class MeterProvider implements APIMeterProvider {
 
   /// List of views for configuring metric collection.
   final List<View> _views = [];
+
+  /// The ExemplarFilter used by this provider's meters.
+  ExemplarFilter? exemplarFilter;
 
   /// Private constructor for creating MeterProvider instances.
   ///

--- a/lib/src/metrics/storage/gauge_storage.dart
+++ b/lib/src/metrics/storage/gauge_storage.dart
@@ -3,8 +3,9 @@
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
-import '../data/exemplar.dart';
 import '../data/metric_point.dart';
+import '../exemplar_filter.dart';
+import '../exemplar_reservoir.dart';
 import 'metric_storage.dart';
 
 /// GaugeStorage is used for storing the last recorded value for each set of attributes.
@@ -12,17 +13,34 @@ class GaugeStorage<T extends num> extends NumericStorage<T> {
   /// Map of attribute sets to gauge data.
   final Map<Attributes, _GaugePointData<T>> _points = {};
 
-  /// Creates a new GaugeStorage instance.
-  GaugeStorage();
+  /// The exemplar filter used by this storage.
+  final ExemplarFilter? exemplarFilter;
 
-  /// Records a measurement with the given attributes.
+  /// Creates a new GaugeStorage instance.
+  GaugeStorage({this.exemplarFilter});
+
+  /// Records a measurement with the given attributes and context.
   @override
-  void record(T value, [Attributes? attributes]) {
+  void record(T value, [Attributes? attributes, Context? context]) {
     // Create a normalized key for lookup
     final key = attributes ?? _emptyAttributes();
 
+    final pointData = _GaugePointData<T>(
+      value: value,
+      updateTime: DateTime.now(),
+      reservoir: SimpleFixedSizeExemplarReservoir(1), // Simple fixed size of 1
+    );
+
     // Always update with the latest value
-    _points[key] = _GaugePointData<T>(value: value, updateTime: DateTime.now());
+    _points[key] = pointData;
+
+    // Process exemplars if a filter is provided
+    if (exemplarFilter != null && context != null) {
+      if (exemplarFilter!.shouldSample(value, key, context)) {
+        pointData.reservoir
+            .offerMeasurement(value, key, context, DateTime.now());
+      }
+    }
   }
 
   /// Helper to get empty attributes safely
@@ -82,7 +100,7 @@ class GaugeStorage<T extends num> extends NumericStorage<T> {
         startTime: data.updateTime, // For gauges, start time is the update time
         time: now,
         value: data.value,
-        exemplars: data.exemplars,
+        exemplars: data.reservoir.collectAndReset(entry.key),
       );
     }).toList();
   }
@@ -91,19 +109,6 @@ class GaugeStorage<T extends num> extends NumericStorage<T> {
   @override
   void reset() {
     _points.clear();
-  }
-
-  /// Adds an exemplar to a specific point.
-  @override
-  void addExemplar(Exemplar exemplar, [Attributes? attributes]) {
-    // Create a normalized key for lookup
-    final key = attributes ?? _emptyAttributes();
-
-    // Find matching attributes
-    final existingKey = _findMatchingKey(key);
-    if (existingKey != null) {
-      _points[existingKey]!.exemplars.add(exemplar);
-    }
   }
 }
 
@@ -115,8 +120,9 @@ class _GaugePointData<T extends num> {
   /// The time this value was recorded.
   final DateTime updateTime;
 
-  /// Exemplars for this point.
-  final List<Exemplar> exemplars = [];
+  /// Reservoir for this point.
+  final ExemplarReservoir reservoir;
 
-  _GaugePointData({required this.value, required this.updateTime});
+  _GaugePointData(
+      {required this.value, required this.updateTime, required this.reservoir});
 }

--- a/lib/src/metrics/storage/gauge_storage.dart
+++ b/lib/src/metrics/storage/gauge_storage.dart
@@ -9,38 +9,45 @@ import '../exemplar_reservoir.dart';
 import 'metric_storage.dart';
 
 /// GaugeStorage is used for storing the last recorded value for each set of attributes.
-class GaugeStorage<T extends num> extends NumericStorage<T> {
+class GaugeStorage<T extends num> extends NumericStorage<T>
+    with ExemplarSampling<T> {
   /// Map of attribute sets to gauge data.
   final Map<Attributes, _GaugePointData<T>> _points = {};
 
   /// The exemplar filter used by this storage.
-  final ExemplarFilter? exemplarFilter;
+  @override
+  final ExemplarFilter exemplarFilter;
 
   /// Creates a new GaugeStorage instance.
-  GaugeStorage({this.exemplarFilter});
+  GaugeStorage({ExemplarFilter? exemplarFilter})
+      : exemplarFilter = exemplarFilter ?? const TraceBasedExemplarFilter();
 
   /// Records a measurement with the given attributes and context.
   @override
-  void record(T value, [Attributes? attributes, Context? context]) {
+  void record(T value,
+      [Attributes? attributes, Context? context, DateTime? timestamp]) {
     // Create a normalized key for lookup
     final key = attributes ?? _emptyAttributes();
+    final existingKey = _findMatchingKey(key);
 
-    final pointData = _GaugePointData<T>(
-      value: value,
-      updateTime: DateTime.now(),
-      reservoir: SimpleFixedSizeExemplarReservoir(1), // Simple fixed size of 1
-    );
-
-    // Always update with the latest value
-    _points[key] = pointData;
-
-    // Process exemplars if a filter is provided
-    if (exemplarFilter != null && context != null) {
-      if (exemplarFilter!.shouldSample(value, key, context)) {
-        pointData.reservoir
-            .offerMeasurement(value, key, context, DateTime.now());
-      }
+    _GaugePointData<T> pointData;
+    if (existingKey != null) {
+      pointData = _points[existingKey]!;
+      pointData.value = value;
+      pointData.updateTime = DateTime.now();
+    } else {
+      pointData = _GaugePointData<T>(
+        value: value,
+        updateTime: DateTime.now(),
+        reservoir:
+            SimpleFixedSizeExemplarReservoir(1), // Simple fixed size of 1
+      );
+      // Always update with the latest value
+      _points[key] = pointData;
     }
+
+    maybeOffer(pointData.reservoir, value, key, context ?? Context.current,
+        timestamp ?? DateTime.now());
   }
 
   /// Helper to get empty attributes safely
@@ -115,10 +122,10 @@ class GaugeStorage<T extends num> extends NumericStorage<T> {
 /// Data for a single gauge point.
 class _GaugePointData<T extends num> {
   /// The current value.
-  final T value;
+  T value;
 
   /// The time this value was recorded.
-  final DateTime updateTime;
+  DateTime updateTime;
 
   /// Reservoir for this point.
   final ExemplarReservoir reservoir;

--- a/lib/src/metrics/storage/histogram_storage.dart
+++ b/lib/src/metrics/storage/histogram_storage.dart
@@ -9,7 +9,8 @@ import '../exemplar_reservoir.dart';
 import 'metric_storage.dart';
 
 /// HistogramStorage is used for storing and accumulating histogram data.
-class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
+class HistogramStorage<T extends num> extends HistogramStorageBase<T>
+    with ExemplarSampling<T> {
   /// Map of attribute sets to histogram data.
   final Map<Attributes, _HistogramPointData<T>> _points = {};
 
@@ -23,45 +24,46 @@ class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
   final DateTime _startTime = DateTime.now();
 
   /// The exemplar filter used by this storage.
-  final ExemplarFilter? exemplarFilter;
+  @override
+  final ExemplarFilter exemplarFilter;
 
   /// Creates a new HistogramStorage instance.
   HistogramStorage(
       {required this.boundaries,
       this.recordMinMax = true,
-      this.exemplarFilter});
+      ExemplarFilter? exemplarFilter})
+      : exemplarFilter = exemplarFilter ?? const TraceBasedExemplarFilter();
 
   /// Records a measurement with the given attributes and context.
   @override
-  void record(T value, [Attributes? attributes, Context? context]) {
+  void record(T value,
+      [Attributes? attributes, Context? context, DateTime? timestamp]) {
     // Create a normalized key for lookup
     final key = attributes ?? _emptyAttributes();
 
     _HistogramPointData<T> pointData;
     // Find matching attributes
     final existingKey = _findMatchingKey(key);
+    var bucketIndex = boundaries.length;
     if (existingKey != null) {
       // Update existing point
       pointData = _points[existingKey]!;
-      pointData.record(value);
+      bucketIndex = pointData.record(value);
     } else {
       // Create new point
       pointData = _HistogramPointData<T>(
         boundaries: boundaries,
         recordMinMax: recordMinMax,
-        reservoir: AlignedHistogramBucketExemplarReservoir(boundaries),
+        reservoir: boundaries.length > 1
+            ? AlignedHistogramBucketExemplarReservoir(boundaries)
+            : SimpleFixedSizeExemplarReservoir(1),
       );
-      pointData.record(value);
+      bucketIndex = pointData.record(value);
       _points[key] = pointData;
     }
 
-    // Process exemplars if a filter is provided
-    if (exemplarFilter != null && context != null) {
-      if (exemplarFilter!.shouldSample(value, key, context)) {
-        pointData.reservoir
-            .offerMeasurement(value, key, context, DateTime.now());
-      }
-    }
+    maybeOffer(pointData.reservoir, value, key, context ?? Context.current,
+        timestamp ?? DateTime.now(), bucketIndex);
   }
 
   /// Helper to get empty attributes safely
@@ -245,7 +247,8 @@ class _HistogramPointData<T extends num> {
   }
 
   /// Records a measurement.
-  void record(T value) {
+  /// Returns the bucket index where the measurement fell.
+  int record(T value) {
     count++;
     sum += value;
 
@@ -266,5 +269,6 @@ class _HistogramPointData<T extends num> {
 
     // Increment the bucket count
     counts[bucketIndex]++;
+    return bucketIndex;
   }
 }

--- a/lib/src/metrics/storage/histogram_storage.dart
+++ b/lib/src/metrics/storage/histogram_storage.dart
@@ -3,8 +3,9 @@
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
-import '../data/exemplar.dart';
 import '../data/metric_point.dart';
+import '../exemplar_filter.dart';
+import '../exemplar_reservoir.dart';
 import 'metric_storage.dart';
 
 /// HistogramStorage is used for storing and accumulating histogram data.
@@ -21,26 +22,45 @@ class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
   /// The start time for all points.
   final DateTime _startTime = DateTime.now();
 
-  /// Creates a new HistogramStorage instance.
-  HistogramStorage({required this.boundaries, this.recordMinMax = true});
+  /// The exemplar filter used by this storage.
+  final ExemplarFilter? exemplarFilter;
 
-  /// Records a measurement with the given attributes.
+  /// Creates a new HistogramStorage instance.
+  HistogramStorage(
+      {required this.boundaries,
+      this.recordMinMax = true,
+      this.exemplarFilter});
+
+  /// Records a measurement with the given attributes and context.
   @override
-  void record(T value, [Attributes? attributes]) {
+  void record(T value, [Attributes? attributes, Context? context]) {
     // Create a normalized key for lookup
     final key = attributes ?? _emptyAttributes();
 
+    _HistogramPointData<T> pointData;
     // Find matching attributes
     final existingKey = _findMatchingKey(key);
     if (existingKey != null) {
       // Update existing point
-      _points[existingKey]!.record(value);
+      pointData = _points[existingKey]!;
+      pointData.record(value);
     } else {
       // Create new point
-      _points[key] = _HistogramPointData<T>(
+      pointData = _HistogramPointData<T>(
         boundaries: boundaries,
         recordMinMax: recordMinMax,
-      )..record(value);
+        reservoir: AlignedHistogramBucketExemplarReservoir(boundaries),
+      );
+      pointData.record(value);
+      _points[key] = pointData;
+    }
+
+    // Process exemplars if a filter is provided
+    if (exemplarFilter != null && context != null) {
+      if (exemplarFilter!.shouldSample(value, key, context)) {
+        pointData.reservoir
+            .offerMeasurement(value, key, context, DateTime.now());
+      }
     }
   }
 
@@ -177,7 +197,7 @@ class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
         startTime: _startTime,
         endTime: now,
         value: histogramValue,
-        exemplars: data.exemplars,
+        exemplars: data.reservoir.collectAndReset(entry.key),
       );
     }).toList();
   }
@@ -186,19 +206,6 @@ class HistogramStorage<T extends num> extends HistogramStorageBase<T> {
   @override
   void reset() {
     _points.clear();
-  }
-
-  /// Adds an exemplar to a specific point.
-  @override
-  void addExemplar(Exemplar exemplar, [Attributes? attributes]) {
-    // Create a normalized key for lookup
-    final key = attributes ?? _emptyAttributes();
-
-    // Find matching attributes
-    final existingKey = _findMatchingKey(key);
-    if (existingKey != null) {
-      _points[existingKey]!.exemplars.add(exemplar);
-    }
   }
 }
 
@@ -225,10 +232,13 @@ class _HistogramPointData<T extends num> {
   /// Whether to record min and max values.
   final bool recordMinMax;
 
-  /// Exemplars for this point.
-  final List<Exemplar> exemplars = [];
+  /// Reservoir for this point.
+  final ExemplarReservoir reservoir;
 
-  _HistogramPointData({required this.boundaries, required this.recordMinMax}) {
+  _HistogramPointData(
+      {required this.boundaries,
+      required this.recordMinMax,
+      required this.reservoir}) {
     // Initialize count array with one more than boundaries
     // (for the +Inf bucket)
     counts = List<int>.filled(boundaries.length + 1, 0);

--- a/lib/src/metrics/storage/metric_storage.dart
+++ b/lib/src/metrics/storage/metric_storage.dart
@@ -3,7 +3,6 @@
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
-import '../data/exemplar.dart';
 import '../data/metric_point.dart';
 
 /// Base storage interface for all metric types.
@@ -11,15 +10,12 @@ import '../data/metric_point.dart';
 abstract class MetricStorage {
   /// Resets the storage (for delta temporality).
   void reset();
-
-  /// Adds an exemplar to a specific point.
-  void addExemplar(Exemplar exemplar, [Attributes? attributes]);
 }
 
 /// Storage for metrics that have simple numeric input and output (sum, gauge).
 abstract class NumericStorage<T extends num> extends MetricStorage {
-  /// Records a measurement with the given attributes.
-  void record(T value, [Attributes? attributes]);
+  /// Records a measurement with the given attributes and context.
+  void record(T value, [Attributes? attributes, Context? context]);
 
   /// Gets the current value for the given attributes.
   /// If no attributes are provided, returns a summary value depending on the instrument type.
@@ -31,8 +27,8 @@ abstract class NumericStorage<T extends num> extends MetricStorage {
 
 /// Storage for histogram metrics that have numeric input but HistogramValue output.
 abstract class HistogramStorageBase<T extends num> extends MetricStorage {
-  /// Records a measurement with the given attributes.
-  void record(T value, [Attributes? attributes]);
+  /// Records a measurement with the given attributes and context.
+  void record(T value, [Attributes? attributes, Context? context]);
 
   /// Gets the current histogram value for the given attributes.
   /// If no attributes are provided, returns a combined HistogramValue across all attribute sets.

--- a/lib/src/metrics/storage/metric_storage.dart
+++ b/lib/src/metrics/storage/metric_storage.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
 import '../data/metric_point.dart';
+import '../exemplar_filter.dart';
+import '../exemplar_reservoir.dart';
 
 /// Base storage interface for all metric types.
 /// This replaces the old PointStorage with proper input/output type separation.
@@ -15,7 +17,8 @@ abstract class MetricStorage {
 /// Storage for metrics that have simple numeric input and output (sum, gauge).
 abstract class NumericStorage<T extends num> extends MetricStorage {
   /// Records a measurement with the given attributes and context.
-  void record(T value, [Attributes? attributes, Context? context]);
+  void record(T value,
+      [Attributes? attributes, Context? context, DateTime? timestamp]);
 
   /// Gets the current value for the given attributes.
   /// If no attributes are provided, returns a summary value depending on the instrument type.
@@ -28,7 +31,8 @@ abstract class NumericStorage<T extends num> extends MetricStorage {
 /// Storage for histogram metrics that have numeric input but HistogramValue output.
 abstract class HistogramStorageBase<T extends num> extends MetricStorage {
   /// Records a measurement with the given attributes and context.
-  void record(T value, [Attributes? attributes, Context? context]);
+  void record(T value,
+      [Attributes? attributes, Context? context, DateTime? timestamp]);
 
   /// Gets the current histogram value for the given attributes.
   /// If no attributes are provided, returns a combined HistogramValue across all attribute sets.
@@ -36,4 +40,18 @@ abstract class HistogramStorageBase<T extends num> extends MetricStorage {
 
   /// Collects the current set of metric points containing HistogramValue objects.
   List<MetricPoint<HistogramValue>> collectPoints();
+}
+
+/// Mixin for managing exemplar sampling policy across storage implementations.
+mixin ExemplarSampling<T extends num> {
+  ExemplarFilter get exemplarFilter;
+
+  void maybeOffer(ExemplarReservoir reservoir, T value, Attributes attributes,
+      Context context, DateTime timestamp,
+      [int? bucketIndex]) {
+    if (exemplarFilter.shouldSample(value, attributes, context)) {
+      reservoir.offerMeasurement(
+          value, attributes, context, timestamp, bucketIndex);
+    }
+  }
 }

--- a/lib/src/metrics/storage/sum_storage.dart
+++ b/lib/src/metrics/storage/sum_storage.dart
@@ -3,8 +3,9 @@
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
-import '../data/exemplar.dart';
 import '../data/metric_point.dart';
+import '../exemplar_filter.dart';
+import '../exemplar_reservoir.dart';
 import 'metric_storage.dart';
 
 /// Storage implementation for sum-based metrics like Counter and UpDownCounter.
@@ -33,20 +34,25 @@ class SumStorage<T extends num> extends NumericStorage<T> {
   /// This is used for cumulative temporality reporting.
   final DateTime _startTime = DateTime.now();
 
+  /// The exemplar filter used by this storage.
+  final ExemplarFilter? exemplarFilter;
+
   /// Creates a new SumStorage instance.
   ///
   /// @param isMonotonic Whether this storage is for a monotonic sum
-  SumStorage({required this.isMonotonic});
+  /// @param exemplarFilter Optional filter for exemplars
+  SumStorage({required this.isMonotonic, this.exemplarFilter});
 
-  /// Records a measurement with the given attributes.
+  /// Records a measurement with the given attributes and context.
   ///
   /// For synchronous instruments, this is a delta that gets added to the existing value.
   /// For asynchronous instruments, this should be the absolute value.
   ///
   /// @param value The value to record
   /// @param attributes Optional attributes to associate with this measurement
+  /// @param context Optional context associated with this measurement
   @override
-  void record(T value, [Attributes? attributes]) {
+  void record(T value, [Attributes? attributes, Context? context]) {
     // Check constraints for monotonic counters
     if (isMonotonic && value < 0) {
       print(
@@ -56,16 +62,33 @@ class SumStorage<T extends num> extends NumericStorage<T> {
       return;
     }
 
+    _SumPointData<T> pointData;
     // Check if we already have an entry for these attributes
     if (_points.containsKey(attributes)) {
       // Add to existing data point
-      _points[attributes]!.add(value);
+      pointData = _points[attributes]!;
+      pointData.add(value);
     } else {
       // Create new data point
-      _points[attributes] = _SumPointData<T>(
+      pointData = _SumPointData<T>(
         value: value,
         lastUpdateTime: DateTime.now(),
+        reservoir:
+            SimpleFixedSizeExemplarReservoir(1), // Simple fixed size of 1
       );
+      _points[attributes] = pointData;
+    }
+
+    // Process exemplars if a filter is provided
+    if (exemplarFilter != null && context != null) {
+      if (exemplarFilter!.shouldSample(value,
+          attributes ?? OTelFactory.otelFactory!.attributes(), context)) {
+        pointData.reservoir.offerMeasurement(
+            value,
+            attributes ?? OTelFactory.otelFactory!.attributes(),
+            context,
+            DateTime.now());
+      }
     }
   }
 
@@ -130,7 +153,7 @@ class SumStorage<T extends num> extends NumericStorage<T> {
         time: now,
         value: typedValue,
         isMonotonic: isMonotonic,
-        exemplars: entry.value.exemplars,
+        exemplars: entry.value.reservoir.collectAndReset(attributes),
       );
     }).toList();
   }
@@ -143,20 +166,6 @@ class SumStorage<T extends num> extends NumericStorage<T> {
   @override
   void reset() {
     _points.clear();
-  }
-
-  /// Adds an exemplar to a specific point.
-  ///
-  /// Exemplars are example measurements that provide additional
-  /// context about specific observations.
-  ///
-  /// @param exemplar The exemplar to add
-  /// @param attributes The attributes identifying the point to add the exemplar to
-  @override
-  void addExemplar(Exemplar exemplar, [Attributes? attributes]) {
-    if (_points.containsKey(attributes)) {
-      _points[attributes]!.exemplars.add(exemplar);
-    }
   }
 }
 
@@ -171,14 +180,18 @@ class _SumPointData<T extends num> {
   /// The time this point was last updated.
   DateTime lastUpdateTime;
 
-  /// Exemplars for this point.
-  final List<Exemplar> exemplars = [];
+  /// Reservoir for this point.
+  final ExemplarReservoir reservoir;
 
   /// Creates a new _SumPointData instance.
   ///
   /// @param value The initial value
   /// @param lastUpdateTime The time of the initial value
-  _SumPointData({required this.value, required this.lastUpdateTime});
+  /// @param reservoir The exemplar reservoir for this point
+  _SumPointData(
+      {required this.value,
+      required this.lastUpdateTime,
+      required this.reservoir});
 
   /// Adds a value to this point (for synchronous counters).
   ///

--- a/lib/src/metrics/storage/sum_storage.dart
+++ b/lib/src/metrics/storage/sum_storage.dart
@@ -19,7 +19,8 @@ import 'metric_storage.dart';
 ///
 /// More information:
 /// https://opentelemetry.io/docs/specs/otel/metrics/sdk/#the-temporality-of-instruments
-class SumStorage<T extends num> extends NumericStorage<T> {
+class SumStorage<T extends num> extends NumericStorage<T>
+    with ExemplarSampling<T> {
   /// Map of attribute sets to accumulated values.
   final Map<Attributes?, _SumPointData<T>> _points = {};
 
@@ -35,13 +36,15 @@ class SumStorage<T extends num> extends NumericStorage<T> {
   final DateTime _startTime = DateTime.now();
 
   /// The exemplar filter used by this storage.
-  final ExemplarFilter? exemplarFilter;
+  @override
+  final ExemplarFilter exemplarFilter;
 
   /// Creates a new SumStorage instance.
   ///
   /// @param isMonotonic Whether this storage is for a monotonic sum
   /// @param exemplarFilter Optional filter for exemplars
-  SumStorage({required this.isMonotonic, this.exemplarFilter});
+  SumStorage({required this.isMonotonic, ExemplarFilter? exemplarFilter})
+      : exemplarFilter = exemplarFilter ?? const TraceBasedExemplarFilter();
 
   /// Records a measurement with the given attributes and context.
   ///
@@ -52,7 +55,8 @@ class SumStorage<T extends num> extends NumericStorage<T> {
   /// @param attributes Optional attributes to associate with this measurement
   /// @param context Optional context associated with this measurement
   @override
-  void record(T value, [Attributes? attributes, Context? context]) {
+  void record(T value,
+      [Attributes? attributes, Context? context, DateTime? timestamp]) {
     // Check constraints for monotonic counters
     if (isMonotonic && value < 0) {
       print(
@@ -79,17 +83,12 @@ class SumStorage<T extends num> extends NumericStorage<T> {
       _points[attributes] = pointData;
     }
 
-    // Process exemplars if a filter is provided
-    if (exemplarFilter != null && context != null) {
-      if (exemplarFilter!.shouldSample(value,
-          attributes ?? OTelFactory.otelFactory!.attributes(), context)) {
-        pointData.reservoir.offerMeasurement(
-            value,
-            attributes ?? OTelFactory.otelFactory!.attributes(),
-            context,
-            DateTime.now());
-      }
-    }
+    maybeOffer(
+        pointData.reservoir,
+        value,
+        attributes ?? OTelFactory.otelFactory!.attributes(),
+        context ?? Context.current,
+        timestamp ?? DateTime.now());
   }
 
   /// Gets the current value for the given attributes.

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../dartastic_opentelemetry.dart';
+import 'metrics/exemplar_filter.dart';
 
 /// Main entry point for the OpenTelemetry SDK.
 ///
@@ -134,6 +135,7 @@ class OTel {
   /// @param spanKind Default span kind (default: SpanKind.server)
   /// @param metricExporter Custom metric exporter for metrics
   /// @param metricReader Custom metric reader for metrics
+  /// @param exemplarFilter Custom exemplar filter for metrics
   /// @param enableMetrics Whether to enable metrics collection (default: true)
   /// @param enableLogs Whether to enable logs collection and auto-configure exporter (default: true).
   ///   When enabled, the logs exporter is configured based on OTEL_LOGS_EXPORTER env var.
@@ -169,6 +171,7 @@ class OTel {
     SpanKind spanKind = SpanKind.server,
     MetricExporter? metricExporter,
     MetricReader? metricReader,
+    ExemplarFilter? exemplarFilter,
     bool enableMetrics = true,
     bool enableLogs = true,
     LogRecordExporter? logRecordExporter,
@@ -510,6 +513,7 @@ class OTel {
           endpoint: endpoint,
           secure: explicitSecure,
           resource: OTel.defaultResource,
+          exemplarFilter: exemplarFilter,
         );
       } else {
         // Use the provided exporter and/or reader
@@ -519,6 +523,7 @@ class OTel {
           metricExporter: metricExporter,
           metricReader: metricReader,
           resource: OTel.defaultResource,
+          exemplarFilter: exemplarFilter,
         );
       }
     }

--- a/test/unit/infrastructure_coverage_test.dart
+++ b/test/unit/infrastructure_coverage_test.dart
@@ -606,41 +606,6 @@ void main() {
       expect(storage.getValue(unknownAttrs), closeTo(0.0, 0.001));
     });
 
-    test('SumStorage addExemplar adds to existing point', () {
-      final storage = SumStorage<int>(isMonotonic: true);
-
-      final attrs = OTel.attributesFromMap({'key': 'val'});
-      storage.record(42, attrs);
-
-      final exemplar = Exemplar(
-        attributes: OTel.attributes(),
-        filteredAttributes: OTel.attributes(),
-        timestamp: DateTime.now(),
-        value: 42,
-      );
-      storage.addExemplar(exemplar, attrs);
-
-      final points = storage.collectPoints();
-      expect(points.length, equals(1));
-      expect(points.first.exemplars?.length, equals(1));
-    });
-
-    test('SumStorage addExemplar does nothing for non-existing point', () {
-      final storage = SumStorage<int>(isMonotonic: true);
-
-      final attrs = OTel.attributesFromMap({'key': 'val'});
-      final exemplar = Exemplar(
-        attributes: OTel.attributes(),
-        filteredAttributes: OTel.attributes(),
-        timestamp: DateTime.now(),
-        value: 42,
-      );
-      // No point exists for these attrs, so addExemplar should be a no-op.
-      storage.addExemplar(exemplar, attrs);
-
-      expect(storage.collectPoints(), isEmpty);
-    });
-
     test('SumStorage collectPoints with null attributes', () {
       final storage = SumStorage<int>(isMonotonic: true);
       storage.record(7); // null attributes

--- a/test/unit/metrics/data/exemplar_test.dart
+++ b/test/unit/metrics/data/exemplar_test.dart
@@ -85,9 +85,7 @@ void main() {
 
       // Create exemplar from measurement
       final exemplar = Exemplar.fromMeasurement(
-        value: measurement.value,
-        measurementAttributes:
-            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
+        measurement: measurement,
         timestamp: timestamp,
         aggregationAttributes: attributesSubset,
         traceId: traceId,
@@ -153,9 +151,7 @@ void main() {
       final measurement = createTestMeasurement(100, measurementAttributes);
 
       final exemplar = Exemplar.fromMeasurement(
-        value: measurement.value,
-        measurementAttributes:
-            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
+        measurement: measurement,
         timestamp: DateTime.now(),
         aggregationAttributes: aggregationAttributes,
       );
@@ -224,9 +220,7 @@ void main() {
       final measurement1 = createTestMeasurement(100, emptyMeasurementAttrs);
 
       final exemplar1 = Exemplar.fromMeasurement(
-        value: measurement1.value,
-        measurementAttributes:
-            measurement1.attributes ?? OTelFactory.otelFactory!.attributes(),
+        measurement: measurement1,
         timestamp: DateTime.now(),
         aggregationAttributes: someAggregationAttrs,
       );
@@ -244,9 +238,7 @@ void main() {
       final measurement2 = createTestMeasurement(100, someMeasurementAttrs);
 
       final exemplar2 = Exemplar.fromMeasurement(
-        value: measurement2.value,
-        measurementAttributes:
-            measurement2.attributes ?? OTelFactory.otelFactory!.attributes(),
+        measurement: measurement2,
         timestamp: DateTime.now(),
         aggregationAttributes: emptyAggregationAttrs,
       );
@@ -278,9 +270,7 @@ void main() {
       final aggregationAttributes = Attributes.of({'key1': 'value1'});
 
       final exemplar = Exemplar.fromMeasurement(
-        value: measurement.value,
-        measurementAttributes:
-            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
+        measurement: measurement,
         timestamp: DateTime.now(),
         aggregationAttributes: aggregationAttributes,
       );
@@ -311,9 +301,7 @@ void main() {
       final measurement = createTestMeasurement(100, measurementAttributes);
 
       final exemplar = Exemplar.fromMeasurement(
-        value: measurement.value,
-        measurementAttributes:
-            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
+        measurement: measurement,
         timestamp: DateTime.now(),
         aggregationAttributes: aggregationAttributes,
       );

--- a/test/unit/metrics/data/exemplar_test.dart
+++ b/test/unit/metrics/data/exemplar_test.dart
@@ -85,7 +85,9 @@ void main() {
 
       // Create exemplar from measurement
       final exemplar = Exemplar.fromMeasurement(
-        measurement: measurement,
+        value: measurement.value,
+        measurementAttributes:
+            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
         timestamp: timestamp,
         aggregationAttributes: attributesSubset,
         traceId: traceId,
@@ -151,7 +153,9 @@ void main() {
       final measurement = createTestMeasurement(100, measurementAttributes);
 
       final exemplar = Exemplar.fromMeasurement(
-        measurement: measurement,
+        value: measurement.value,
+        measurementAttributes:
+            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
         timestamp: DateTime.now(),
         aggregationAttributes: aggregationAttributes,
       );
@@ -220,7 +224,9 @@ void main() {
       final measurement1 = createTestMeasurement(100, emptyMeasurementAttrs);
 
       final exemplar1 = Exemplar.fromMeasurement(
-        measurement: measurement1,
+        value: measurement1.value,
+        measurementAttributes:
+            measurement1.attributes ?? OTelFactory.otelFactory!.attributes(),
         timestamp: DateTime.now(),
         aggregationAttributes: someAggregationAttrs,
       );
@@ -238,7 +244,9 @@ void main() {
       final measurement2 = createTestMeasurement(100, someMeasurementAttrs);
 
       final exemplar2 = Exemplar.fromMeasurement(
-        measurement: measurement2,
+        value: measurement2.value,
+        measurementAttributes:
+            measurement2.attributes ?? OTelFactory.otelFactory!.attributes(),
         timestamp: DateTime.now(),
         aggregationAttributes: emptyAggregationAttrs,
       );
@@ -270,7 +278,9 @@ void main() {
       final aggregationAttributes = Attributes.of({'key1': 'value1'});
 
       final exemplar = Exemplar.fromMeasurement(
-        measurement: measurement,
+        value: measurement.value,
+        measurementAttributes:
+            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
         timestamp: DateTime.now(),
         aggregationAttributes: aggregationAttributes,
       );
@@ -301,7 +311,9 @@ void main() {
       final measurement = createTestMeasurement(100, measurementAttributes);
 
       final exemplar = Exemplar.fromMeasurement(
-        measurement: measurement,
+        value: measurement.value,
+        measurementAttributes:
+            measurement.attributes ?? OTelFactory.otelFactory!.attributes(),
         timestamp: DateTime.now(),
         aggregationAttributes: aggregationAttributes,
       );

--- a/test/unit/metrics/exemplar_reservoir_test.dart
+++ b/test/unit/metrics/exemplar_reservoir_test.dart
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'dart:math';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/metrics/exemplar_reservoir.dart';
+import 'package:test/test.dart';
+
+class _ThrowingRandom implements Random {
+  @override
+  int nextInt(int max) => throw StateError('nextInt should not be called');
+  @override
+  bool nextBool() => throw StateError('nextBool should not be called');
+  @override
+  double nextDouble() => throw StateError('nextDouble should not be called');
+}
+
+void main() {
+  setUp(() async {
+    await OTel.reset();
+    await OTel.initialize();
+  });
+  tearDown(() async {
+    await OTel.shutdown();
+  });
+
+  group('SimpleFixedSizeExemplarReservoir tests', () {
+    test('samples correctly using deterministic random', () {
+      // Use a seeded random for deterministic tests.
+      // Random(42) produces a specific sequence of ints.
+      final random = Random(42);
+      final reservoir = SimpleFixedSizeExemplarReservoir(2, random: random);
+
+      final attributes = Attributes.of({});
+      final context = Context.current;
+
+      // Offer first two measurements, they should both fit in the size=2 reservoir
+      reservoir.offerMeasurement(10, attributes, context, DateTime.now());
+      reservoir.offerMeasurement(20, attributes, context, DateTime.now());
+
+      var exemplars = reservoir.collectAndReset(attributes);
+      expect(exemplars.length, equals(2));
+      expect(exemplars.map((e) => e.value).toSet(), equals({10, 20}));
+
+      // The reservoir was reset, so measurementsSeen is 0.
+      // The first two measurements (10, 20) are stored unconditionally.
+      // The next three (30, 40, 50) will trigger random sampling replacement.
+      for (var i = 1; i <= 5; i++) {
+        reservoir.offerMeasurement(i * 10, attributes, context, DateTime.now());
+      }
+      exemplars = reservoir.collectAndReset(attributes);
+
+      // Since it's deterministic and fixed size is 2, length is always 2.
+      // With Random(42) and this exact sequence (after a reset), the surviving values are known:
+      expect(exemplars.length, equals(2));
+      expect(exemplars.map((e) => e.value).toSet(), equals({10, 30}));
+
+      // Reset is called so the reservoir should be empty if collected again
+      expect(reservoir.collectAndReset(attributes).length, equals(0));
+    });
+
+    test('collectAndReset clears measurementsSeen', () {
+      final random = _ThrowingRandom();
+      final reservoir = SimpleFixedSizeExemplarReservoir(2, random: random);
+      final attributes = Attributes.of({});
+      final context = Context.current;
+
+      // Offer exactly size measurements (no random needed)
+      reservoir.offerMeasurement(10, attributes, context, DateTime.now());
+      reservoir.offerMeasurement(20, attributes, context, DateTime.now());
+      reservoir.collectAndReset(attributes);
+
+      // Offer again exactly size measurements
+      // If _measurementsSeen was NOT reset, it would call random.nextInt and throw
+      expect(
+        () {
+          reservoir.offerMeasurement(30, attributes, context, DateTime.now());
+          reservoir.offerMeasurement(40, attributes, context, DateTime.now());
+        },
+        returnsNormally,
+      );
+
+      final exemplars = reservoir.collectAndReset(attributes);
+      expect(exemplars.map((e) => e.value).toSet(), equals({30, 40}));
+    });
+  });
+
+  group('AlignedHistogramBucketExemplarReservoir tests', () {
+    test('probabilistic replacement per bucket', () {
+      final random = Random(123);
+      final boundaries = [10.0, 20.0];
+      final reservoir =
+          AlignedHistogramBucketExemplarReservoir(boundaries, random: random);
+
+      final attributes = Attributes.of({});
+      final context = Context.current;
+
+      // Bucket 0: <= 10.0
+      reservoir.offerMeasurement(5, attributes, context, DateTime.now());
+      // Bucket 1: <= 20.0
+      reservoir.offerMeasurement(15, attributes, context, DateTime.now());
+      // Bucket 2: > 20.0
+      reservoir.offerMeasurement(25, attributes, context, DateTime.now());
+
+      var exemplars = reservoir.collectAndReset(attributes);
+      expect(exemplars.length, equals(3));
+      expect(exemplars.map((e) => e.value).toSet(), equals({5, 15, 25}));
+
+      // Test multiple measurements in the same bucket
+      for (var i = 0; i < 10; i++) {
+        reservoir.offerMeasurement(
+            5 + (i * 0.1), attributes, context, DateTime.now());
+      }
+      exemplars = reservoir.collectAndReset(attributes);
+      // Still only one exemplar for that bucket
+      expect(exemplars.length, equals(1));
+
+      // With Random(123) and this exact sequence (after a reset), the surviving value is known:
+      expect(exemplars.first.value, equals(5.2));
+    });
+
+    test('collectAndReset clears per-bucket counts', () {
+      final random = _ThrowingRandom();
+      final boundaries = [10.0];
+      final reservoir =
+          AlignedHistogramBucketExemplarReservoir(boundaries, random: random);
+      final attributes = Attributes.of({});
+      final context = Context.current;
+
+      // First offer in bucket 0, no random needed
+      reservoir.offerMeasurement(5, attributes, context, DateTime.now());
+      reservoir.collectAndReset(attributes);
+
+      // Offer again in bucket 0
+      // If counts[0] was NOT reset (still 1), it would try to roll random.nextInt(2) and throw
+      expect(
+        () =>
+            reservoir.offerMeasurement(5, attributes, context, DateTime.now()),
+        returnsNormally,
+      );
+
+      final exemplars = reservoir.collectAndReset(attributes);
+      expect(exemplars.length, equals(1));
+    });
+
+    test('trusts pre-computed bucketIndex', () {
+      final boundaries = [10.0, 20.0];
+      final reservoir = AlignedHistogramBucketExemplarReservoir(boundaries);
+      final attributes = Attributes.of({});
+      final context = Context.current;
+
+      // A value of 5 belongs in bucket 0 (<= 10.0) normally.
+      // If we pass bucketIndex: 2 (> 20.0), it should unconditionally trust the index.
+      reservoir.offerMeasurement(5, attributes, context, DateTime.now(), 2);
+
+      // Now offer another value of 5 to bucket 0.
+      reservoir.offerMeasurement(5, attributes, context, DateTime.now(), 0);
+
+      // Since they landed in distinct buckets, there should be 2 exemplars collected.
+      // If it ignored the pre-computed index, both would be in bucket 0,
+      // resulting in only 1 exemplar collected.
+      final exemplars = reservoir.collectAndReset(attributes);
+      expect(exemplars.length, equals(2));
+    });
+  });
+}

--- a/test/unit/metrics/storage/gauge_storage_test.dart
+++ b/test/unit/metrics/storage/gauge_storage_test.dart
@@ -121,36 +121,5 @@ void main() {
       expect(storage.getValue(attributes1), equals(0.0)); // Default value
       expect(storage.getValue(attributes2), equals(0.0)); // Default value
     });
-
-    test('GaugeStorage addExemplar adds exemplars to points', () {
-      final storage = GaugeStorage<double>();
-      final attributes1 = {'service': 'api'}.toAttributes();
-
-      // Record a value
-      storage.record(5.5, attributes1);
-
-      // Create an exemplar
-      final traceId = OTel.traceId();
-      final spanId = OTel.spanId();
-      final exemplar = Exemplar(
-        value: 5.5,
-        timestamp: DateTime.now(),
-        traceId: traceId,
-        spanId: spanId,
-        attributes: {'request.id': '123'}.toAttributes(),
-        filteredAttributes: OTel.attributes(),
-      );
-
-      // Add the exemplar
-      storage.addExemplar(exemplar, attributes1);
-
-      // Collect points and verify exemplar was added
-      final points = storage.collectPoints();
-      expect(points.length, equals(1));
-      expect(points.first.exemplars!.length, equals(1));
-      expect(points.first.exemplars!.first.value, equals(5.5));
-      expect(points.first.exemplars!.first.traceId, equals(traceId));
-      expect(points.first.exemplars!.first.spanId, equals(spanId));
-    });
   });
 }

--- a/test/unit/metrics/storage/gauge_storage_test.dart
+++ b/test/unit/metrics/storage/gauge_storage_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/src/metrics/exemplar_filter.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -121,5 +122,70 @@ void main() {
       expect(storage.getValue(attributes1), equals(0.0)); // Default value
       expect(storage.getValue(attributes2), equals(0.0)); // Default value
     });
+    test('retains sampled exemplar if followed by unsampled record', () {
+      final storage =
+          GaugeStorage<int>(); // uses default TraceBasedExemplarFilter
+      final attributes = Attributes.of({'k': 'v'});
+
+      final tracer = OTel.tracer();
+      final span = tracer.startSpan('test-span');
+      final sampledContext = Context.current.withSpan(span);
+      final unsampledContext = Context.current; // No active span
+
+      // Record a sampled measurement
+      storage.record(10, attributes, sampledContext);
+
+      // Record an unsampled measurement
+      storage.record(20, attributes, unsampledContext);
+
+      final points = storage.collectPoints();
+      expect(points.length, equals(1));
+
+      // Value should be latest (20)
+      expect(points.first.value, equals(20));
+
+      // Exemplar should be from the sampled measurement (value 10)
+      final exemplars = points.first.exemplars!;
+      expect(exemplars.length, equals(1));
+      expect(exemplars.first.value, equals(10));
+      expect(exemplars.first.traceId, equals(span.spanContext.traceId));
+
+      span.end();
+    });
+
+    test('reservoir survives across multiple record calls', () {
+      // Create a filter that accepts everything
+      final storage = GaugeStorage<int>(exemplarFilter: _AlwaysSampleFilter());
+      final attributes = Attributes.of({});
+      final context = Context.current;
+
+      // First record
+      storage.record(10, attributes, context);
+
+      // Second record (reservoir should be reused, not recreated)
+      storage.record(20, attributes, context);
+
+      final points = storage.collectPoints();
+      expect(points.length, equals(1));
+
+      // The reservoir size is 1, so it only retains 1 exemplar.
+      // Depending on SimpleFixedSizeExemplarReservoir random, it might keep 10 or 20,
+      // but it MUST keep at least one. If reservoir was recreated every time, it would
+      // always keep the last one.
+      expect(points.first.exemplars!.length, equals(1));
+
+      // Collecting points should have called collectAndReset.
+      // If we record another value now, the reservoir should have been cleared.
+      storage.record(30, attributes, context);
+      final nextPoints = storage.collectPoints();
+      expect(nextPoints.length, equals(1));
+      expect(nextPoints.first.exemplars!.length, equals(1));
+      expect(nextPoints.first.exemplars!.first.value, equals(30));
+    });
   });
+}
+
+class _AlwaysSampleFilter implements ExemplarFilter {
+  @override
+  bool shouldSample(num value, Attributes attributes, Context context) => true;
 }

--- a/test/unit/metrics/storage/histogram_storage_test.dart
+++ b/test/unit/metrics/storage/histogram_storage_test.dart
@@ -154,36 +154,5 @@ void main() {
       expect(histogramValue.sum, equals(30.0)); // 5 + 10 + 15, but as double
       expect(histogramValue.count, equals(3));
     });
-
-    test('HistogramStorage with exemplars', () {
-      final storage = HistogramStorage<double>(boundaries: [0.0, 10.0, 20.0]);
-      final attributes = {'service': 'api'}.toAttributes();
-
-      // Record a value
-      storage.record(15.0, attributes);
-
-      // Create an exemplar
-      final traceId = OTel.traceId();
-      final spanId = OTel.spanId();
-      final exemplar = Exemplar(
-        value: 15.0,
-        timestamp: DateTime.now(),
-        traceId: traceId,
-        spanId: spanId,
-        attributes: {'request.id': '123'}.toAttributes(),
-        filteredAttributes: OTel.attributes(),
-      );
-
-      // Add the exemplar
-      storage.addExemplar(exemplar, attributes);
-
-      // Collect points and verify exemplar was added
-      final points = storage.collectPoints();
-      expect(points.length, equals(1));
-      expect(points.first.exemplars!.length, equals(1));
-      expect(points.first.exemplars!.first.value, equals(15.0));
-      expect(points.first.exemplars!.first.traceId, equals(traceId));
-      expect(points.first.exemplars!.first.spanId, equals(spanId));
-    });
   });
 }


### PR DESCRIPTION
Resolves #154 

This PR implements Metrics SDK Exemplar support according to the OpenTelemetry Specification v1.60.0. This allows the metrics SDK to collect specific exemplar data points along with aggregated metrics, establishing a correlation between metrics and trace data.

### Changes
- **Exemplar Filter Integration:** Added `ExemplarFilter` interfaces and implemented the standard filters (`AlwaysOnExemplarFilter`, `AlwaysOffExemplarFilter`, `TraceBasedExemplarFilter`). Plumbed `OTEL_METRICS_EXEMPLAR_FILTER` through `MetricsConfiguration`.
- **Exemplar Reservoirs:** Introduced `ExemplarReservoir` sampling strategies (`SimpleFixedSizeExemplarReservoir` for monotonic sums and gauges, and `AlignedHistogramBucketExemplarReservoir` for histograms).
- **Storage Refactoring:** Removed manual `addExemplar` injection and updated `SumStorage`, `GaugeStorage`, and `HistogramStorage` to automatically sample exemplars via their internal reservoirs during the `record()` cycle.
- **Instrument Context Capture:** Upgraded all metric instruments (Counters, Histograms, Gauges, and Observables) to automatically capture `Context.current` during `record()` and pass it to the storage layer for tracing correlations.
- **Testing:** Fixed and enhanced tests to thoroughly cover `Exemplar.fromMeasurement` mapping and ensuring reservoirs correctly retain valid trace metadata without memory leaks.
