### PR TITLE
The OTLP log exporters send event_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /.run/
 /dartastic_opentelemetry.iml
 /.claude/settings.local.json
+
+# Cloned by tool/setup_protos.sh; generated output lives in lib/proto
+protos/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The OTLP log exporters now send `event_name`.** `LogRecord.eventName` was never copied onto the wire, so every
+  event emitted with `emit(eventName: ...)` arrived at the collector as a plain log record with no name, and anything
+  filtering on `event_name` saw nothing. The bundled protobuf definitions were generated from opentelemetry-proto
+  v1.1.0, which predates the field; they are regenerated from v1.11.0, which adds `LogRecord.event_name` and the
+  `EntityRef` and string-table fields on `Resource`, `AnyValue` and `KeyValue`. No generated type was removed.
 - The `dartastic_opentelemetry_api` dependency is pinned to the current rc (`>=1.0.0-rc.3 <1.0.0-rc.4`) so a new API
   prerelease cannot break a fresh `pub get`. Widen it only after the SDK is adapted
   ([#297](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/pull/297)).

--- a/lib/proto/collector/logs/v1/logs_service.pbgrpc.dart
+++ b/lib/proto/collector/logs/v1/logs_service.pbgrpc.dart
@@ -35,8 +35,6 @@ class LogsServiceClient extends $grpc.Client {
 
   LogsServiceClient(super.channel, {super.options, super.interceptors});
 
-  /// For performance reasons, it is recommended to keep this RPC
-  /// alive for the entire life of the application.
   $grpc.ResponseFuture<$0.ExportLogsServiceResponse> export(
     $0.ExportLogsServiceRequest request, {
     $grpc.CallOptions? options,

--- a/lib/proto/collector/metrics/v1/metrics_service.pbgrpc.dart
+++ b/lib/proto/collector/metrics/v1/metrics_service.pbgrpc.dart
@@ -35,8 +35,6 @@ class MetricsServiceClient extends $grpc.Client {
 
   MetricsServiceClient(super.channel, {super.options, super.interceptors});
 
-  /// For performance reasons, it is recommended to keep this RPC
-  /// alive for the entire life of the application.
   $grpc.ResponseFuture<$0.ExportMetricsServiceResponse> export(
     $0.ExportMetricsServiceRequest request, {
     $grpc.CallOptions? options,

--- a/lib/proto/collector/trace/v1/trace_service.pbgrpc.dart
+++ b/lib/proto/collector/trace/v1/trace_service.pbgrpc.dart
@@ -35,8 +35,6 @@ class TraceServiceClient extends $grpc.Client {
 
   TraceServiceClient(super.channel, {super.options, super.interceptors});
 
-  /// For performance reasons, it is recommended to keep this RPC
-  /// alive for the entire life of the application.
   $grpc.ResponseFuture<$0.ExportTraceServiceResponse> export(
     $0.ExportTraceServiceRequest request, {
     $grpc.CallOptions? options,

--- a/lib/proto/common/v1/common.pb.dart
+++ b/lib/proto/common/v1/common.pb.dart
@@ -25,10 +25,11 @@ enum AnyValue_Value {
   arrayValue,
   kvlistValue,
   bytesValue,
+  stringValueStrindex,
   notSet
 }
 
-/// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+/// Represents any type of attribute value. AnyValue may contain a
 /// primitive value such as a string or integer or it may contain an arbitrary nested
 /// object containing arrays, key-value lists and primitives.
 class AnyValue extends $pb.GeneratedMessage {
@@ -40,6 +41,7 @@ class AnyValue extends $pb.GeneratedMessage {
     ArrayValue? arrayValue,
     KeyValueList? kvlistValue,
     $core.List<$core.int>? bytesValue,
+    $core.int? stringValueStrindex,
   }) {
     final result = create();
     if (stringValue != null) result.stringValue = stringValue;
@@ -49,6 +51,8 @@ class AnyValue extends $pb.GeneratedMessage {
     if (arrayValue != null) result.arrayValue = arrayValue;
     if (kvlistValue != null) result.kvlistValue = kvlistValue;
     if (bytesValue != null) result.bytesValue = bytesValue;
+    if (stringValueStrindex != null)
+      result.stringValueStrindex = stringValueStrindex;
     return result;
   }
 
@@ -69,6 +73,7 @@ class AnyValue extends $pb.GeneratedMessage {
     5: AnyValue_Value.arrayValue,
     6: AnyValue_Value.kvlistValue,
     7: AnyValue_Value.bytesValue,
+    8: AnyValue_Value.stringValueStrindex,
     0: AnyValue_Value.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
@@ -76,7 +81,7 @@ class AnyValue extends $pb.GeneratedMessage {
       package: const $pb.PackageName(
           _omitMessageNames ? '' : 'opentelemetry.proto.common.v1'),
       createEmptyInstance: create)
-    ..oo(0, [1, 2, 3, 4, 5, 6, 7])
+    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8])
     ..aOS(1, _omitFieldNames ? '' : 'stringValue')
     ..aOB(2, _omitFieldNames ? '' : 'boolValue')
     ..aInt64(3, _omitFieldNames ? '' : 'intValue')
@@ -87,6 +92,7 @@ class AnyValue extends $pb.GeneratedMessage {
         subBuilder: KeyValueList.create)
     ..a<$core.List<$core.int>>(
         7, _omitFieldNames ? '' : 'bytesValue', $pb.PbFieldType.OY)
+    ..aI(8, _omitFieldNames ? '' : 'stringValueStrindex')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -114,6 +120,7 @@ class AnyValue extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   @$pb.TagNumber(6)
   @$pb.TagNumber(7)
+  @$pb.TagNumber(8)
   AnyValue_Value whichValue() => _AnyValue_ValueByTag[$_whichOneof(0)]!;
   @$pb.TagNumber(1)
   @$pb.TagNumber(2)
@@ -122,6 +129,7 @@ class AnyValue extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   @$pb.TagNumber(6)
   @$pb.TagNumber(7)
+  @$pb.TagNumber(8)
   void clearValue() => $_clearField($_whichOneof(0));
 
   @$pb.TagNumber(1)
@@ -190,6 +198,25 @@ class AnyValue extends $pb.GeneratedMessage {
   $core.bool hasBytesValue() => $_has(6);
   @$pb.TagNumber(7)
   void clearBytesValue() => $_clearField(7);
+
+  /// Reference to the string value in ProfilesDictionary.string_table.
+  ///
+  /// Note: This is currently used exclusively in the Profiling signal.
+  /// Implementers of OTLP receivers for signals other than Profiling should
+  /// treat the presence of this value as a non-fatal issue.
+  /// Log an error or warning indicating an unexpected field intended for the
+  /// Profiling signal and process the data as if this value were absent or
+  /// empty, ignoring its semantic content for the non-Profiling signal.
+  ///
+  /// Status: [Alpha]
+  @$pb.TagNumber(8)
+  $core.int get stringValueStrindex => $_getIZ(7);
+  @$pb.TagNumber(8)
+  set stringValueStrindex($core.int value) => $_setSignedInt32(7, value);
+  @$pb.TagNumber(8)
+  $core.bool hasStringValueStrindex() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearStringValueStrindex() => $_clearField(8);
 }
 
 /// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
@@ -297,22 +324,26 @@ class KeyValueList extends $pb.GeneratedMessage {
 
   /// A collection of key/value pairs of key-value pairs. The list may be empty (may
   /// contain 0 elements).
+  ///
   /// The keys MUST be unique (it is not allowed to have more than one
   /// value with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(1)
   $pb.PbList<KeyValue> get values => $_getList(0);
 }
 
-/// KeyValue is a key-value pair that is used to store Span attributes, Link
+/// Represents a key-value pair that is used to store Span attributes, Link
 /// attributes, etc.
 class KeyValue extends $pb.GeneratedMessage {
   factory KeyValue({
     $core.String? key,
     AnyValue? value,
+    $core.int? keyStrindex,
   }) {
     final result = create();
     if (key != null) result.key = key;
     if (value != null) result.value = value;
+    if (keyStrindex != null) result.keyStrindex = keyStrindex;
     return result;
   }
 
@@ -333,6 +364,7 @@ class KeyValue extends $pb.GeneratedMessage {
     ..aOS(1, _omitFieldNames ? '' : 'key')
     ..aOM<AnyValue>(2, _omitFieldNames ? '' : 'value',
         subBuilder: AnyValue.create)
+    ..aI(3, _omitFieldNames ? '' : 'keyStrindex')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -353,6 +385,8 @@ class KeyValue extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<KeyValue>(create);
   static KeyValue? _defaultInstance;
 
+  /// The key name of the pair.
+  /// key_strindex MUST NOT be set if key is used.
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -362,6 +396,7 @@ class KeyValue extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearKey() => $_clearField(1);
 
+  /// The value of the pair.
   @$pb.TagNumber(2)
   AnyValue get value => $_getN(1);
   @$pb.TagNumber(2)
@@ -372,6 +407,26 @@ class KeyValue extends $pb.GeneratedMessage {
   void clearValue() => $_clearField(2);
   @$pb.TagNumber(2)
   AnyValue ensureValue() => $_ensure(1);
+
+  /// Reference to the string key in ProfilesDictionary.string_table.
+  /// key MUST NOT be set if key_strindex is used.
+  ///
+  /// Note: This is currently used exclusively in the Profiling signal.
+  /// Implementers of OTLP receivers for signals other than Profiling should
+  /// treat the presence of this key as a non-fatal issue.
+  /// Log an error or warning indicating an unexpected field intended for the
+  /// Profiling signal and process the data as if this value were absent or
+  /// empty, ignoring its semantic content for the non-Profiling signal.
+  ///
+  /// Status: [Alpha]
+  @$pb.TagNumber(3)
+  $core.int get keyStrindex => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set keyStrindex($core.int value) => $_setSignedInt32(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasKeyStrindex() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearKeyStrindex() => $_clearField(3);
 }
 
 /// InstrumentationScope is a message representing the instrumentation scope information
@@ -433,6 +488,7 @@ class InstrumentationScope extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<InstrumentationScope>(create);
   static InstrumentationScope? _defaultInstance;
 
+  /// A name denoting the Instrumentation scope.
   /// An empty instrumentation scope name means the name is unknown.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -443,6 +499,8 @@ class InstrumentationScope extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearName() => $_clearField(1);
 
+  /// Defines the version of the instrumentation scope.
+  /// An empty instrumentation scope version means the version is unknown.
   @$pb.TagNumber(2)
   $core.String get version => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -455,9 +513,13 @@ class InstrumentationScope extends $pb.GeneratedMessage {
   /// Additional attributes that describe the scope. [Optional].
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(3)
   $pb.PbList<KeyValue> get attributes => $_getList(2);
 
+  /// The number of attributes that were discarded. Attributes
+  /// can be discarded because their keys are too long or because there are too many
+  /// attributes. If this value is 0, then no attributes were dropped.
   @$pb.TagNumber(4)
   $core.int get droppedAttributesCount => $_getIZ(3);
   @$pb.TagNumber(4)
@@ -466,6 +528,108 @@ class InstrumentationScope extends $pb.GeneratedMessage {
   $core.bool hasDroppedAttributesCount() => $_has(3);
   @$pb.TagNumber(4)
   void clearDroppedAttributesCount() => $_clearField(4);
+}
+
+/// A reference to an Entity.
+/// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
+///
+/// Status: [Development]
+class EntityRef extends $pb.GeneratedMessage {
+  factory EntityRef({
+    $core.String? schemaUrl,
+    $core.String? type,
+    $core.Iterable<$core.String>? idKeys,
+    $core.Iterable<$core.String>? descriptionKeys,
+  }) {
+    final result = create();
+    if (schemaUrl != null) result.schemaUrl = schemaUrl;
+    if (type != null) result.type = type;
+    if (idKeys != null) result.idKeys.addAll(idKeys);
+    if (descriptionKeys != null) result.descriptionKeys.addAll(descriptionKeys);
+    return result;
+  }
+
+  EntityRef._();
+
+  factory EntityRef.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory EntityRef.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'EntityRef',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'opentelemetry.proto.common.v1'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'schemaUrl')
+    ..aOS(2, _omitFieldNames ? '' : 'type')
+    ..pPS(3, _omitFieldNames ? '' : 'idKeys')
+    ..pPS(4, _omitFieldNames ? '' : 'descriptionKeys')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EntityRef clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EntityRef copyWith(void Function(EntityRef) updates) =>
+      super.copyWith((message) => updates(message as EntityRef)) as EntityRef;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EntityRef create() => EntityRef._();
+  @$core.override
+  EntityRef createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static EntityRef getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EntityRef>(create);
+  static EntityRef? _defaultInstance;
+
+  /// The Schema URL, if known. This is the identifier of the Schema that the entity data
+  /// is recorded in. To learn more about Schema URL see
+  /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  ///
+  /// This schema_url applies to the data in this message and to the Resource attributes
+  /// referenced by id_keys and description_keys.
+  /// TODO: discuss if we are happy with this somewhat complicated definition of what
+  /// the schema_url applies to.
+  ///
+  /// This field obsoletes the schema_url field in ResourceMetrics/ResourceSpans/ResourceLogs.
+  @$pb.TagNumber(1)
+  $core.String get schemaUrl => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set schemaUrl($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasSchemaUrl() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSchemaUrl() => $_clearField(1);
+
+  /// Defines the type of the entity. MUST not change during the lifetime of the entity.
+  /// For example: "service" or "host". This field is required and MUST not be empty
+  /// for valid entities.
+  @$pb.TagNumber(2)
+  $core.String get type => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set type($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearType() => $_clearField(2);
+
+  /// Attribute Keys that identify the entity.
+  /// MUST not change during the lifetime of the entity. The Id must contain at least one attribute.
+  /// These keys MUST exist in the containing {message}.attributes.
+  @$pb.TagNumber(3)
+  $pb.PbList<$core.String> get idKeys => $_getList(2);
+
+  /// Descriptive (non-identifying) attribute keys of the entity.
+  /// MAY change over the lifetime of the entity. MAY be empty.
+  /// These attribute keys are not part of entity's identity.
+  /// These keys MUST exist in the containing {message}.attributes.
+  @$pb.TagNumber(4)
+  $pb.PbList<$core.String> get descriptionKeys => $_getList(3);
 }
 
 const $core.bool _omitFieldNames =

--- a/lib/proto/common/v1/common.pbjson.dart
+++ b/lib/proto/common/v1/common.pbjson.dart
@@ -42,6 +42,14 @@ const AnyValue$json = {
       '10': 'kvlistValue'
     },
     {'1': 'bytes_value', '3': 7, '4': 1, '5': 12, '9': 0, '10': 'bytesValue'},
+    {
+      '1': 'string_value_strindex',
+      '3': 8,
+      '4': 1,
+      '5': 5,
+      '9': 0,
+      '10': 'stringValueStrindex'
+    },
   ],
   '8': [
     {'1': 'value'},
@@ -56,7 +64,8 @@ final $typed_data.Uint8List anyValueDescriptor = $convert.base64Decode(
     'EoCzIpLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLkFycmF5VmFsdWVIAFIKYXJyYXlW'
     'YWx1ZRJQCgxrdmxpc3RfdmFsdWUYBiABKAsyKy5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi'
     '52MS5LZXlWYWx1ZUxpc3RIAFILa3ZsaXN0VmFsdWUSIQoLYnl0ZXNfdmFsdWUYByABKAxIAFIK'
-    'Ynl0ZXNWYWx1ZUIHCgV2YWx1ZQ==');
+    'Ynl0ZXNWYWx1ZRI0ChVzdHJpbmdfdmFsdWVfc3RyaW5kZXgYCCABKAVIAFITc3RyaW5nVmFsdW'
+    'VTdHJpbmRleEIHCgV2YWx1ZQ==');
 
 @$core.Deprecated('Use arrayValueDescriptor instead')
 const ArrayValue$json = {
@@ -111,13 +120,15 @@ const KeyValue$json = {
       '6': '.opentelemetry.proto.common.v1.AnyValue',
       '10': 'value'
     },
+    {'1': 'key_strindex', '3': 3, '4': 1, '5': 5, '10': 'keyStrindex'},
   ],
 };
 
 /// Descriptor for `KeyValue`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List keyValueDescriptor = $convert.base64Decode(
     'CghLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRI9CgV2YWx1ZRgCIAEoCzInLm9wZW50ZWxlbW'
-    'V0cnkucHJvdG8uY29tbW9uLnYxLkFueVZhbHVlUgV2YWx1ZQ==');
+    'V0cnkucHJvdG8uY29tbW9uLnYxLkFueVZhbHVlUgV2YWx1ZRIhCgxrZXlfc3RyaW5kZXgYAyAB'
+    'KAVSC2tleVN0cmluZGV4');
 
 @$core.Deprecated('Use instrumentationScopeDescriptor instead')
 const InstrumentationScope$json = {
@@ -149,3 +160,20 @@ final $typed_data.Uint8List instrumentationScopeDescriptor = $convert.base64Deco
     'ABKAlSB3ZlcnNpb24SRwoKYXR0cmlidXRlcxgDIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8u'
     'Y29tbW9uLnYxLktleVZhbHVlUgphdHRyaWJ1dGVzEjgKGGRyb3BwZWRfYXR0cmlidXRlc19jb3'
     'VudBgEIAEoDVIWZHJvcHBlZEF0dHJpYnV0ZXNDb3VudA==');
+
+@$core.Deprecated('Use entityRefDescriptor instead')
+const EntityRef$json = {
+  '1': 'EntityRef',
+  '2': [
+    {'1': 'schema_url', '3': 1, '4': 1, '5': 9, '10': 'schemaUrl'},
+    {'1': 'type', '3': 2, '4': 1, '5': 9, '10': 'type'},
+    {'1': 'id_keys', '3': 3, '4': 3, '5': 9, '10': 'idKeys'},
+    {'1': 'description_keys', '3': 4, '4': 3, '5': 9, '10': 'descriptionKeys'},
+  ],
+};
+
+/// Descriptor for `EntityRef`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List entityRefDescriptor = $convert.base64Decode(
+    'CglFbnRpdHlSZWYSHQoKc2NoZW1hX3VybBgBIAEoCVIJc2NoZW1hVXJsEhIKBHR5cGUYAiABKA'
+    'lSBHR5cGUSFwoHaWRfa2V5cxgDIAMoCVIGaWRLZXlzEikKEGRlc2NyaXB0aW9uX2tleXMYBCAD'
+    'KAlSD2Rlc2NyaXB0aW9uS2V5cw==');

--- a/lib/proto/logs/v1/logs.pb.dart
+++ b/lib/proto/logs/v1/logs.pb.dart
@@ -159,7 +159,8 @@ class ResourceLogs extends $pb.GeneratedMessage {
   $pb.PbList<ScopeLogs> get scopeLogs => $_getList(1);
 
   /// The Schema URL, if known. This is the identifier of the Schema that the resource data
-  /// is recorded in. To learn more about Schema URL see
+  /// is recorded in. Notably, the last part of the URL path is the version number of the
+  /// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   /// This schema_url applies to the data in the "resource" field. It does not apply
   /// to the data in the "scope_logs" field which have their own schema_url field.
@@ -245,9 +246,11 @@ class ScopeLogs extends $pb.GeneratedMessage {
   $pb.PbList<LogRecord> get logRecords => $_getList(1);
 
   /// The Schema URL, if known. This is the identifier of the Schema that the log data
-  /// is recorded in. To learn more about Schema URL see
+  /// is recorded in. Notably, the last part of the URL path is the version number of the
+  /// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  /// This schema_url applies to all logs in the "logs" field.
+  /// This schema_url applies to the data in the "scope" field and all logs in the
+  /// "log_records" field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -272,6 +275,7 @@ class LogRecord extends $pb.GeneratedMessage {
     $core.List<$core.int>? traceId,
     $core.List<$core.int>? spanId,
     $fixnum.Int64? observedTimeUnixNano,
+    $core.String? eventName,
   }) {
     final result = create();
     if (timeUnixNano != null) result.timeUnixNano = timeUnixNano;
@@ -286,6 +290,7 @@ class LogRecord extends $pb.GeneratedMessage {
     if (spanId != null) result.spanId = spanId;
     if (observedTimeUnixNano != null)
       result.observedTimeUnixNano = observedTimeUnixNano;
+    if (eventName != null) result.eventName = eventName;
     return result;
   }
 
@@ -323,6 +328,7 @@ class LogRecord extends $pb.GeneratedMessage {
     ..a<$fixnum.Int64>(
         11, _omitFieldNames ? '' : 'observedTimeUnixNano', $pb.PbFieldType.OF6,
         defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(12, _omitFieldNames ? '' : 'eventName')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -394,6 +400,7 @@ class LogRecord extends $pb.GeneratedMessage {
   /// Additional attributes that describe the specific event occurrence. [Optional].
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(6)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(4);
 
@@ -484,6 +491,25 @@ class LogRecord extends $pb.GeneratedMessage {
   $core.bool hasObservedTimeUnixNano() => $_has(9);
   @$pb.TagNumber(11)
   void clearObservedTimeUnixNano() => $_clearField(11);
+
+  /// A unique identifier of event category/type.
+  /// All events with the same event_name are expected to conform to the same
+  /// schema for both their attributes and their body.
+  ///
+  /// Recommended to be fully qualified and short (no longer than 256 characters).
+  ///
+  /// Presence of event_name on the log record identifies this record
+  /// as an event.
+  ///
+  /// [Optional].
+  @$pb.TagNumber(12)
+  $core.String get eventName => $_getSZ(10);
+  @$pb.TagNumber(12)
+  set eventName($core.String value) => $_setString(10, value);
+  @$pb.TagNumber(12)
+  $core.bool hasEventName() => $_has(10);
+  @$pb.TagNumber(12)
+  void clearEventName() => $_clearField(12);
 }
 
 const $core.bool _omitFieldNames =

--- a/lib/proto/logs/v1/logs.pbenum.dart
+++ b/lib/proto/logs/v1/logs.pbenum.dart
@@ -16,7 +16,6 @@ import 'package:protobuf/protobuf.dart' as $pb;
 
 /// Possible values for LogRecord.SeverityNumber.
 class SeverityNumber extends $pb.ProtobufEnum {
-  /// UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
   static const SeverityNumber SEVERITY_NUMBER_UNSPECIFIED =
       SeverityNumber._(0, _omitEnumNames ? '' : 'SEVERITY_NUMBER_UNSPECIFIED');
   static const SeverityNumber SEVERITY_NUMBER_TRACE =

--- a/lib/proto/logs/v1/logs.pbjson.dart
+++ b/lib/proto/logs/v1/logs.pbjson.dart
@@ -209,6 +209,7 @@ const LogRecord$json = {
     {'1': 'flags', '3': 8, '4': 1, '5': 7, '10': 'flags'},
     {'1': 'trace_id', '3': 9, '4': 1, '5': 12, '10': 'traceId'},
     {'1': 'span_id', '3': 10, '4': 1, '5': 12, '10': 'spanId'},
+    {'1': 'event_name', '3': 12, '4': 1, '5': 9, '10': 'eventName'},
   ],
   '9': [
     {'1': 4, '2': 5},
@@ -225,5 +226,5 @@ final $typed_data.Uint8List logRecordDescriptor = $convert.base64Decode(
     'ZhbHVlUgRib2R5EkcKCmF0dHJpYnV0ZXMYBiADKAsyJy5vcGVudGVsZW1ldHJ5LnByb3RvLmNv'
     'bW1vbi52MS5LZXlWYWx1ZVIKYXR0cmlidXRlcxI4Chhkcm9wcGVkX2F0dHJpYnV0ZXNfY291bn'
     'QYByABKA1SFmRyb3BwZWRBdHRyaWJ1dGVzQ291bnQSFAoFZmxhZ3MYCCABKAdSBWZsYWdzEhkK'
-    'CHRyYWNlX2lkGAkgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYCiABKAxSBnNwYW5JZEoECAQQBQ'
-    '==');
+    'CHRyYWNlX2lkGAkgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYCiABKAxSBnNwYW5JZBIdCgpldm'
+    'VudF9uYW1lGAwgASgJUglldmVudE5hbWVKBAgEEAU=');

--- a/lib/proto/metrics/v1/metrics.pb.dart
+++ b/lib/proto/metrics/v1/metrics.pb.dart
@@ -27,6 +27,24 @@ export 'metrics.pbenum.dart';
 /// storage, OR can be embedded by other protocols that transfer OTLP metrics
 /// data but do not implement the OTLP protocol.
 ///
+/// MetricsData
+/// └─── ResourceMetrics
+///   ├── Resource
+///   ├── SchemaURL
+///   └── ScopeMetrics
+///      ├── Scope
+///      ├── SchemaURL
+///      └── Metric
+///         ├── Name
+///         ├── Description
+///         ├── Unit
+///         └── data
+///            ├── Gauge
+///            ├── Sum
+///            ├── Histogram
+///            ├── ExponentialHistogram
+///            └── Summary
+///
 /// The main difference between this message and collector protocol is that
 /// in this message there will not be any "control" or "metadata" specific to
 /// OTLP protocol.
@@ -160,7 +178,8 @@ class ResourceMetrics extends $pb.GeneratedMessage {
   $pb.PbList<ScopeMetrics> get scopeMetrics => $_getList(1);
 
   /// The Schema URL, if known. This is the identifier of the Schema that the resource data
-  /// is recorded in. To learn more about Schema URL see
+  /// is recorded in. Notably, the last part of the URL path is the version number of the
+  /// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   /// This schema_url applies to the data in the "resource" field. It does not apply
   /// to the data in the "scope_metrics" field which have their own schema_url field.
@@ -247,9 +266,11 @@ class ScopeMetrics extends $pb.GeneratedMessage {
   $pb.PbList<Metric> get metrics => $_getList(1);
 
   /// The Schema URL, if known. This is the identifier of the Schema that the metric data
-  /// is recorded in. To learn more about Schema URL see
+  /// is recorded in. Notably, the last part of the URL path is the version number of the
+  /// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  /// This schema_url applies to all metrics in the "metrics" field.
+  /// This schema_url applies to the data in the "scope" field and all metrics in the
+  /// "metrics" field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -274,7 +295,6 @@ enum Metric_Data {
 ///
 ///   https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md
 ///
-///
 /// The data model and relation between entities is shown in the
 /// diagram below. Here, "DataPoint" is the term used to refer to any
 /// one of the specific data point value types, and "points" is the term used
@@ -286,7 +306,7 @@ enum Metric_Data {
 /// - DataPoint contains timestamps, attributes, and one of the possible value type
 ///   fields.
 ///
-///     Metric
+///    Metric
 ///  +------------+
 ///  |name        |
 ///  |description |
@@ -364,6 +384,7 @@ class Metric extends $pb.GeneratedMessage {
     Histogram? histogram,
     ExponentialHistogram? exponentialHistogram,
     Summary? summary,
+    $core.Iterable<$1.KeyValue>? metadata,
   }) {
     final result = create();
     if (name != null) result.name = name;
@@ -375,6 +396,7 @@ class Metric extends $pb.GeneratedMessage {
     if (exponentialHistogram != null)
       result.exponentialHistogram = exponentialHistogram;
     if (summary != null) result.summary = summary;
+    if (metadata != null) result.metadata.addAll(metadata);
     return result;
   }
 
@@ -413,6 +435,8 @@ class Metric extends $pb.GeneratedMessage {
         subBuilder: ExponentialHistogram.create)
     ..aOM<Summary>(11, _omitFieldNames ? '' : 'summary',
         subBuilder: Summary.create)
+    ..pPM<$1.KeyValue>(12, _omitFieldNames ? '' : 'metadata',
+        subBuilder: $1.KeyValue.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -446,7 +470,7 @@ class Metric extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   void clearData() => $_clearField($_whichOneof(0));
 
-  /// name of the metric.
+  /// The name of the metric.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -456,7 +480,7 @@ class Metric extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearName() => $_clearField(1);
 
-  /// description of the metric, which can be used in documentation.
+  /// A description of the metric, which can be used in documentation.
   @$pb.TagNumber(2)
   $core.String get description => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -466,8 +490,8 @@ class Metric extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearDescription() => $_clearField(2);
 
-  /// unit in which the metric value is reported. Follows the format
-  /// described by http://unitsofmeasure.org/ucum.html.
+  /// The unit in which the metric value is reported. Follows the format
+  /// described by https://ucum.org/ucum and https://units-of-measurement.org/
   @$pb.TagNumber(3)
   $core.String get unit => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -531,6 +555,17 @@ class Metric extends $pb.GeneratedMessage {
   void clearSummary() => $_clearField(11);
   @$pb.TagNumber(11)
   Summary ensureSummary() => $_ensure(7);
+
+  /// Additional metadata attributes that describe the metric. [Optional].
+  /// Attributes are non-identifying.
+  /// Consumers SHOULD NOT need to be aware of these attributes.
+  /// These attributes MAY be used to encode information allowing
+  /// for lossless roundtrip translation to / from another data model.
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
+  @$pb.TagNumber(12)
+  $pb.PbList<$1.KeyValue> get metadata => $_getList(8);
 }
 
 /// Gauge represents the type of a scalar metric that always exports the
@@ -587,6 +622,8 @@ class Gauge extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Gauge>(create);
   static Gauge? _defaultInstance;
 
+  /// The time series data points.
+  /// Note: Multiple time series may be included (same timestamp, different attributes).
   @$pb.TagNumber(1)
   $pb.PbList<NumberDataPoint> get dataPoints => $_getList(0);
 }
@@ -647,6 +684,8 @@ class Sum extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Sum>(create);
   static Sum? _defaultInstance;
 
+  /// The time series data points.
+  /// Note: Multiple time series may be included (same timestamp, different attributes).
   @$pb.TagNumber(1)
   $pb.PbList<NumberDataPoint> get dataPoints => $_getList(0);
 
@@ -662,7 +701,7 @@ class Sum extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearAggregationTemporality() => $_clearField(2);
 
-  /// If "true" means that the sum is monotonic.
+  /// Represents whether the sum is monotonic.
   @$pb.TagNumber(3)
   $core.bool get isMonotonic => $_getBF(2);
   @$pb.TagNumber(3)
@@ -726,6 +765,8 @@ class Histogram extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Histogram>(create);
   static Histogram? _defaultInstance;
 
+  /// The time series data points.
+  /// Note: Multiple time series may be included (same timestamp, different attributes).
   @$pb.TagNumber(1)
   $pb.PbList<HistogramDataPoint> get dataPoints => $_getList(0);
 
@@ -796,6 +837,8 @@ class ExponentialHistogram extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<ExponentialHistogram>(create);
   static ExponentialHistogram? _defaultInstance;
 
+  /// The time series data points.
+  /// Note: Multiple time series may be included (same timestamp, different attributes).
   @$pb.TagNumber(1)
   $pb.PbList<ExponentialHistogramDataPoint> get dataPoints => $_getList(0);
 
@@ -814,10 +857,13 @@ class ExponentialHistogram extends $pb.GeneratedMessage {
 
 /// Summary metric data are used to convey quantile summaries,
 /// a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary)
-/// and OpenMetrics (see: https://github.com/OpenObservability/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
+/// and OpenMetrics (see: https://github.com/prometheus/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
 /// data type. These data points cannot always be merged in a meaningful way.
 /// While they can be useful in some applications, histogram data points are
 /// recommended for new applications.
+/// Summary metrics do not have an aggregation temporality field. This is
+/// because the count and sum fields of a SummaryDataPoint are assumed to be
+/// cumulative values.
 class Summary extends $pb.GeneratedMessage {
   factory Summary({
     $core.Iterable<SummaryDataPoint>? dataPoints,
@@ -863,6 +909,8 @@ class Summary extends $pb.GeneratedMessage {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Summary>(create);
   static Summary? _defaultInstance;
 
+  /// The time series data points.
+  /// Note: Multiple time series may be included (same timestamp, different attributes).
   @$pb.TagNumber(1)
   $pb.PbList<SummaryDataPoint> get dataPoints => $_getList(0);
 }
@@ -1010,6 +1058,7 @@ class NumberDataPoint extends $pb.GeneratedMessage {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(7)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(5);
 
@@ -1165,7 +1214,7 @@ class HistogramDataPoint extends $pb.GeneratedMessage {
   /// events, and is assumed to be monotonic over the values of these events.
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   @$pb.TagNumber(5)
   $core.double get sum => $_getN(3);
   @$pb.TagNumber(5)
@@ -1181,7 +1230,9 @@ class HistogramDataPoint extends $pb.GeneratedMessage {
   /// The sum of the bucket_counts must equal the value in the count field.
   ///
   /// The number of elements in bucket_counts array must be by one greater than
-  /// the number of elements in explicit_bounds array.
+  /// the number of elements in explicit_bounds array. The exception to this rule
+  /// is when the length of bucket_counts is 0, then the length of explicit_bounds
+  /// must also be 0.
   @$pb.TagNumber(6)
   $pb.PbList<$fixnum.Int64> get bucketCounts => $_getList(4);
 
@@ -1198,6 +1249,9 @@ class HistogramDataPoint extends $pb.GeneratedMessage {
   /// Histogram buckets are inclusive of their upper boundary, except the last
   /// bucket where the boundary is at infinity. This format is intentionally
   /// compatible with the OpenMetrics histogram definition.
+  ///
+  /// If bucket_counts length is 0 then explicit_bounds length must also be 0,
+  /// otherwise the data point is invalid.
   @$pb.TagNumber(7)
   $pb.PbList<$core.double> get explicitBounds => $_getList(5);
 
@@ -1210,6 +1264,7 @@ class HistogramDataPoint extends $pb.GeneratedMessage {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(9)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(7);
 
@@ -1301,7 +1356,7 @@ class ExponentialHistogramDataPoint_Buckets extends $pb.GeneratedMessage {
           ExponentialHistogramDataPoint_Buckets>(create);
   static ExponentialHistogramDataPoint_Buckets? _defaultInstance;
 
-  /// Offset is the bucket index of the first entry in the bucket_counts array.
+  /// The bucket index of the first entry in the bucket_counts array.
   ///
   /// Note: This uses a varint encoding as a simple form of compression.
   @$pb.TagNumber(1)
@@ -1313,7 +1368,7 @@ class ExponentialHistogramDataPoint_Buckets extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearOffset() => $_clearField(1);
 
-  /// bucket_counts is an array of count values, where bucket_counts[i] carries
+  /// An array of count values, where bucket_counts[i] carries
   /// the count of the bucket at index (offset+i). bucket_counts[i] is the count
   /// of values greater than base^(offset+i) and less than or equal to
   /// base^(offset+i+1).
@@ -1434,6 +1489,7 @@ class ExponentialHistogramDataPoint extends $pb.GeneratedMessage {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(1)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(0);
 
@@ -1464,7 +1520,7 @@ class ExponentialHistogramDataPoint extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   void clearTimeUnixNano() => $_clearField(3);
 
-  /// count is the number of values in the population. Must be
+  /// The number of values in the population. Must be
   /// non-negative. This value must be equal to the sum of the "bucket_counts"
   /// values in the positive and negative Buckets plus the "zero_count" field.
   @$pb.TagNumber(4)
@@ -1476,14 +1532,14 @@ class ExponentialHistogramDataPoint extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   void clearCount() => $_clearField(4);
 
-  /// sum of the values in the population. If count is zero then this field
+  /// The sum of the values in the population. If count is zero then this field
   /// must be zero.
   ///
   /// Note: Sum should only be filled out when measuring non-negative discrete
   /// events, and is assumed to be monotonic over the values of these events.
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   @$pb.TagNumber(5)
   $core.double get sum => $_getN(4);
   @$pb.TagNumber(5)
@@ -1517,7 +1573,7 @@ class ExponentialHistogramDataPoint extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   void clearScale() => $_clearField(6);
 
-  /// zero_count is the count of values that are either exactly zero or
+  /// The count of values that are either exactly zero or
   /// within the region considered zero by the instrumentation at the
   /// tolerated degree of precision.  This bucket stores values that
   /// cannot be expressed using the standard exponential formula as
@@ -1576,7 +1632,7 @@ class ExponentialHistogramDataPoint extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $pb.PbList<Exemplar> get exemplars => $_getList(10);
 
-  /// min is the minimum value over (start_time, end_time].
+  /// The minimum value over (start_time, end_time].
   @$pb.TagNumber(12)
   $core.double get min => $_getN(11);
   @$pb.TagNumber(12)
@@ -1586,7 +1642,7 @@ class ExponentialHistogramDataPoint extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   void clearMin() => $_clearField(12);
 
-  /// max is the maximum value over (start_time, end_time].
+  /// The maximum value over (start_time, end_time].
   @$pb.TagNumber(13)
   $core.double get max => $_getN(12);
   @$pb.TagNumber(13)
@@ -1698,7 +1754,8 @@ class SummaryDataPoint_ValueAtQuantile extends $pb.GeneratedMessage {
 }
 
 /// SummaryDataPoint is a single data point in a timeseries that describes the
-/// time-varying values of a Summary metric.
+/// time-varying values of a Summary metric. The count and sum fields represent
+/// cumulative values.
 class SummaryDataPoint extends $pb.GeneratedMessage {
   factory SummaryDataPoint({
     $fixnum.Int64? startTimeUnixNano,
@@ -1814,7 +1871,7 @@ class SummaryDataPoint extends $pb.GeneratedMessage {
   /// events, and is assumed to be monotonic over the values of these events.
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+  /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
   @$pb.TagNumber(5)
   $core.double get sum => $_getN(3);
   @$pb.TagNumber(5)
@@ -1834,6 +1891,7 @@ class SummaryDataPoint extends $pb.GeneratedMessage {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(7)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(5);
 

--- a/lib/proto/metrics/v1/metrics.pbjson.dart
+++ b/lib/proto/metrics/v1/metrics.pbjson.dart
@@ -182,6 +182,14 @@ const Metric$json = {
       '9': 0,
       '10': 'summary'
     },
+    {
+      '1': 'metadata',
+      '3': 12,
+      '4': 3,
+      '5': 11,
+      '6': '.opentelemetry.proto.common.v1.KeyValue',
+      '10': 'metadata'
+    },
   ],
   '8': [
     {'1': 'data'},
@@ -203,7 +211,8 @@ final $typed_data.Uint8List metricDescriptor = $convert.base64Decode(
     'JrChVleHBvbmVudGlhbF9oaXN0b2dyYW0YCiABKAsyNC5vcGVudGVsZW1ldHJ5LnByb3RvLm1l'
     'dHJpY3MudjEuRXhwb25lbnRpYWxIaXN0b2dyYW1IAFIUZXhwb25lbnRpYWxIaXN0b2dyYW0SQw'
     'oHc3VtbWFyeRgLIAEoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8ubWV0cmljcy52MS5TdW1tYXJ5'
-    'SABSB3N1bW1hcnlCBgoEZGF0YUoECAQQBUoECAYQB0oECAgQCQ==');
+    'SABSB3N1bW1hcnkSQwoIbWV0YWRhdGEYDCADKAsyJy5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW'
+    '1vbi52MS5LZXlWYWx1ZVIIbWV0YWRhdGFCBgoEZGF0YUoECAQQBUoECAYQB0oECAgQCQ==');
 
 @$core.Deprecated('Use gaugeDescriptor instead')
 const Gauge$json = {

--- a/lib/proto/resource/v1/resource.pb.dart
+++ b/lib/proto/resource/v1/resource.pb.dart
@@ -23,11 +23,13 @@ class Resource extends $pb.GeneratedMessage {
   factory Resource({
     $core.Iterable<$0.KeyValue>? attributes,
     $core.int? droppedAttributesCount,
+    $core.Iterable<$0.EntityRef>? entityRefs,
   }) {
     final result = create();
     if (attributes != null) result.attributes.addAll(attributes);
     if (droppedAttributesCount != null)
       result.droppedAttributesCount = droppedAttributesCount;
+    if (entityRefs != null) result.entityRefs.addAll(entityRefs);
     return result;
   }
 
@@ -49,6 +51,8 @@ class Resource extends $pb.GeneratedMessage {
         subBuilder: $0.KeyValue.create)
     ..aI(2, _omitFieldNames ? '' : 'droppedAttributesCount',
         fieldType: $pb.PbFieldType.OU3)
+    ..pPM<$0.EntityRef>(3, _omitFieldNames ? '' : 'entityRefs',
+        subBuilder: $0.EntityRef.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -72,10 +76,11 @@ class Resource extends $pb.GeneratedMessage {
   /// Set of attributes that describe the resource.
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(1)
   $pb.PbList<$0.KeyValue> get attributes => $_getList(0);
 
-  /// dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+  /// The number of dropped attributes. If the value is 0, then
   /// no attributes were dropped.
   @$pb.TagNumber(2)
   $core.int get droppedAttributesCount => $_getIZ(1);
@@ -85,6 +90,14 @@ class Resource extends $pb.GeneratedMessage {
   $core.bool hasDroppedAttributesCount() => $_has(1);
   @$pb.TagNumber(2)
   void clearDroppedAttributesCount() => $_clearField(2);
+
+  /// Set of entities that participate in this Resource.
+  ///
+  /// Note: keys in the references MUST exist in attributes of this message.
+  ///
+  /// Status: [Development]
+  @$pb.TagNumber(3)
+  $pb.PbList<$0.EntityRef> get entityRefs => $_getList(2);
 }
 
 const $core.bool _omitFieldNames =

--- a/lib/proto/resource/v1/resource.pbjson.dart
+++ b/lib/proto/resource/v1/resource.pbjson.dart
@@ -34,6 +34,14 @@ const Resource$json = {
       '5': 13,
       '10': 'droppedAttributesCount'
     },
+    {
+      '1': 'entity_refs',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.opentelemetry.proto.common.v1.EntityRef',
+      '10': 'entityRefs'
+    },
   ],
 };
 
@@ -41,4 +49,5 @@ const Resource$json = {
 final $typed_data.Uint8List resourceDescriptor = $convert.base64Decode(
     'CghSZXNvdXJjZRJHCgphdHRyaWJ1dGVzGAEgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb2'
     '1tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1dGVzX2NvdW50'
-    'GAIgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50');
+    'GAIgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50EkkKC2VudGl0eV9yZWZzGAMgAygLMigub3'
+    'BlbnRlbGVtZXRyeS5wcm90by5jb21tb24udjEuRW50aXR5UmVmUgplbnRpdHlSZWZz');

--- a/lib/proto/trace/v1/trace.pb.dart
+++ b/lib/proto/trace/v1/trace.pb.dart
@@ -159,7 +159,8 @@ class ResourceSpans extends $pb.GeneratedMessage {
   $pb.PbList<ScopeSpans> get scopeSpans => $_getList(1);
 
   /// The Schema URL, if known. This is the identifier of the Schema that the resource data
-  /// is recorded in. To learn more about Schema URL see
+  /// is recorded in. Notably, the last part of the URL path is the version number of the
+  /// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   /// This schema_url applies to the data in the "resource" field. It does not apply
   /// to the data in the "scope_spans" field which have their own schema_url field.
@@ -244,9 +245,11 @@ class ScopeSpans extends $pb.GeneratedMessage {
   $pb.PbList<Span> get spans => $_getList(1);
 
   /// The Schema URL, if known. This is the identifier of the Schema that the span data
-  /// is recorded in. To learn more about Schema URL see
+  /// is recorded in. Notably, the last part of the URL path is the version number of the
+  /// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  /// This schema_url applies to all spans and span events in the "spans" field.
+  /// This schema_url applies to the data in the "scope" field and all spans and span
+  /// events in the "spans" field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -317,7 +320,7 @@ class Span_Event extends $pb.GeneratedMessage {
       $pb.GeneratedMessage.$_defaultFor<Span_Event>(create);
   static Span_Event? _defaultInstance;
 
-  /// time_unix_nano is the time the event occurred.
+  /// The time the event occurred.
   @$pb.TagNumber(1)
   $fixnum.Int64 get timeUnixNano => $_getI64(0);
   @$pb.TagNumber(1)
@@ -327,7 +330,7 @@ class Span_Event extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearTimeUnixNano() => $_clearField(1);
 
-  /// name of the event.
+  /// The name of the event.
   /// This field is semantically required to be set to non-empty string.
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
@@ -338,13 +341,14 @@ class Span_Event extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearName() => $_clearField(2);
 
-  /// attributes is a collection of attribute key/value pairs on the event.
+  /// A collection of attribute key/value pairs on the event.
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(3)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(2);
 
-  /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
+  /// The number of dropped attributes. If the value is 0,
   /// then no attributes were dropped.
   @$pb.TagNumber(4)
   $core.int get droppedAttributesCount => $_getIZ(3);
@@ -455,13 +459,14 @@ class Span_Link extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   void clearTraceState() => $_clearField(3);
 
-  /// attributes is a collection of attribute key/value pairs on the link.
+  /// A collection of attribute key/value pairs on the link.
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(4)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(3);
 
-  /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
+  /// The number of dropped attributes. If the value is 0,
   /// then no attributes were dropped.
   @$pb.TagNumber(5)
   $core.int get droppedAttributesCount => $_getIZ(4);
@@ -472,14 +477,23 @@ class Span_Link extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   void clearDroppedAttributesCount() => $_clearField(5);
 
-  /// Flags, a bit field. 8 least significant bits are the trace
-  /// flags as defined in W3C Trace Context specification. Readers
-  /// MUST not assume that 24 most significant bits will be zero.
-  /// When creating new spans, the most-significant 24-bits MUST be
-  /// zero.  To read the 8-bit W3C trace flag (use flags &
-  /// SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+  /// Flags, a bit field.
+  ///
+  /// Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+  /// Context specification. To read the 8-bit W3C trace flag, use
+  /// `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
   ///
   /// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  ///
+  /// Bits 8 and 9 represent the 3 states of whether the link is remote.
+  /// The states are (unknown, is not remote, is remote).
+  /// To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+  /// To read whether the link is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
+  ///
+  /// Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+  /// When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.
+  ///
+  /// [Optional].
   @$pb.TagNumber(6)
   $core.int get flags => $_getIZ(5);
   @$pb.TagNumber(6)
@@ -684,7 +698,7 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   void clearKind() => $_clearField(6);
 
-  /// start_time_unix_nano is the start time of the span. On the client side, this is the time
+  /// The start time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution starts. On the server side, this
   /// is the time when the server's application handler starts running.
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
@@ -699,7 +713,7 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   void clearStartTimeUnixNano() => $_clearField(7);
 
-  /// end_time_unix_nano is the end time of the span. On the client side, this is the time
+  /// The end time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution ends. On the server side, this
   /// is the time when the server application handler stops running.
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
@@ -714,7 +728,7 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   void clearEndTimeUnixNano() => $_clearField(8);
 
-  /// attributes is a collection of key/value pairs. Note, global attributes
+  /// A collection of key/value pairs. Note, global attributes
   /// like server name can be set using the resource API. Examples of attributes:
   ///
   ///     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
@@ -722,14 +736,13 @@ class Span extends $pb.GeneratedMessage {
   ///     "example.com/myattribute": true
   ///     "example.com/score": 10.239
   ///
-  /// The OpenTelemetry API specification further restricts the allowed value types:
-  /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
+  /// The behavior of software that receives duplicated keys can be unpredictable.
   @$pb.TagNumber(9)
   $pb.PbList<$1.KeyValue> get attributes => $_getList(8);
 
-  /// dropped_attributes_count is the number of attributes that were discarded. Attributes
+  /// The number of attributes that were discarded. Attributes
   /// can be discarded because their keys are too long or because there are too many
   /// attributes. If this value is 0, then no attributes were dropped.
   @$pb.TagNumber(10)
@@ -741,11 +754,11 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   void clearDroppedAttributesCount() => $_clearField(10);
 
-  /// events is a collection of Event items.
+  /// A collection of Event items.
   @$pb.TagNumber(11)
   $pb.PbList<Span_Event> get events => $_getList(10);
 
-  /// dropped_events_count is the number of dropped events. If the value is 0, then no
+  /// The number of dropped events. If the value is 0, then no
   /// events were dropped.
   @$pb.TagNumber(12)
   $core.int get droppedEventsCount => $_getIZ(11);
@@ -756,12 +769,12 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   void clearDroppedEventsCount() => $_clearField(12);
 
-  /// links is a collection of Links, which are references from this span to a span
+  /// A collection of Links, which are references from this span to a span
   /// in the same or different trace.
   @$pb.TagNumber(13)
   $pb.PbList<Span_Link> get links => $_getList(12);
 
-  /// dropped_links_count is the number of dropped links after the maximum size was
+  /// The number of dropped links after the maximum size was
   /// enforced. If this value is 0, then no links were dropped.
   @$pb.TagNumber(14)
   $core.int get droppedLinksCount => $_getIZ(13);
@@ -785,20 +798,27 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(15)
   Status ensureStatus() => $_ensure(14);
 
-  /// Flags, a bit field. 8 least significant bits are the trace
-  /// flags as defined in W3C Trace Context specification. Readers
-  /// MUST not assume that 24 most significant bits will be zero.
-  /// To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  /// Flags, a bit field.
+  ///
+  /// Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+  /// Context specification. To read the 8-bit W3C trace flag, use
+  /// `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  ///
+  /// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  ///
+  /// Bits 8 and 9 represent the 3 states of whether a span's parent
+  /// is remote. The states are (unknown, is not remote, is remote).
+  /// To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+  /// To read whether the span is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
   ///
   /// When creating span messages, if the message is logically forwarded from another source
   /// with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
   /// be copied as-is. If creating from a source that does not have an equivalent flags field
-  /// (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  /// (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
   /// be set to zero.
+  /// Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
   ///
   /// [Optional].
-  ///
-  /// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   @$pb.TagNumber(16)
   $core.int get flags => $_getIZ(15);
   @$pb.TagNumber(16)

--- a/lib/proto/trace/v1/trace.pbenum.dart
+++ b/lib/proto/trace/v1/trace.pbenum.dart
@@ -38,9 +38,19 @@ class SpanFlags extends $pb.ProtobufEnum {
   static const SpanFlags SPAN_FLAGS_TRACE_FLAGS_MASK =
       SpanFlags._(255, _omitEnumNames ? '' : 'SPAN_FLAGS_TRACE_FLAGS_MASK');
 
+  /// Bits 8 and 9 are used to indicate that the parent span or link span is remote.
+  /// Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
+  /// Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
+  static const SpanFlags SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK = SpanFlags._(
+      256, _omitEnumNames ? '' : 'SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK');
+  static const SpanFlags SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = SpanFlags._(
+      512, _omitEnumNames ? '' : 'SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK');
+
   static const $core.List<SpanFlags> values = <SpanFlags>[
     SPAN_FLAGS_DO_NOT_USE,
     SPAN_FLAGS_TRACE_FLAGS_MASK,
+    SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK,
+    SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK,
   ];
 
   static final $core.Map<$core.int, SpanFlags> _byValue =

--- a/lib/proto/trace/v1/trace.pbjson.dart
+++ b/lib/proto/trace/v1/trace.pbjson.dart
@@ -21,13 +21,16 @@ const SpanFlags$json = {
   '2': [
     {'1': 'SPAN_FLAGS_DO_NOT_USE', '2': 0},
     {'1': 'SPAN_FLAGS_TRACE_FLAGS_MASK', '2': 255},
+    {'1': 'SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK', '2': 256},
+    {'1': 'SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK', '2': 512},
   ],
 };
 
 /// Descriptor for `SpanFlags`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List spanFlagsDescriptor = $convert.base64Decode(
     'CglTcGFuRmxhZ3MSGQoVU1BBTl9GTEFHU19ET19OT1RfVVNFEAASIAobU1BBTl9GTEFHU19UUk'
-    'FDRV9GTEFHU19NQVNLEP8B');
+    'FDRV9GTEFHU19NQVNLEP8BEioKJVNQQU5fRkxBR1NfQ09OVEVYVF9IQVNfSVNfUkVNT1RFX01B'
+    'U0sQgAISJgohU1BBTl9GTEFHU19DT05URVhUX0lTX1JFTU9URV9NQVNLEIAE');
 
 @$core.Deprecated('Use tracesDataDescriptor instead')
 const TracesData$json = {

--- a/lib/src/logs/export/otlp/log_record_transformer.dart
+++ b/lib/src/logs/export/otlp/log_record_transformer.dart
@@ -163,6 +163,9 @@ class OtlpLogRecordTransformer {
     if (logRecord.traceFlags != null) {
       otlpLog.flags = logRecord.traceFlags!.asByte;
     }
+    if (logRecord.eventName != null) {
+      otlpLog.eventName = logRecord.eventName!;
+    }
 
     return otlpLog;
   }

--- a/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_config_test.dart
+++ b/test/unit/logs/export/otlp/http/otlp_http_log_record_exporter_config_test.dart
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OtlpHttpLogRecordExporterConfig endpoint normalisation', () {
+    test('a bare localhost gets the OTLP/HTTP default port', () {
+      final config =
+          OtlpHttpLogRecordExporterConfig(endpoint: 'http://localhost');
+      expect(config.endpoint, equals('http://localhost:4318'));
+    });
+
+    test('an endpoint with a port and a path is kept as given', () {
+      final config = OtlpHttpLogRecordExporterConfig(
+          endpoint: 'https://collector.example:4318/v1/logs');
+      expect(config.endpoint, equals('https://collector.example:4318/v1/logs'));
+    });
+
+    test('a scheme with no host is refused', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(endpoint: 'http://'),
+        throwsA(isA<ArgumentError>()
+            .having((e) => e.message, 'message', contains('Invalid host'))),
+      );
+    });
+
+    test('an endpoint the URI parser cannot read is refused', () {
+      expect(
+        () => OtlpHttpLogRecordExporterConfig(endpoint: 'http://[::1'),
+        throwsA(isA<ArgumentError>().having(
+            (e) => e.message, 'message', contains('Invalid URL format'))),
+      );
+    });
+  });
+}

--- a/test/unit/logs/export/otlp/log_record_transformer_test.dart
+++ b/test/unit/logs/export/otlp/log_record_transformer_test.dart
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:dartastic_opentelemetry/proto/opentelemetry_proto_dart.dart'
+    as proto;
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
@@ -63,6 +65,47 @@ void main() {
       expect(otlpLog.observedTimeUnixNano, equals(observedTimestamp));
       expect(otlpLog.severityText, equals('INFO'));
       expect(otlpLog.body.stringValue, equals('Test message'));
+      expect(otlpLog.eventName, equals('test.event'));
+    });
+
+    test('event name is the OTLP event_name field, not an attribute', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'Exception',
+        eventName: 'exception',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.hasEventName(), isTrue);
+      expect(otlpLog.eventName, equals('exception'));
+      expect(otlpLog.attributes.where((a) => a.key == 'event.name'), isEmpty);
+
+      // Round-trip through the wire encoding: the field must survive
+      // serialization, not just live on the in-memory message.
+      final decoded =
+          proto.ExportLogsServiceRequest.fromBuffer(request.writeToBuffer());
+      expect(
+        decoded.resourceLogs.first.scopeLogs.first.logRecords.first.eventName,
+        equals('exception'),
+      );
+    });
+
+    test('a record without an event name leaves event_name unset', () {
+      final logRecord = SDKLogRecord(
+        instrumentationScope: scope,
+        severityNumber: Severity.INFO,
+        body: 'plain log line',
+      );
+
+      final request = OtlpLogRecordTransformer.transformLogRecords([logRecord]);
+      final otlpLog =
+          request.resourceLogs.first.scopeLogs.first.logRecords.first;
+
+      expect(otlpLog.hasEventName(), isFalse);
     });
 
     test('transforms severity levels correctly', () {

--- a/tool/setup_protos.sh
+++ b/tool/setup_protos.sh
@@ -5,7 +5,7 @@ set -e
 PROTO_DIR="protos"
 OUTPUT_DIR="lib/proto"
 TEMP_DIR=".proto_gen_temp"
-OPENTELEMETRY_PROTO_VERSION="v1.1.0"  # Update this to the version you want to use
+OPENTELEMETRY_PROTO_VERSION="v1.11.0"  # Update this to the version you want to use
 
 # Create directories if they don't exist
 mkdir -p "$PROTO_DIR/opentelemetry-proto"


### PR DESCRIPTION
#### Description

`LogRecord.eventName` was never copied onto the wire. Every record emitted with `emit(eventName: ...)` reached the collector as a plain log record with no name, so anything filtering on `event_name` saw nothing. Attributes, body, scope and resource were all intact; only that field was missing.

The transformer could not have set it: the bundled protobuf definitions were generated from opentelemetry-proto **v1.1.0**, which predates `LogRecord.event_name` (field 12, added in v1.4.0). `tool/setup_protos.sh` now pins **v1.11.0** and the generated files are regenerated. That also brings `EntityRef` on `Resource` and the string-table fields on `AnyValue` and `KeyValue`; no generated type was removed and no other exporter code changes. `_transformLogRecord` copies `eventName` when present and leaves the field unset otherwise.

`protos/` (where the generator clones upstream) is now gitignored so a regeneration does not offer the clone for commit.

#### Link to tracking issue
None filed; found from a wire capture.

#### Testing

`log_record_transformer_test.dart`:
- the existing single-record test now asserts `eventName` on the transformed record (it already passed `eventName: 'test.event'` in and never checked it);
- a new test round-trips through `writeToBuffer()` / `fromBuffer()` and asserts the name survives the wire encoding, and that it is the `event_name` field rather than an `event.name` attribute;
- a new test asserts a record with no event name leaves the field unset.

The first two fail before the change (the generated class had no `eventName` at all). Also added `otlp_http_log_record_exporter_config_test.dart` for the endpoint normaliser's two refusal paths, which had no coverage. Full suite and coverage pass locally via the pre-push hook (93.65%).

#### CHANGELOG
- [x] `CHANGELOG.md` updated under 1.1.0-beta.16-wip (Fixed). No PR link in the entry yet; add it if you want the number there.

#### Documentation
None needed; the API already documents `eventName` on `LogRecord` and `emit`.

#### Spec Compliance
Logs Data Model, field `EventName`: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-eventname ("Type: string ... Event name identifies the class or type of the Event"). OTLP carries it as `LogRecord.event_name` since opentelemetry-proto v1.4.0. The OTLP exporter MUST transmit the log record's fields; it was silently dropping this one.

#### Authorship
- [ ] I, a human, authored this pull request and stand behind these changes.
- Assisted-by: Claude Fable 5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7j6yPYdv4SXz2Ti5x8hLS