### PR TITLE
fix(metrics): export the real instrumentation scope of each meter (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.1.0-beta.16-wip]
 
+### Fixed
+
+- Metrics now export the real instrumentation scope of the meter that created them, as the
+  [Metrics SDK specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/metrics/sdk.md#exportbatch)
+  requires. Before, the OTLP transform wrote one fixed scope named `@dart/dartastic_opentelemetry`
+  with the version `1.0.0` for the whole batch, and the name, version and schema URL from `getMeter`
+  never reached the wire. The transform now writes one `ScopeMetrics` message for each distinct
+  scope. A meter with no version exports no version
+  ([#292](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/pull/292)).
+- A batch with no metrics now produces a resource with no `ScopeMetrics` group. Before, it produced
+  one group that held the fixed scope and no metrics
+  ([#292](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/pull/292)).
+
 ## [1.1.0-beta.15] - 2026-08-28
 
 ### Breaking Changes

--- a/lib/src/metrics/export/otlp/metric_transformer.dart
+++ b/lib/src/metrics/export/otlp/metric_transformer.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart'
-    show OTelLog;
+    show InstrumentationScope, OTelLog;
 import 'package:fixnum/fixnum.dart';
 
 import '../../../../proto/collector/metrics/v1/metrics_service.pb.dart';
@@ -44,19 +44,60 @@ class MetricTransformer {
         ? transformResource(effectiveResource)
         : resource_proto.Resource();
 
-    final scopeMetrics = proto.ScopeMetrics();
-    scopeMetrics.scope = common_proto.InstrumentationScope(
-      name: '@dart/dartastic_opentelemetry',
-      version: '1.0.0',
-    );
+    // The transform groups the metrics by instrumentation scope. Each
+    // scope becomes one ScopeMetrics message, as the OTLP data model
+    // requires.
+    //
+    // InstrumentationScope has no equality operator, so this map compares
+    // by identity. Each Meter builds its scope one time and gives that one
+    // object to all of its instruments. Identity therefore groups the
+    // metrics correctly, and the map needs no key allocation.
+    final scopeGroups = <InstrumentationScope?, proto.ScopeMetrics>{};
     for (final metric in data.metrics) {
+      final scope = metric.instrumentationScope;
+      final scopeMetrics = scopeGroups[scope] ??= _createScopeMetrics(scope);
       scopeMetrics.metrics
           .add(transformMetric(metric, exemplarFilter: exemplarFilter));
     }
 
-    resourceMetrics.scopeMetrics.add(scopeMetrics);
+    resourceMetrics.scopeMetrics.addAll(scopeGroups.values);
     request.resourceMetrics.add(resourceMetrics);
     return request;
+  }
+
+  /// Creates the ScopeMetrics message for one instrumentation scope.
+  ///
+  /// A null scope gives a scope message with an empty name. The OTLP data
+  /// model reads an empty name as "unknown".
+  static proto.ScopeMetrics _createScopeMetrics(InstrumentationScope? scope) {
+    final scopeMetrics = proto.ScopeMetrics();
+    if (scope == null) {
+      scopeMetrics.scope = common_proto.InstrumentationScope();
+      return scopeMetrics;
+    }
+
+    final protoScope = common_proto.InstrumentationScope()..name = scope.name;
+
+    final version = scope.version;
+    if (version != null && version.isNotEmpty) {
+      protoScope.version = version;
+    }
+
+    final attributes = scope.attributes;
+    if (attributes != null) {
+      protoScope.attributes.addAll(
+        attributes.toMap().entries.map(
+              (entry) => _createKeyValue(entry.key, entry.value.value),
+            ),
+      );
+    }
+    scopeMetrics.scope = protoScope;
+
+    final schemaUrl = scope.schemaUrl;
+    if (schemaUrl != null && schemaUrl.isNotEmpty) {
+      scopeMetrics.schemaUrl = schemaUrl;
+    }
+    return scopeMetrics;
   }
 
   /// Transforms a Resource to an OTLP Resource proto.

--- a/lib/src/metrics/instruments/counter.dart
+++ b/lib/src/metrics/instruments/counter.dart
@@ -164,6 +164,7 @@ class Counter<T extends num> implements APICounter<T>, SDKInstrument {
       description: description,
       unit: unit,
       type: MetricType.sum,
+      instrumentationScope: _meter.instrumentationScope,
       points: points,
     );
 

--- a/lib/src/metrics/instruments/gauge.dart
+++ b/lib/src/metrics/instruments/gauge.dart
@@ -111,6 +111,7 @@ class Gauge<T extends num> implements APIGauge<T>, SDKInstrument {
       description: description,
       unit: unit,
       type: MetricType.gauge,
+      instrumentationScope: _meter.instrumentationScope,
       points: points,
     );
 

--- a/lib/src/metrics/instruments/histogram.dart
+++ b/lib/src/metrics/instruments/histogram.dart
@@ -135,6 +135,7 @@ class Histogram<T extends num> implements APIHistogram<T>, SDKInstrument {
       description: description,
       unit: unit,
       type: MetricType.histogram,
+      instrumentationScope: _meter.instrumentationScope,
       points: points,
     );
 

--- a/lib/src/metrics/instruments/observable_counter.dart
+++ b/lib/src/metrics/instruments/observable_counter.dart
@@ -232,6 +232,7 @@ class ObservableCounter<T extends num>
         description: description,
         unit: unit,
         temporality: AggregationTemporality.cumulative,
+        instrumentationScope: _meter.instrumentationScope,
         points: points,
         isMonotonic: true, // Counters are monotonic
       ),

--- a/lib/src/metrics/instruments/observable_gauge.dart
+++ b/lib/src/metrics/instruments/observable_gauge.dart
@@ -182,6 +182,7 @@ class ObservableGauge<T extends num>
         name: name,
         description: description,
         unit: unit,
+        instrumentationScope: _meter.instrumentationScope,
         points: points,
       ),
     ];

--- a/lib/src/metrics/instruments/observable_up_down_counter.dart
+++ b/lib/src/metrics/instruments/observable_up_down_counter.dart
@@ -211,6 +211,7 @@ class ObservableUpDownCounter<T extends num>
         description: description,
         unit: unit,
         temporality: AggregationTemporality.cumulative,
+        instrumentationScope: _meter.instrumentationScope,
         points: points,
         isMonotonic: false, // Up/down counters are non-monotonic
       ),

--- a/lib/src/metrics/instruments/up_down_counter.dart
+++ b/lib/src/metrics/instruments/up_down_counter.dart
@@ -110,6 +110,7 @@ class UpDownCounter<T extends num>
       description: description,
       unit: unit,
       type: MetricType.sum, // UpDownCounter is still a sum, just not monotonic
+      instrumentationScope: _meter.instrumentationScope,
       points: points,
     );
 

