### PR TITLE
fix(tool): unbreak the backport constraint detection and run tests serially

### DIFF
--- a/tool/backport_release.dart
+++ b/tool/backport_release.dart
@@ -81,7 +81,7 @@ const _backportedDep = 'dartastic_opentelemetry_api';
 final _betaTagRe = RegExp(r'^v1\.\d+\.\d+-beta(\.\d+)?$');
 
 /// Tag pattern for the stable channel itself.
-final _stableTagRe = RegExp(r'^v0\.9\.\d+$');
+final _stableTagRe = RegExp(r'^v0\.\d+\.\d+$');
 
 Future<void> main(List<String> args) async {
   final flags = _Flags.parse(args);
@@ -394,7 +394,7 @@ String _latestBetaTag() {
   return tags.last;
 }
 
-/// Reads the `_backportedDep` constraint from the most recent `0.9.x` tag.
+/// Reads the `_backportedDep` constraint from the most recent stable `0.x` tag.
 /// That is the constraint the previous republication shipped, which is right
 /// as long as the stable api line has not moved since.
 String _previousStableApiConstraint() {
@@ -408,8 +408,8 @@ String _previousStableApiConstraint() {
       if (m != null) return m.group(1)!;
     }
   }
-  _die('could not auto-detect the $_backportedDep constraint from any v0.9.x '
-      'tag — pass --api-constraint (e.g. --api-constraint ^0.9.1).');
+  _die('could not auto-detect the $_backportedDep constraint from any stable '
+      'v0.x tag; pass --api-constraint (e.g. --api-constraint ^0.11.0).');
 }
 
 /// Warns (does not fail) if pub.dev already lists this version. A soft check:

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -9,7 +9,9 @@ cd "$(dirname "$0")/.." || exit 1
 # Parse command line arguments
 # Need trace logging for coverage of debug and trace logs
 LOG_LEVEL="trace"
-CONCURRENCY="10"
+# Serial by default: the OTLP socket and collector-backed tests bind ports
+# and race each other under concurrency. Pass --concurrency N to go faster.
+CONCURRENCY="1"
 FAIL_FAST="false"
 TEST_PATH="./test"
 

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -2,7 +2,10 @@
 
 # Parse command line arguments
 LOG_LEVEL="info"
-CONCURRENCY="20"
+# Serial by default: the OTLP socket and collector-backed tests bind ports
+# and race each other under concurrency. Pass --concurrency N to go faster
+# when you are not touching the exporters.
+CONCURRENCY="1"
 FAIL_FAST="false"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Two release-tooling fixes that were sitting in my working tree.

**`backport_release.dart`: `_stableTagRe` was pinned to `^v0\.9\.\d+$`.** Once the stable line moved to v0.10.0, no tag matched and the backport fell back to an older v0.9.x, so the 0.11.0 republication picked up `dartastic_opentelemetry_api: ^0.9.1` and failed analyze with 54 errors against the rc.3 surface. I worked around it at release time with `--api-constraint ^0.11.0`. Widening the pattern to `^v0\.\d+\.\d+$` fixes it properly. The `$` anchor still excludes prerelease tags, and tags are sorted so the most recent stable one wins.

**`test.sh` and `coverage.sh` now default to `--concurrency 1`.** The OTLP socket tests and the collector-backed integration tests bind ports and race each other. Four files have failed intermittently in whole-suite runs while passing in isolation. The contention is suite-wide rather than inside any one file, so lowering the default is what removes the flakes. Both scripts still take `--concurrency N`.

Tool scripts only, no library or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3LcZp1QRqoTrKB6PnaJ1Y