### PR TITLE
feat: automate pull request labeling based on modified file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,127 @@
+# Applied by .github/workflows/labeler.yml. Every label named here must also
+# exist in tool/create-labels.sh, which creates them.
+
+# Components, one per folder under lib/src/.
+
+trace:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/trace/**'
+          - 'lib/proto/trace/**'
+          - 'test/unit/trace/**'
+          - 'test/integration/context_propagation_test.dart'
+
+metrics:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/metrics/**'
+          - 'lib/proto/metrics/**'
+          - 'test/unit/metrics/**'
+          - 'test/integration/metrics/**'
+
+logs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/logs/**'
+          - 'lib/proto/logs/**'
+          - 'test/unit/logs/**'
+
+# No folder of its own: the propagator sits under lib/src/context/propagation/
+# and the rest is in the API package.
+baggage:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/**/*baggage*'
+          - 'test/unit/baggage/**'
+          - 'test/performance/baggage/**'
+          - 'example/baggage_*.dart'
+
+context:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/context/**'
+          - 'test/unit/context/**'
+          - 'test/integration/context_propagation_test.dart'
+          - 'example/propagator_example.dart'
+          - 'example/isolate_context_example.dart'
+
+resource:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/resource/**'
+          - 'lib/proto/resource/**'
+          - 'test/unit/sdk/resource*_test.dart'
+          - 'test/integration/resource_attributes_test.dart'
+          - 'test/web/web_resource_detector_test.dart'
+          - 'test/web/web_otlp_resource_e2e_test.dart'
+
+environment:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/environment/**'
+          - 'test/unit/environment/**'
+          - 'test/integration/environment_variables_test.dart'
+          - 'tool/*env_vars*'
+          - 'tool/read_otel_config.dart'
+
+export:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/src/export/**'
+          - 'lib/src/trace/export/**'
+          - 'lib/src/metrics/export/**'
+          - 'lib/src/logs/export/**'
+          - 'lib/proto/collector/**'
+          - 'test/unit/export/**'
+          - 'test/unit/**/export/**'
+          - 'example/otlp_*.dart'
+
+proto:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/proto/**'
+          - 'tool/setup_protos.sh'
+
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lib/dartastic_opentelemetry.dart'
+          - 'lib/src/otel.dart'
+          - 'lib/src/version.dart'
+          - 'lib/src/factory/**'
+          - 'lib/src/util/**'
+          - 'lib/testing.dart'
+          - 'test/unit/factory/**'
+          - 'test/unit/util/**'
+
+# Everything that is not a signal.
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'test/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+tooling:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tool/**'
+          - 'Makefile'
+          - 'analysis_options.yaml'
+          - 'coverage.sh'
+          - '.coveragerc'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'example/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'pubspec.yaml'

--- a/.github/workflows/create-labels.yml
+++ b/.github/workflows/create-labels.yml
@@ -1,0 +1,30 @@
+name: Create labels
+
+# Keeps the repository's labels in sync with tool/create-labels.sh, which is
+# the source of truth for them.
+on:
+  push:
+    branches: [main]
+    paths:
+      - tool/create-labels.sh
+      - .github/workflows/create-labels.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  create-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # labels are created through the issues API
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          chmod +x tool/create-labels.sh
+          ./tool/create-labels.sh

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,29 @@
+name: Labeler
+
+# pull_request_target, because a fork's GITHUB_TOKEN is read-only and cannot
+# add labels under pull_request. It carries a write token, so this workflow
+# must never check out or run anything from the head ref.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # enough to apply labels that already exist
+    steps:
+      - uses: actions/labeler@v7
+        with:
+          configuration-path: .github/labeler.yml
+          # Remove a label once its globs stop matching. Only labels defined
+          # in labeler.yml are touched.
+          sync-labels: true

--- a/tool/create-labels.sh
+++ b/tool/create-labels.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Create the component labels that .github/labeler.yml matches by path. This
+# file is the source of truth for them; .github/workflows/create-labels.yml
+# runs it on push to main, so run it by hand only to bootstrap a fork.
+#
+# actions/labeler could create missing labels itself, but only if granted
+# `issues: write`. Creating them here keeps that workflow narrower and gives
+# the labels real colours and descriptions.
+#
+# Safe to re-run: --force updates an existing label rather than erroring.
+#
+# Usage: ./tool/create-labels.sh [owner/repo]
+
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: the GitHub CLI (gh) is required. See https://cli.github.com" >&2
+  exit 1
+fi
+
+# With no argument, gh resolves the repository from the current checkout.
+GH_ARGS=()
+if [ -n "${1:-}" ]; then
+  GH_ARGS=(--repo "$1")
+fi
+
+label() {
+  local name="$1" color="$2" description="$3"
+  echo "  $name"
+  gh label create "$name" --color "$color" --description "$description" --force \
+    ${GH_ARGS[@]+"${GH_ARGS[@]}"} >/dev/null
+}
+
+echo "Creating component labels..."
+
+# Components, one per folder under lib/src/.
+label trace       1d76db "Tracing: spans, tracers, samplers, propagation."
+label metrics     0e8a16 "Metrics: meters, instruments, views, aggregation."
+label logs        5319e7 "Logs: loggers, log records, the log bridge."
+label baggage     d4c5f9 "Baggage and the W3C baggage propagator."
+label context     bfd4f2 "Context and context propagation."
+label resource    c5def5 "Resources and resource detectors."
+label environment bfdadc "OTEL_* environment variables and configuration."
+label export      fbca04 "OTLP exporters and the export pipeline."
+label proto       e99695 "Generated OpenTelemetry protobuf code."
+label core        0052cc "The OTel entrypoint, the factory layer, shared utilities."
+
+# Everything that is not a signal.
+label tests         c2e0c6 "Test suites and test utilities."
+label ci            ededed "GitHub Actions workflows and repository configuration."
+label tooling       d3d3d3 "Scripts under tool/, build and analysis configuration."
+label documentation 0075ca "Improvements or additions to documentation"
+label dependencies  f9d0c4 "Package dependencies and version constraints."
+
+echo
+echo "Done. .github/workflows/labeler.yml applies these by changed path."


### PR DESCRIPTION
#### Description

Labels PRs from the paths they change, using `actions/labeler`.

Ten component labels, one per folder under `lib/src/`: `trace`, `metrics`, `logs`, `baggage`, `context`, `resource`, `environment`, `export`, `proto`, `core`. Each also covers the matching tests, protos, and examples. Five more for the rest: `tests`, `ci`, `tooling`, `documentation`, `dependencies`.

Three things worth a look:

- Runs on `pull_request_target`, because a fork's token can't add labels otherwise. It carries a write token, so the job must never check out the head ref — labeler doesn't need to.
- `sync-labels: true`, so a label comes off once its globs stop matching.
- `tool/create-labels.sh` creates the labels, run by a workflow on push to main. Labeler could create them itself, but only with `issues: write`, and auto-created labels get a random colour and no description.

Two open to review: no `repository_owner` guard on the label workflow, and `labeler@v7` is pinned by tag like the other workflows here rather than by SHA.

#### Link to tracking issue
Fixes #301

#### CHANGELOG
- [x] `CHANGELOG.md` updated, or not needed for this change

#### Authorship
- [x] I, a human, authored this pull request and stand behind these changes.
- Assisted-by (AI tools used such as "Fable 5", or "None"): Claude