--- a/lib/src/metrics/meter.dart
+++ b/lib/src/metrics/meter.dart
@@ -43,6 +43,23 @@ class Meter implements APIMeter {
       : _delegate = delegate,
         _provider = provider;
 
+  /// The instrumentation scope of this meter.
+  ///
+  /// Each metric that an instrument of this meter collects carries this
+  /// object. The SDK builds the object one time and then shares it,
+  /// because the collection path runs at each export interval.
+  ///
+  /// The API factory does not accept a null version. A meter with no
+  /// version therefore gets an empty version. OTLP reads an empty version
+  /// as "not set", so the exported data stays correct.
+  late final InstrumentationScope instrumentationScope =
+      OTelAPI.instrumentationScope(
+    name: name,
+    version: version ?? '',
+    schemaUrl: schemaUrl,
+    attributes: attributes,
+  );
+
   /// Gets the name of the instrumentation scope.
   ///
   /// This name uniquely identifies the instrumentation library, such as

--- a/test/unit/metrics/export/otlp/metric_transformer_test.dart
+++ b/test/unit/metrics/export/otlp/metric_transformer_test.dart
@@ -315,9 +315,9 @@ void main() {
         );
         expect(rm.scopeMetrics.length, equals(1));
         final sm = rm.scopeMetrics.first;
-        // Same scope constant the OTLP exporters have always stamped.
-        expect(sm.scope.name, equals('@dart/dartastic_opentelemetry'));
-        expect(sm.scope.version, equals('1.0.0'));
+        // A metric with no scope exports as the unknown scope.
+        expect(sm.scope.name, isEmpty);
+        expect(sm.scope.version, isEmpty);
         expect(sm.metrics.length, equals(2));
         expect(sm.metrics.first.name, equals('m.one'));
         expect(sm.metrics.last.name, equals('m.two'));
@@ -359,7 +359,7 @@ void main() {
         );
       });
 
