### PR TITLE
test(metrics): assert metrics endpoint URLs against a real collector

### DIFF
--- a/test/unit/metrics/export/metric_config_endpoint_test.dart
+++ b/test/unit/metrics/export/metric_config_endpoint_test.dart
@@ -1,0 +1,181 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// End-to-end endpoint wiring for the OTLP/HTTP metric exporter.
+//
+// These bind a local collector and assert on the request path it actually
+// receives, so they prove the exporter's URL construction rather than its
+// instrumentation. Asserting on debug log output would couple the tests to
+// log strings and require a specific OTelLog level to be in effect.
+//
+// Two requirements are covered, kept in separate groups because different
+// changes fix them:
+//
+//   #229 - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT must be applied at all.
+//          Fixed in #72; these tests hold it in place.
+//   #219 - a per-signal endpoint MUST be used as-is, while the generic
+//          OTEL_EXPORTER_OTLP_ENDPOINT is a base URL that takes the signal
+//          path appended. Still open, so the two per-signal cases are
+//          skipped rather than red.
+//
+// Spec: protocol/exporter.md, "Endpoint URLs for OTLP/HTTP"
+//   1. For the per-signal variables (OTEL_EXPORTER_OTLP_<signal>_ENDPOINT),
+//      the URL MUST be used as-is without any modification. The only
+//      exception is that if an URL contains no path part, the root path /
+//      MUST be used.
+//   2. If signals are sent that have no per-signal configuration,
+//      OTEL_EXPORTER_OTLP_ENDPOINT is used as a base URL and the signals
+//      are sent to these paths relative to that: Metrics: v1/metrics
+
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+/// Reason attached to the cases #219 has to fix before they can run.
+const _blockedOn219 =
+    'Blocked on #219: OtlpHttpMetricExporter appends /v1/metrics '
+    'unconditionally, so a per-signal endpoint is modified instead of being '
+    'used as-is. Un-skip when #219 lands.';
+
+void main() {
+  late HttpServer server;
+  late int port;
+  late List<String> requestPaths;
+
+  setUp(() async {
+    await OTel.reset();
+    requestPaths = [];
+    server = await HttpServer.bind('localhost', 0);
+    port = server.port;
+    server.listen((request) async {
+      requestPaths.add(request.uri.path);
+      await request.drain<void>();
+      request.response.statusCode = 200;
+      await request.response.close();
+    });
+  });
+
+  tearDown(() async {
+    await server.close(force: true);
+    try {
+      await OTel.shutdown();
+    } catch (_) {}
+    await OTel.reset();
+    EnvironmentService.testOverrides = null;
+  });
+
+  /// Initializes with [vars], exports one metric, and waits for the local
+  /// collector to receive it.
+  ///
+  /// forceFlush() can return before the HTTP request has been handled, so
+  /// this polls rather than asserting immediately, which would race the
+  /// socket and fail intermittently.
+  Future<void> initAndFlush(Map<String, String> vars,
+      {String? endpoint}) async {
+    EnvironmentService.testOverrides = {
+      'OTEL_TRACES_EXPORTER': 'none',
+      ...vars,
+    };
+    await OTel.initialize(
+      endpoint: endpoint,
+      serviceName: 'metrics-endpoint-test',
+      detectPlatformResources: false,
+      enableLogs: false,
+    );
+    OTel.meter('endpoint-meter').createCounter<int>(name: 'hits').add(1);
+    await OTel.meterProvider().forceFlush();
+
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (requestPaths.isEmpty && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(requestPaths, isNotEmpty,
+        reason: 'the exporter never reached the test collector');
+  }
+
+  // Whether the configured endpoint reaches the exporter at all. These match
+  // the configured base as a prefix rather than the exact path, so they stay
+  // green independently of the #219 signal-path defect covered below.
+  group('OTEL_EXPORTER_OTLP_METRICS_ENDPOINT is applied (#229)', () {
+    test('a per-signal metrics endpoint reaches the exporter', () async {
+      await initAndFlush({
+        'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT':
+            'http://localhost:$port/tenant/metrics-in',
+      });
+
+      expect(requestPaths.single, startsWith('/tenant/metrics-in'));
+    });
+
+    test('a per-signal metrics endpoint overrides the generic endpoint',
+        () async {
+      await initAndFlush({
+        // Nothing listens on port 9, so reaching the test collector at all
+        // proves the per-signal value won.
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:9/wrong',
+        'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT':
+            'http://localhost:$port/metrics-only',
+      });
+
+      expect(requestPaths.single, startsWith('/metrics-only'));
+    });
+
+    test('the generic endpoint is used when no per-signal endpoint is set',
+        () async {
+      await initAndFlush({
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:$port/base',
+      });
+
+      expect(requestPaths.single, startsWith('/base'));
+    });
+
+    test('the initialize() endpoint parameter reaches the exporter', () async {
+      await initAndFlush({}, endpoint: 'http://localhost:$port/from-init');
+
+      expect(requestPaths.single, startsWith('/from-init'));
+    });
+  });
+
+  // Exact URL construction: the signal path belongs on base URLs only.
+  group('signal path is appended only to base URLs (#219)', () {
+    test(
+      'a per-signal metrics endpoint is used as-is',
+      () async {
+        await initAndFlush({
+          'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT':
+              'http://localhost:$port/tenant/metrics-in',
+        });
+
+        expect(requestPaths, equals(['/tenant/metrics-in']));
+      },
+      skip: _blockedOn219,
+    );
+
+    test(
+      'a per-signal endpoint with no path part uses the root path',
+      () async {
+        await initAndFlush({
+          'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT': 'http://localhost:$port',
+        });
+
+        expect(requestPaths, equals(['/']));
+      },
+      skip: _blockedOn219,
+    );
+
+    test('a generic base endpoint takes /v1/metrics appended', () async {
+      await initAndFlush({
+        'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:$port/base',
+      });
+
+      expect(requestPaths, equals(['/base/v1/metrics']));
+    });
+
+    test('the initialize() endpoint parameter takes /v1/metrics appended',
+        () async {
+      await initAndFlush({}, endpoint: 'http://localhost:$port/from-init');
+
+      expect(requestPaths, equals(['/from-init/v1/metrics']));
+    });
+  });
+}


### PR DESCRIPTION
Adds end-to-end coverage for how the OTLP/HTTP metric exporter builds its request
URL. The tests bind a local HTTP server and assert on the request path it actually
receives, so they prove the exporter's URL construction rather than its
instrumentation.

Tests only — no production code changes, and no CHANGELOG entry, since nothing here
changes for app developers.

## Why assert against a collector

The alternative is to assert that a debug log line mentions the endpoint. That
couples the test to a log string, requires a specific `OTelLog` level to be in
effect, and passes even if the endpoint is logged correctly but handed to the
exporter config incorrectly. `OtlpHttpMetricExporter._config` is private, so there is
no in-process seam to read the endpoint back — the request path a collector receives
is the closest observable thing to the behavior we care about.

## What is covered

| case | expectation | status |
|------|-------------|--------|
| per-signal endpoint reaches the exporter | path starts with the configured base | green |
| per-signal endpoint overrides the generic endpoint | path starts with the per-signal base | green |
| generic endpoint used when no per-signal endpoint is set | path starts with the configured base | green |
| `initialize()` endpoint parameter reaches the exporter | path starts with the configured base | green |
| generic base endpoint takes `/v1/metrics` appended | `/base/v1/metrics` | green |
| `initialize()` endpoint takes `/v1/metrics` appended | `/from-init/v1/metrics` | green |
| per-signal endpoint used as-is | `/tenant/metrics-in` | skipped, #219 |
| per-signal endpoint with no path uses the root path | `/` | skipped, #219 |

The first group deliberately matches the configured base as a **prefix** rather than
the exact path, so it stays green independently of the #219 defect below.

## #229

Fixed in #72. These tests hold it in place, and they are mutation-verified: dropping
`otlpConfig.endpoint ??` from `MetricsConfiguration._createExporter` fails both
per-signal cases and correctly leaves the two base-URL cases passing.

## #219 — still open, and this is what the tests found

`protocol/exporter.md`, "Endpoint URLs for OTLP/HTTP":

> 1. For the per-signal variables (`OTEL_EXPORTER_OTLP_<signal>_ENDPOINT`), the URL
>    MUST be used as-is without any modification. The only exception is that if an
>    URL contains no path part, the root path `/` MUST be used.

`OtlpHttpMetricExporter._getEndpointUrl()` appends `/v1/metrics` unconditionally:

| configured | spec requires | actual |
|------------|---------------|--------|
| `http://host/tenant/metrics-in` | `/tenant/metrics-in` | `/tenant/metrics-in/v1/metrics` |
| `http://host` | `/` | `/v1/metrics` |

Those two cases carry a `skip` reason naming #219 rather than landing red. Un-skip
them when #219 is fixed — they are the acceptance criteria for it.

This is not metrics-only. `otlp_http_span_exporter.dart:78` and
`otlp_http_log_record_exporter.dart:74` do the identical thing for their own signals,
so #219 should fix all three together.

## Flake safety

`forceFlush()` can return before the HTTP request has been handled, so the helper
polls for the request rather than asserting immediately, which would race the socket.
Verified stable over repeated runs and under the `tool/coverage.sh` environment
(`OTEL_LOG_LEVEL=trace`).

Relates to #229, #219.
