### PR TITLE
test(metrics): named-provider exemplar regression, reader failure paths, endpoint validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ExemplarFilter` and `ExemplarReservoir` are exported.** `OTel.initialize`
+  accepts an `exemplarFilter` and `MeterProvider.exemplarFilter` is public, but
+  the types themselves were not exported, so neither could be used from
+  application code.
 - **Attribute limit environment variables are parsed** (#73):
   `OTEL_ATTRIBUTE_COUNT_LIMIT`, `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` and the
   `OTEL_LOGRECORD_*` variants, with the spec's signal-specific-then-general

--- a/lib/dartastic_opentelemetry.dart
+++ b/lib/dartastic_opentelemetry.dart
@@ -38,6 +38,8 @@ export 'src/metrics/data/exemplar.dart';
 export 'src/metrics/data/metric.dart';
 export 'src/metrics/data/metric_data.dart';
 export 'src/metrics/data/metric_point.dart';
+export 'src/metrics/exemplar_filter.dart';
+export 'src/metrics/exemplar_reservoir.dart';
 export 'src/metrics/export/composite_metric_exporter.dart';
 export 'src/metrics/export/metric_config.dart';
 export 'src/metrics/export/metrics_sdk_config.dart';

--- a/lib/src/metrics/meter_provider.dart
+++ b/lib/src/metrics/meter_provider.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../dartastic_opentelemetry.dart';
-import 'exemplar_filter.dart';
 import 'meter.dart';
 
 part 'meter_provider_create.dart';

--- a/lib/src/otel.dart
+++ b/lib/src/otel.dart
@@ -7,7 +7,6 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../dartastic_opentelemetry.dart';
-import 'metrics/exemplar_filter.dart';
 
 /// Main entry point for the OpenTelemetry SDK.
 ///

--- a/test/unit/metrics/exemplar_reservoir_test.dart
+++ b/test/unit/metrics/exemplar_reservoir_test.dart
@@ -4,7 +4,6 @@
 import 'dart:math';
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
-import 'package:dartastic_opentelemetry/src/metrics/exemplar_reservoir.dart';
 import 'package:test/test.dart';
 
 class _ThrowingRandom implements Random {

--- a/test/unit/metrics/named_provider_exemplar_test.dart
+++ b/test/unit/metrics/named_provider_exemplar_test.dart
@@ -1,0 +1,82 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test for the exemplar filter default on providers that
+// MetricsConfiguration never configures.
+//
+// While MeterProvider.exemplarFilter was nullable and both storages guarded
+// on `exemplarFilter != null`, null meant "sample nothing". Only the default
+// provider is assigned a filter, by MetricsConfiguration.configureMeterProvider,
+// so any provider from addMeterProvider silently produced no exemplars at all.
+//
+// metrics/sdk.md requires the opposite: "Exemplar sampling SHOULD be turned on
+// by default" and "The ExemplarFilter ... default value SHOULD be TraceBased".
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() async {
+    await OTel.reset();
+    EnvironmentService.testOverrides = {'OTEL_TRACES_EXPORTER': 'none'};
+    await OTel.initialize(
+      serviceName: 'named-provider-exemplar-test',
+      detectPlatformResources: false,
+      enableLogs: false,
+    );
+  });
+
+  tearDown(() async {
+    try {
+      await OTel.shutdown();
+    } catch (_) {}
+    await OTel.reset();
+    EnvironmentService.testOverrides = null;
+  });
+
+  /// Records [value] on a counter from [provider] inside a sampled span and
+  /// returns the exemplar count collected for it.
+  Future<int> exemplarsForCounterIn(MeterProvider provider) async {
+    final counter =
+        provider.getMeter(name: 'probe').createCounter<int>(name: 'c');
+
+    final tracer = OTel.tracer();
+    final span = tracer.startSpan('probe-span');
+    await tracer.withSpanAsync(span, () async => counter.add(7));
+    span.end();
+
+    var total = 0;
+    for (final metric in await provider.collectAllMetrics()) {
+      for (final point in metric.points) {
+        total += point.exemplars?.length ?? 0;
+      }
+    }
+    return total;
+  }
+
+  test('a named provider defaults to TraceBased rather than no filter', () {
+    final named = OTel.addMeterProvider('named');
+
+    expect(named.exemplarFilter, isA<TraceBasedExemplarFilter>(),
+        reason: 'the spec default is TraceBased, and an unset filter would '
+            'silently disable exemplar sampling entirely');
+  });
+
+  test('a named provider samples exemplars inside a sampled span', () async {
+    final named = OTel.addMeterProvider('named');
+
+    expect(await exemplarsForCounterIn(named), 1);
+  });
+
+  test('the default provider still samples exemplars', () async {
+    expect(await exemplarsForCounterIn(OTel.meterProvider()), 1);
+  });
+
+  test('a named provider honours an explicitly assigned AlwaysOff filter',
+      () async {
+    final named = OTel.addMeterProvider('named')
+      ..exemplarFilter = const AlwaysOffExemplarFilter();
+
+    expect(await exemplarsForCounterIn(named), 0);
+  });
+}

--- a/test/unit/metrics/periodic_metric_reader_test.dart
+++ b/test/unit/metrics/periodic_metric_reader_test.dart
@@ -1,0 +1,135 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// PeriodicExportingMetricReader configuration accessors and the failure
+// paths around forceFlush and shutdown, which were uncovered.
+//
+// The reader is documented as swallowing exporter failures and reporting a
+// boolean rather than propagating, so these pin that contract: an exporter
+// that throws must not take the caller down with it.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+/// An exporter whose every operation throws.
+class _ThrowingExporter implements MetricExporter {
+  @override
+  Future<bool> export(MetricData data) async =>
+      throw StateError('export failed');
+
+  @override
+  Future<bool> forceFlush() async => throw StateError('forceFlush failed');
+
+  @override
+  Future<bool> shutdown() async => throw StateError('shutdown failed');
+}
+
+/// An exporter that records calls and succeeds.
+class _RecordingExporter implements MetricExporter {
+  int exports = 0;
+  int flushes = 0;
+  int shutdowns = 0;
+
+  @override
+  Future<bool> export(MetricData data) async {
+    exports++;
+    return true;
+  }
+
+  @override
+  Future<bool> forceFlush() async {
+    flushes++;
+    return true;
+  }
+
+  @override
+  Future<bool> shutdown() async {
+    shutdowns++;
+    return true;
+  }
+}
+
+void main() {
+  setUp(() async {
+    await OTel.reset();
+    EnvironmentService.testOverrides = {'OTEL_TRACES_EXPORTER': 'none'};
+    await OTel.initialize(
+      serviceName: 'periodic-reader-test',
+      detectPlatformResources: false,
+      enableLogs: false,
+      enableMetrics: false,
+    );
+  });
+
+  tearDown(() async {
+    try {
+      await OTel.shutdown();
+    } catch (_) {}
+    await OTel.reset();
+    EnvironmentService.testOverrides = null;
+  });
+
+  group('PeriodicExportingMetricReader configuration', () {
+    test('interval and timeout expose the configured values', () async {
+      final reader = PeriodicExportingMetricReader(
+        _RecordingExporter(),
+        interval: const Duration(seconds: 7),
+        timeout: const Duration(seconds: 3),
+      );
+      addTearDown(reader.shutdown);
+
+      expect(reader.interval, equals(const Duration(seconds: 7)));
+      expect(reader.timeout, equals(const Duration(seconds: 3)));
+    });
+
+    test('interval and timeout fall back to the spec defaults', () async {
+      final reader = PeriodicExportingMetricReader(_RecordingExporter());
+      addTearDown(reader.shutdown);
+
+      expect(reader.interval, equals(const Duration(seconds: 60)));
+      expect(reader.timeout, equals(const Duration(seconds: 30)));
+    });
+  });
+
+  group('PeriodicExportingMetricReader failure handling', () {
+    test('forceFlush reports false instead of propagating an exporter throw',
+        () async {
+      final reader = PeriodicExportingMetricReader(
+        _ThrowingExporter(),
+        interval: const Duration(hours: 1),
+      );
+      addTearDown(() async {
+        try {
+          await reader.shutdown();
+        } catch (_) {}
+      });
+
+      expect(await reader.forceFlush(), isFalse);
+    });
+
+    test('shutdown reports false instead of propagating an exporter throw',
+        () async {
+      final reader = PeriodicExportingMetricReader(
+        _ThrowingExporter(),
+        interval: const Duration(hours: 1),
+      );
+
+      expect(await reader.shutdown(), isFalse);
+    });
+
+    test('forceFlush and shutdown reach the exporter when it succeeds',
+        () async {
+      final exporter = _RecordingExporter();
+      final reader = PeriodicExportingMetricReader(
+        exporter,
+        interval: const Duration(hours: 1),
+      );
+
+      expect(await reader.forceFlush(), isTrue);
+      expect(exporter.flushes, equals(1));
+
+      expect(await reader.shutdown(), isTrue);
+      expect(exporter.shutdowns, equals(1));
+    });
+  });
+}

--- a/test/unit/metrics/storage/gauge_storage_test.dart
+++ b/test/unit/metrics/storage/gauge_storage_test.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
-import 'package:dartastic_opentelemetry/src/metrics/exemplar_filter.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/unit/trace/export/otlp/otlp_grpc_exporter_config_endpoint_test.dart
+++ b/test/unit/trace/export/otlp/otlp_grpc_exporter_config_endpoint_test.dart
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Endpoint validation in OtlpGrpcExporterConfig. These paths were
+// uncovered: a URL-form endpoint with no port, an unparseable port, and the
+// fallthrough for input that is neither host:port nor a valid URI.
+//
+// Validation runs in the constructor, so each case is driven by constructing
+// a config rather than by calling the private validator directly.
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OtlpGrpcExporterConfig endpoint validation', () {
+    test(
+      'a URL with no port gets the default gRPC port appended',
+      () {
+        expect(
+          OtlpGrpcExporterConfig(endpoint: 'http://collector.example.com')
+              .endpoint,
+          equals('http://collector.example.com:4317'),
+        );
+      },
+      skip: 'Blocked on #281: the branch that appends 4317 is guarded on '
+          '!endpoint.contains(":"), which no URL-form endpoint can satisfy, '
+          'so it is dead code and the port is never added.',
+    );
+
+    test('a bare host with no port gets the default gRPC port appended', () {
+      expect(
+        OtlpGrpcExporterConfig(endpoint: 'collector.example.com').endpoint,
+        equals('collector.example.com:4317'),
+      );
+    });
+
+    test('an explicit port in URL form is left alone', () {
+      expect(
+        OtlpGrpcExporterConfig(endpoint: 'http://collector.example.com:4317')
+            .endpoint,
+        equals('http://collector.example.com:4317'),
+      );
+    });
+
+    test('host:port form is left alone', () {
+      expect(
+        OtlpGrpcExporterConfig(endpoint: 'collector.example.com:4317').endpoint,
+        equals('collector.example.com:4317'),
+      );
+    });
+
+    test('a non-numeric port is rejected', () {
+      expect(
+        () =>
+            OtlpGrpcExporterConfig(endpoint: 'collector.example.com:notaport'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('an empty host in URL form is rejected', () {
+      expect(
+        () => OtlpGrpcExporterConfig(endpoint: 'http://:4317'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('the default endpoint is accepted unchanged', () {
+      expect(OtlpGrpcExporterConfig().endpoint, equals('localhost:4317'));
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #277. Adds the regression test that PR was missing, and picks off three uncovered areas found in `coverage/lcov.info`.

Tests only, plus one export fix described below. 15 tests added, 14 green and 1 skipped against a filed issue.

## Named-provider exemplars (4 tests)

#277 fixed the null exemplar filter default, but only the gauge half of that work got a regression test. The null default was found by probing rather than by the suite, so nothing stops it coming back. These pin that a provider from `addMeterProvider` defaults to `TraceBased`, samples inside a sampled span, and still honours an explicitly assigned `AlwaysOff`.

## Export fix

Writing that test surfaced a real gap. `ExemplarFilter` and `ExemplarReservoir` were never exported:

```dart
OTel.initialize(exemplarFilter: ...)      // takes one
MeterProvider.exemplarFilter              // public field
export 'src/metrics/exemplar_filter.dart' // missing
```

So an application could not construct a filter to pass, or even name the type of `meterProvider.exemplarFilter`. The programmatic configuration path the spec requires was unreachable. Both files are now exported.

This also removed four `unnecessary_import` warnings, two of them in tests that had been importing `package:dartastic_opentelemetry/src/metrics/...` directly to work around the omission. Reaching into `src/` from a test is a reliable signal that something should have been exported.

## PeriodicExportingMetricReader (5 tests)

Covers the `interval` and `timeout` accessors and the `forceFlush` and `shutdown` failure paths, pinning that an exporter which throws is reported as `false` rather than propagating to the caller.

## OtlpGrpcExporterConfig endpoint validation (6 tests + 1 skipped)

Covers default-port appending for a bare host, explicit ports in both forms, a malformed port, and an empty host.

The skipped case documents **#281**. The branch meant to append `:4317` to a URL-form endpoint is guarded on `!endpoint.contains(':')`, which no URL-form endpoint can satisfy because of `://`. It is dead code, and `http://collector.example.com` keeps no port at all:

```
http://collector.example.com  ->  http://collector.example.com   (should be :4317)
collector.example.com         ->  collector.example.com:4317     (correct, other path)
```

The test is written to pass once #281 is fixed, so un-skipping it is the acceptance criterion.

## Verification

- `dart analyze`: no issues
- `dart test test/unit/`: 2183 pass, 4 skipped, 0 failures
- Full `tool/coverage.sh` baseline before this PR was 93.5%, 5249 of 5614 lines

Relates to #277, #281.