-      test('empty metrics still produce the resource/scope envelope', () {
+      test('empty metrics produce a resource with no scope groups', () {
         final data = MetricData(
           resource: OTel.resource(Attributes.of({'service.name': 's'})),
           metrics: const [],
@@ -367,10 +367,76 @@ void main() {
 
         final request = MetricTransformer.transformMetrics(data);
 
+        // A batch with no metrics has no scope to name, so it carries no
+        // ScopeMetrics group.
         expect(request.resourceMetrics.length, equals(1));
+        expect(request.resourceMetrics.first.scopeMetrics, isEmpty);
+      });
+    });
+
+    group('instrumentation scope', () {
+      test('a counter metric carries the scope of its meter', () async {
+        final meter = OTel.meterProvider().getMeter(
+          name: 'test.library',
+          version: '2.3.4',
+          schemaUrl: 'https://opentelemetry.io/schemas/1.60.0',
+        );
+        meter.createCounter<int>(name: 'requests').add(1);
+
+        final metrics = await OTel.meterProvider().collectAllMetrics();
+        final scope = metrics.first.instrumentationScope;
+
+        expect(scope, isNotNull);
+        expect(scope!.name, equals('test.library'));
+        expect(scope.version, equals('2.3.4'));
         expect(
-          request.resourceMetrics.first.scopeMetrics.first.metrics,
-          isEmpty,
+          scope.schemaUrl,
+          equals('https://opentelemetry.io/schemas/1.60.0'),
+        );
+      });
+
+      test('a meter with no version exports no version', () async {
+        final meter = OTel.meterProvider().getMeter(name: 'test.noversion');
+        meter.createCounter<int>(name: 'plain').add(1);
+
+        final metrics = await OTel.meterProvider().collectAllMetrics();
+        final request = MetricTransformer.transformMetrics(
+          MetricData(metrics: metrics),
+        );
+
+        final sm = request.resourceMetrics.first.scopeMetrics
+            .firstWhere((sm) => sm.scope.name == 'test.noversion');
+        // The SDK must not invent a version. OTLP reads an empty version
+        // as "not set".
+        expect(sm.scope.version, isEmpty);
+      });
+
+      test('two meters export as two scope groups', () async {
+        final meterA = OTel.meterProvider().getMeter(name: 'lib.a');
+        final meterB = OTel.meterProvider().getMeter(
+          name: 'lib.b',
+          version: '9.9.9',
+        );
+        meterA.createCounter<int>(name: 'a.count').add(1);
+        meterB.createCounter<int>(name: 'b.count').add(2);
+
+        final metrics = await OTel.meterProvider().collectAllMetrics();
+        final request = MetricTransformer.transformMetrics(
+          MetricData(metrics: metrics),
+        );
+
+        final groups = request.resourceMetrics.first.scopeMetrics;
+        final byName = {for (final sm in groups) sm.scope.name: sm};
+
+        expect(byName.keys, containsAll(<String>['lib.a', 'lib.b']));
+        expect(byName['lib.b']!.scope.version, equals('9.9.9'));
+        expect(
+          byName['lib.a']!.metrics.map((m) => m.name),
+          equals(<String>['a.count']),
+        );
+        expect(
+          byName['lib.b']!.metrics.map((m) => m.name),
+          equals(<String>['b.count']),
         );
       });
     });


### PR DESCRIPTION
## What this corrects

Closes #163.

**Specification:** OpenTelemetry Specification v1.60.0, Metrics SDK, [Export(batch)](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/metrics/sdk.md#exportbatch)
(rendered: <https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exportbatch>)

> The SDK MUST provide a way for the exporter to get the Meter information (e.g. name, version, etc.) associated with each `Metric Point`.

The SDK did not do this.

`Metric` has an `instrumentationScope` field, but no instrument set it. The field was always null.
`MetricTransformer` then wrote one fixed scope for the whole batch:

```dart
scopeMetrics.scope = common_proto.InstrumentationScope(
  name: '@dart/dartastic_opentelemetry',
  version: '1.0.0',
);
```

Every metric from every meter went out under that scope. The name, the version and the schema URL
that the caller gave to `getMeter` never reached the wire. An exporter had no way to recover the
real identity of the meter.

## The change

1. **`Meter` builds its scope one time** (`lib/src/metrics/meter.dart`). The meter holds one
   `InstrumentationScope` and shares that object with all of its instruments.
2. **The seven instruments set the scope** on each `Metric` that they collect: `Counter`,
   `UpDownCounter`, `Histogram`, `Gauge`, `ObservableCounter`, `ObservableUpDownCounter` and
   `ObservableGauge`.
3. **`MetricTransformer` groups by scope** and writes one `ScopeMetrics` message for each distinct
   scope, with the name, the version, the attributes and the schema URL.

## Specification compliance

| Point | Behavior after this change |
|---|---|
| Exporter can read the Meter information for each Metric Point | Each `Metric` carries the `InstrumentationScope` of its meter. |
| One `ScopeMetrics` for each scope | The transform groups the metrics and emits one message for each distinct scope. |
| The SDK does not invent a version | A meter with no version exports no version. OTLP reads an empty version as "not set". |
| A metric with no scope | It exports with an empty scope name. The OTLP data model reads an empty name as "unknown". |

The schema URL goes on `ScopeMetrics.schema_url`, which is the field that the OTLP data model gives
for the scope.

This change depends on the correction in
[api#108](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/108), which stopped
`getMeter` from inventing a version and a schema URL (issue #113). Without it, this code would
export the invented values instead of the fixed ones.

## Performance

The collection path runs at each export interval, so the scope is built one time for each meter and
not one time for each collection.

Scope acquisition for 50 instruments on one meter, one collection cycle:

| | us/op |
|---|---|
| Cached scope (this PR) | 0.049 |
| A new scope built at each collection | 0.255 |

The transform keys the groups on scope identity, because each meter shares one scope object with its
instruments. It appends each metric straight into the proto list of its group. The other option is
the group key that `SpanTransformer` and `LogRecordTransformer` use: a string key with an
intermediate list for each group. Both produce the same bytes on the wire.

| Batch | This PR (us/op) | String key and list (us/op) | Faster by |
|---|---|---|---|
| 50 metrics, 1 scope | 36.42 | 39.88 | 9.5% |
| 50 metrics, 5 scopes | 38.14 | 41.78 | 9.5% |
| 50 metrics, 50 scopes | 52.28 | 54.92 | 5.0% |
| 1000 metrics, 4 scopes | 723.31 | 773.04 | 6.9% |

A batch with one scope, which is the usual batch, costs one map entry.

Measured on Dart 3.10 (Flutter 3.35.7), macOS arm64, 30000 iterations after 3000 warm-up
iterations, with the output written to a sink so that the compiler cannot remove it.

## Behavior changes

- A batch with no metrics now produces a resource with **no** `ScopeMetrics` group. Before, it
  produced one group that held the fixed scope and no metrics. A batch with no metrics has no scope
  to name.
- A meter with no version exports **no** version, not `1.0.0`.

Both changes correct the exported data. One existing test asserted the old shape and is now updated.

## Tests

- Updated: the two `transformMetrics` tests that asserted the fixed scope and the old empty-batch shape.
- New: a counter metric carries the scope of its meter, with the name, the version and the schema URL.
- New: a meter with no version exports no version.
- New: two meters export as two `ScopeMetrics` groups, and each group holds its own metrics.

`dart analyze lib test` reports no issues. All 443 tests in `test/unit/metrics` pass.

Two tests in `test/unit/sdk/resource_detector_test.dart` fail on this machine. They also fail on
`main` without this change, and they do not touch metrics.

## Not in this PR

- `lib/src/logs/logger.dart` invents the version `1.0.0` in the same way. This is a separate defect.
- `LogRecordTransformer` writes the schema URL of the scope onto `ResourceLogs` and not onto
  `ScopeLogs`. This looks like a defect. This PR does not copy that pattern and does not correct it.

Assisted-by: Claude Opus 5
