### PR TITLE
fix(sampling): correct TraceIdRatioBased sampler description

### DIFF
--- a/lib/src/trace/sampling/trace_id_ratio_sampler.dart
+++ b/lib/src/trace/sampling/trace_id_ratio_sampler.dart
@@ -15,7 +15,7 @@ class TraceIdRatioSampler implements Sampler {
   final double ratio;
 
   @override
-  String get description => 'TraceIdRatioSampler{$ratio}';
+  String get description => 'TraceIdRatioBased{${ratio.toStringAsFixed(6)}}';
 
   /// Creates a TraceIdRatioSampler with the given ratio.
   /// [ratio] must be in the range [0.0, 1.0].

--- a/test/unit/trace/sampling/trace_id_ratio_sampler_test.dart
+++ b/test/unit/trace/sampling/trace_id_ratio_sampler_test.dart
@@ -25,7 +25,7 @@ void main() {
 
     test('description returns expected value', () {
       final sampler = TraceIdRatioSampler(0.5);
-      expect(sampler.description, equals('TraceIdRatioSampler{0.5}'));
+      expect(sampler.description, equals('TraceIdRatioBased{0.500000}'));
     });
 
     test('sampler with ratio 0.0 never samples', () {


### PR DESCRIPTION
## Summary

* Correct `TraceIdRatioSampler` description to use the `TraceIdRatioBased{RATIO}` format.
* Format the ratio with 6 decimal places.
* Update the corresponding test.

## Verification

* `dart format` clean
* `dart analyze` clean
* `dart test test/unit/trace/sampling/trace_id_ratio_sampler_test.dart` passed

Fixes #127